### PR TITLE
handle non-alphanumeric target names

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		3B7716CE2364AE3500B339EB /* PBXTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7716CD2364AE3500B339EB /* PBXTargetTests.swift */; };
 		4904BDED232ED4B80031E071 /* EmptyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDEC232ED4B80031E071 /* EmptyTypes.swift */; };
 		4904BDEF232F15510031E071 /* ExternalModuleTypesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDEE232F15510031E071 /* ExternalModuleTypesMockableTests.swift */; };
 		4904BDF1232F168D0031E071 /* ExternalModuleTypesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDF0232F168D0031E071 /* ExternalModuleTypesStubbableTests.swift */; };
@@ -940,6 +941,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3B7716CD2364AE3500B339EB /* PBXTargetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PBXTargetTests.swift; sourceTree = "<group>"; };
 		4904BDEC232ED4B80031E071 /* EmptyTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTypes.swift; sourceTree = "<group>"; };
 		4904BDEE232F15510031E071 /* ExternalModuleTypesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleTypesMockableTests.swift; sourceTree = "<group>"; };
 		4904BDF0232F168D0031E071 /* ExternalModuleTypesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleTypesStubbableTests.swift; sourceTree = "<group>"; };
@@ -1794,6 +1796,7 @@
 		OBJ_185 /* Generator */ = {
 			isa = PBXGroup;
 			children = (
+				3B7716CD2364AE3500B339EB /* PBXTargetTests.swift */,
 				OBJ_186 /* DeclaredTypeTests.swift */,
 				OBJ_187 /* StringExtensionsTests.swift */,
 			);
@@ -3987,6 +3990,7 @@
 				4904BDF3232F18A10031E071 /* InitializersMockableTests.swift in Sources */,
 				OBJ_839 /* VariadicParametersMockableTests.swift in Sources */,
 				4904BDF1232F168D0031E071 /* ExternalModuleTypesStubbableTests.swift in Sources */,
+				3B7716CE2364AE3500B339EB /* PBXTargetTests.swift in Sources */,
 				OBJ_840 /* VariadicParametersStubbableTests.swift in Sources */,
 				OBJ_841 /* TreeTests.swift in Sources */,
 				OBJ_842 /* ArgumentCaptorTests.swift in Sources */,

--- a/MockingbirdTests/Generator/PBXTargetTests.swift
+++ b/MockingbirdTests/Generator/PBXTargetTests.swift
@@ -1,0 +1,25 @@
+//
+//  PBXTargetTests.swift
+//  MockingbirdTests
+//
+//  Created by Sterling Hackley on 10/26/19.
+//
+
+import XCTest
+import XcodeProj
+@testable import MockingbirdGenerator
+
+class PBXTargetTests: XCTestCase {
+
+  // MARK: - productModuleName
+
+  func testProductModuleName_handlesNonAlphaNumericCharacters() {
+    let actual = PBXTarget(name: "a-module.name").productModuleName
+    XCTAssertEqual(actual, "a_module_name")
+  }
+
+  func testProductModuleName_handlesFirstCharacterNumeral() {
+    let actual = PBXTarget(name: "123name").productModuleName
+    XCTAssertEqual(actual, "_23name")
+  }
+}


### PR DESCRIPTION
## Changes
- Modifies `PBXTarget` `productModuleName` implementation to handle module names with non-alphanumeric characters.
- Adds PBXTargetTests.swift

## Summary
### Problem
If Mockingbird generates mocks for a module with non-alphanumeric characters in the name, the generated mocks will not compile.

From [Apple documentation](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_swift_into_objective-c):
> By default, this name is the same as your product name, with any nonalphanumeric characters replaced with an underscore (_). If the name begins with a number, the first digit is replaced with an underscore.