### PR TITLE
Fix class-only protocol initializer generation

### DIFF
--- a/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -243,13 +243,15 @@ class MockableTypeTemplate: Template {
   /// Store the source location of where the mock was initialized. This allows `XCTest` errors from
   /// unstubbed method invocations to show up in the testing code.
   var shouldGenerateDefaultInitializer: Bool {
+    let hasDesignatedInitializer =
+      mockableType.methods.contains(where: { $0.isDesignatedInitializer })
+    
     let isInitializableProtocol = mockableType.kind == .protocol
-      && protocolClassConformance == nil
-      && !mockableType.hasOpaqueInheritedType
-    let isInitializableInstance = !mockableType.hasOpaqueInheritedType
-      && !mockableType.methods.contains(where: { $0.isDesignatedInitializer })
-    return isInitializableProtocol
-      || ((isInitializableProtocol || mockableType.kind == .class) && isInitializableInstance)
+      && (protocolClassConformance == nil || !hasDesignatedInitializer)
+    let isInitializableClass = mockableType.kind == .class
+      && !hasDesignatedInitializer
+    
+    return (isInitializableProtocol || isInitializableClass) && !mockableType.hasOpaqueInheritedType
   }
   var defaultInitializer: String {
     guard shouldGenerateDefaultInitializer else { return "" }

--- a/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -9,7 +9,7 @@ import Foundation
 import SourceKittenFramework
 
 /// A light wrapper around a SourceKit structure, used for the mocked module and its dependencies.
-struct RawType {
+class RawType {
   let dictionary: StructureDictionary
   let name: String
   /// Fully qualified with respect to the current module (not with respect to other modules)
@@ -22,6 +22,8 @@ struct RawType {
   let definedInExtension: Bool // Types can be defined and nested within extensions.
   let kind: SwiftDeclarationKind
   let parsedFile: ParsedFile
+  
+  var hasOpaqueInheritedType = false
   
   var isContainedType: Bool { return !containingTypeNames.isEmpty }
   

--- a/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
@@ -127,6 +127,12 @@ class FlattenInheritanceOperation: BasicOperation {
       })
     }
     
+    // It's possible that a known inherited type indirectly references an opaque type.
+    hasOpaqueInheritedType = hasOpaqueInheritedType || rawInheritedTypes.contains(where: {
+      $0.hasOpaqueInheritedType
+    })
+    baseRawType.hasOpaqueInheritedType = hasOpaqueInheritedType
+    
     return createMockableType(hasOpaqueInheritedType)
   }
 }

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -38,42 +38,42 @@ public final class ArgumentMatchingProtocolMock: MockingbirdTestsHost.ArgumentMa
     self.sourceLocation = sourceLocation
   }
 
-  // MARK: Mocked `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: AnyObject?)
+  // MARK: Mocked `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?)
 
-  public func `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: AnyObject?) -> Bool {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: AnyObject?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`optionalStructType`), Mockingbird.ArgumentMatcher(`optionalClassType`), Mockingbird.ArgumentMatcher(`optionalEnumType`), Mockingbird.ArgumentMatcher(`optionalStringType`), Mockingbird.ArgumentMatcher(`optionalBoolType`), Mockingbird.ArgumentMatcher(`optionalMetaType`), Mockingbird.ArgumentMatcher(`optionalAnyType`), Mockingbird.ArgumentMatcher(`optionalAnyObjectType`)])
+  public func `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`optionalStructType`), Mockingbird.ArgumentMatcher(`optionalClassType`), Mockingbird.ArgumentMatcher(`optionalEnumType`), Mockingbird.ArgumentMatcher(`optionalStringType`), Mockingbird.ArgumentMatcher(`optionalBoolType`), Mockingbird.ArgumentMatcher(`optionalMetaType`), Mockingbird.ArgumentMatcher(`optionalAnyType`), Mockingbird.ArgumentMatcher(`optionalAnyObjectType`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, AnyObject?) -> Bool {
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool {
       return concreteImplementation(`optionalStructType`, `optionalClassType`, `optionalEnumType`, `optionalStringType`, `optionalBoolType`, `optionalMetaType`, `optionalAnyType`, `optionalAnyObjectType`)
     } else {
       return (implementation as! () -> Bool)()
     }
   }
 
-  public func `method`(optionalStructType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType?, optionalClassType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType?, optionalEnumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType?, optionalStringType: @escaping @autoclosure () -> String?, optionalBoolType: @escaping @autoclosure () -> Bool?, optionalMetaType: @escaping @autoclosure () -> ClassType.Type?, optionalAnyType: @escaping @autoclosure () -> Any?, optionalAnyObjectType: @escaping @autoclosure () -> AnyObject?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, AnyObject?) -> Bool, Bool> {
+  public func `method`(optionalStructType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType?, optionalClassType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType?, optionalEnumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType?, optionalStringType: @escaping @autoclosure () -> String?, optionalBoolType: @escaping @autoclosure () -> Bool?, optionalMetaType: @escaping @autoclosure () -> ClassType.Type?, optionalAnyType: @escaping @autoclosure () -> Any?, optionalAnyObjectType: @escaping @autoclosure () -> Swift.AnyObject?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool> {
     let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`optionalStructType`), Mockingbird.resolve(`optionalClassType`), Mockingbird.resolve(`optionalEnumType`), Mockingbird.resolve(`optionalStringType`), Mockingbird.resolve(`optionalBoolType`), Mockingbird.resolve(`optionalMetaType`), Mockingbird.resolve(`optionalAnyType`), Mockingbird.resolve(`optionalAnyObjectType`)]
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: AnyObject?) -> Bool", arguments: arguments)
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, AnyObject?) -> Bool, Bool>(mock: self, invocation: invocation)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
-  // MARK: Mocked `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: AnyObject)
+  // MARK: Mocked `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject)
 
-  public func `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: AnyObject) -> Bool {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: AnyObject) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`structType`), Mockingbird.ArgumentMatcher(`classType`), Mockingbird.ArgumentMatcher(`enumType`), Mockingbird.ArgumentMatcher(`stringType`), Mockingbird.ArgumentMatcher(`boolType`), Mockingbird.ArgumentMatcher(`metaType`), Mockingbird.ArgumentMatcher(`anyType`), Mockingbird.ArgumentMatcher(`anyObjectType`)])
+  public func `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`structType`), Mockingbird.ArgumentMatcher(`classType`), Mockingbird.ArgumentMatcher(`enumType`), Mockingbird.ArgumentMatcher(`stringType`), Mockingbird.ArgumentMatcher(`boolType`), Mockingbird.ArgumentMatcher(`metaType`), Mockingbird.ArgumentMatcher(`anyType`), Mockingbird.ArgumentMatcher(`anyObjectType`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, AnyObject) -> Bool {
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool {
       return concreteImplementation(`structType`, `classType`, `enumType`, `stringType`, `boolType`, `metaType`, `anyType`, `anyObjectType`)
     } else {
       return (implementation as! () -> Bool)()
     }
   }
 
-  public func `method`(structType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType, classType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType, enumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType, stringType: @escaping @autoclosure () -> String, boolType: @escaping @autoclosure () -> Bool, metaType: @escaping @autoclosure () -> ClassType.Type, anyType: @escaping @autoclosure () -> Any, anyObjectType: @escaping @autoclosure () -> AnyObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, AnyObject) -> Bool, Bool> {
+  public func `method`(structType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType, classType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType, enumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType, stringType: @escaping @autoclosure () -> String, boolType: @escaping @autoclosure () -> Bool, metaType: @escaping @autoclosure () -> ClassType.Type, anyType: @escaping @autoclosure () -> Any, anyObjectType: @escaping @autoclosure () -> Swift.AnyObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool> {
     let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`structType`), Mockingbird.resolve(`classType`), Mockingbird.resolve(`enumType`), Mockingbird.resolve(`stringType`), Mockingbird.resolve(`boolType`), Mockingbird.resolve(`metaType`), Mockingbird.resolve(`anyType`), Mockingbird.resolve(`anyObjectType`)]
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: AnyObject) -> Bool", arguments: arguments)
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, AnyObject) -> Bool, Bool>(mock: self, invocation: invocation)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 }
 
@@ -2236,8 +2236,6 @@ public final class ClassOnlyProtocolWithInheritanceMock: MockingbirdTestsHost.Cl
     }
   }
 
-  public enum InitializerProxy {}
-
   // MARK: Mocked childInstanceVariable
 
   public var `childInstanceVariable`: Bool {
@@ -2529,6 +2527,11 @@ public final class ClassOnlyProtocolWithInheritanceMock: MockingbirdTestsHost.Cl
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
   // MARK: Mocked `childParameterizedInstanceMethod`(param1: Bool, _ param2: Int)
 
   public func `childParameterizedInstanceMethod`(param1: Bool, _ param2: Int) -> Bool {
@@ -2752,9 +2755,9 @@ public final class ClassOnlyProtocolWithInheritanceMock: MockingbirdTestsHost.Cl
   }
 }
 
-/// Create a source-attributed `MockingbirdTestsHost.ClassOnlyProtocolWithInheritance` class mock metatype.
-public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ClassOnlyProtocolWithInheritance.Protocol) -> ClassOnlyProtocolWithInheritanceMock.InitializerProxy.Type {
-  return ClassOnlyProtocolWithInheritanceMock.InitializerProxy.self
+/// Create a source-attributed `MockingbirdTestsHost.ClassOnlyProtocolWithInheritance` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ClassOnlyProtocolWithInheritance.Protocol) -> ClassOnlyProtocolWithInheritanceMock {
+  return ClassOnlyProtocolWithInheritanceMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked ClassOnlyProtocol
@@ -2772,8 +2775,6 @@ public final class ClassOnlyProtocolMock: MockingbirdTestsHost.ClassOnlyProtocol
     }
   }
 
-  public enum InitializerProxy {}
-
   // MARK: Mocked variable
 
   public var `variable`: Bool {
@@ -2788,11 +2789,16 @@ public final class ClassOnlyProtocolMock: MockingbirdTestsHost.ClassOnlyProtocol
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
 }
 
-/// Create a source-attributed `MockingbirdTestsHost.ClassOnlyProtocol` class mock metatype.
-public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ClassOnlyProtocol.Protocol) -> ClassOnlyProtocolMock.InitializerProxy.Type {
-  return ClassOnlyProtocolMock.InitializerProxy.self
+/// Create a source-attributed `MockingbirdTestsHost.ClassOnlyProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ClassOnlyProtocol.Protocol) -> ClassOnlyProtocolMock {
+  return ClassOnlyProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked ClassType
@@ -3782,8 +3788,6 @@ public final class DeprecatedClassOnlyProtocolWithInheritanceMock: MockingbirdTe
     }
   }
 
-  public enum InitializerProxy {}
-
   // MARK: Mocked childInstanceVariable
 
   public var `childInstanceVariable`: Bool {
@@ -4075,6 +4079,11 @@ public final class DeprecatedClassOnlyProtocolWithInheritanceMock: MockingbirdTe
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
   // MARK: Mocked `childParameterizedInstanceMethod`(param1: Bool, _ param2: Int)
 
   public func `childParameterizedInstanceMethod`(param1: Bool, _ param2: Int) -> Bool {
@@ -4298,9 +4307,9 @@ public final class DeprecatedClassOnlyProtocolWithInheritanceMock: MockingbirdTe
   }
 }
 
-/// Create a source-attributed `MockingbirdTestsHost.DeprecatedClassOnlyProtocolWithInheritance` class mock metatype.
-public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.DeprecatedClassOnlyProtocolWithInheritance.Protocol) -> DeprecatedClassOnlyProtocolWithInheritanceMock.InitializerProxy.Type {
-  return DeprecatedClassOnlyProtocolWithInheritanceMock.InitializerProxy.self
+/// Create a source-attributed `MockingbirdTestsHost.DeprecatedClassOnlyProtocolWithInheritance` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.DeprecatedClassOnlyProtocolWithInheritance.Protocol) -> DeprecatedClassOnlyProtocolWithInheritanceMock {
+  return DeprecatedClassOnlyProtocolWithInheritanceMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked DeprecatedClassOnlyProtocol
@@ -4318,8 +4327,6 @@ public final class DeprecatedClassOnlyProtocolMock: MockingbirdTestsHost.Depreca
     }
   }
 
-  public enum InitializerProxy {}
-
   // MARK: Mocked variable
 
   public var `variable`: Bool {
@@ -4334,11 +4341,16 @@ public final class DeprecatedClassOnlyProtocolMock: MockingbirdTestsHost.Depreca
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
 }
 
-/// Create a source-attributed `MockingbirdTestsHost.DeprecatedClassOnlyProtocol` class mock metatype.
-public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.DeprecatedClassOnlyProtocol.Protocol) -> DeprecatedClassOnlyProtocolMock.InitializerProxy.Type {
-  return DeprecatedClassOnlyProtocolMock.InitializerProxy.self
+/// Create a source-attributed `MockingbirdTestsHost.DeprecatedClassOnlyProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.DeprecatedClassOnlyProtocol.Protocol) -> DeprecatedClassOnlyProtocolMock {
+  return DeprecatedClassOnlyProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked DictionaryCollection
@@ -8761,12 +8773,16 @@ public final class NSObjectProtocolConformingProtocolMock: Foundation.NSObject, 
     }
   }
 
-  public enum InitializerProxy {}
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
 }
 
-/// Create a source-attributed `MockingbirdTestsHost.NSObjectProtocolConformingProtocol` class mock metatype.
-public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.NSObjectProtocolConformingProtocol.Protocol) -> NSObjectProtocolConformingProtocolMock.InitializerProxy.Type {
-  return NSObjectProtocolConformingProtocolMock.InitializerProxy.self
+/// Create a source-attributed `MockingbirdTestsHost.NSObjectProtocolConformingProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.NSObjectProtocolConformingProtocol.Protocol) -> NSObjectProtocolConformingProtocolMock {
+  return NSObjectProtocolConformingProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked NSViewInheritingProtocol

--- a/MockingbirdSupport/Swift/Misc.swift
+++ b/MockingbirdSupport/Swift/Misc.swift
@@ -1,0 +1,5 @@
+public protocol AnyObject {}
+
+public typealias `class` = AnyObject
+
+public typealias AnyClass = AnyObject.Type

--- a/MockingbirdTests/Framework/InitializerTests.swift
+++ b/MockingbirdTests/Framework/InitializerTests.swift
@@ -11,6 +11,8 @@ import Mockingbird
 
 class InitializerTests: XCTestCase {
   
+  // MARK: Standard initialization
+  
   var initializerClass: InitializerClassMock!
   var initializerProtocol: InitializerProtocolMock!
   
@@ -24,6 +26,42 @@ class InitializerTests: XCTestCase {
   
   func testInitializerProtocol() {
     initializerProtocol = mock(InitializerProtocol.self)
+  }
+  
+  
+  // MARK: Empty type initialization
+  
+  var emptyProtocol: EmptyProtocolMock!
+  var emptyClass: EmptyClassMock!
+  var emptyInheritingProtocol: EmptyInheritingProtocolMock!
+  var emptyInheritingClass: EmptyInheritingClassMock!
+  
+  func testEmptyTypeInitialization() {
+    emptyProtocol = mock(EmptyProtocol.self)
+    emptyClass = mock(EmptyClass.self)
+  }
+  
+  func testEmptyInheritingTypeInitialization() {
+    emptyInheritingProtocol = mock(EmptyInheritingProtocol.self)
+    emptyInheritingClass = mock(EmptyInheritingClass.self)
+  }
+  
+  
+  // MARK: Class only protocol initialization
+  
+  var deprecatedClassOnlyProtocol: DeprecatedClassOnlyProtocolMock!
+  var deprecatedClassOnlyProtocolWithInheritance: DeprecatedClassOnlyProtocolWithInheritanceMock!
+  var classOnlyProtocol: ClassOnlyProtocolMock!
+  var classOnlyProtocolWithInheritance: ClassOnlyProtocolWithInheritanceMock!
+  
+  func testDeprecatedClassOnlyProtocolInitialization() {
+    deprecatedClassOnlyProtocol = mock(DeprecatedClassOnlyProtocol.self)
+    deprecatedClassOnlyProtocolWithInheritance = mock(DeprecatedClassOnlyProtocolWithInheritance.self)
+  }
+  
+  func testClassOnlyProtocolInitialization() {
+    classOnlyProtocol = mock(ClassOnlyProtocol.self)
+    classOnlyProtocolWithInheritance = mock(ClassOnlyProtocolWithInheritance.self)
   }
 }
 


### PR DESCRIPTION
## Changes
- Adds Swift/Misc.swift supporting source file with AnyObject and `class` type definitions
- Improves unit tests for initializers

## Summary
### Problem 1
Mockingbird was treating class-only protocols (protocols constrained to `AnyObject` or `class`) as an “opaque type” (a referenced type whose source is missing / not parsable). The solution is to include `protocol AnyObject {}` in the `MockingbirdSupport/Swift` supporting source files.

### Problem 2
The logic for when to generate an empty designated initializer to use when calling `mock(SomeType.self)` incorrectly excluded class-conforming protocols without checking for existing inherited designated initializers.