### PR TITLE
Fix fnmatch implementation on macOS Catalina

### DIFF
--- a/.github/workflows/build-framework-cli.yml
+++ b/.github/workflows/build-framework-cli.yml
@@ -1,10 +1,34 @@
-name: Build Framework and CLI
+name: Build + Test
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-latest:
+    name: Run on latest macOS
+    runs-on: macOS-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Clean
+      run: make clean
+    - name: Build
+      run: make build
+    - name: Install
+      run: make install
+    - name: Set Up
+      run: |
+        mockingbird install \
+          --target MockingbirdTestsHost \
+          --destination MockingbirdTests \
+          --loglevel verbose \
+          --verbose
+    - name: Test
+      run: make clean-test
+    - name: Cached Test
+      run: make test
 
+  build-mojave:
+    name: Run on macOS Mojave
     runs-on: macOS-10.14
     
     steps:

--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		4970D6782331E67C002EE154 /* OpaqueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4970D6772331E67C002EE154 /* OpaqueTypes.swift */; };
 		4970D6AA23335ABE002EE154 /* CompilationDirectives.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4970D6A923335ABD002EE154 /* CompilationDirectives.swift */; };
 		49732AF0232F322B0090E1A9 /* MethodParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49732AEF232F322B0090E1A9 /* MethodParameter.swift */; };
+		499854542368AD0A0022D413 /* PathFnmatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499854532368AD0A0022D413 /* PathFnmatchTests.swift */; };
 		49BA452A23415F6A002BD9B5 /* String+SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BA452923415F6A002BD9B5 /* String+SHA1.swift */; };
 		49BA452F234189F4002BD9B5 /* CodableTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BA452E234189F4002BD9B5 /* CodableTarget.swift */; };
 		49BA45312341E97D002BD9B5 /* CheckCacheOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BA45302341E97D002BD9B5 /* CheckCacheOperation.swift */; };
@@ -964,6 +965,7 @@
 		4970D6772331E67C002EE154 /* OpaqueTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpaqueTypes.swift; sourceTree = "<group>"; };
 		4970D6A923335ABD002EE154 /* CompilationDirectives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompilationDirectives.swift; sourceTree = "<group>"; };
 		49732AEF232F322B0090E1A9 /* MethodParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodParameter.swift; sourceTree = "<group>"; };
+		499854532368AD0A0022D413 /* PathFnmatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathFnmatchTests.swift; sourceTree = "<group>"; };
 		49BA452923415F6A002BD9B5 /* String+SHA1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA1.swift"; sourceTree = "<group>"; };
 		49BA452E234189F4002BD9B5 /* CodableTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTarget.swift; sourceTree = "<group>"; };
 		49BA45302341E97D002BD9B5 /* CheckCacheOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckCacheOperation.swift; sourceTree = "<group>"; };
@@ -1800,6 +1802,7 @@
 			isa = PBXGroup;
 			children = (
 				3B7716CD2364AE3500B339EB /* PBXTargetTests.swift */,
+				499854532368AD0A0022D413 /* PathFnmatchTests.swift */,
 				OBJ_186 /* DeclaredTypeTests.swift */,
 				OBJ_187 /* StringExtensionsTests.swift */,
 			);
@@ -3999,6 +4002,7 @@
 				OBJ_841 /* TreeTests.swift in Sources */,
 				OBJ_842 /* ArgumentCaptorTests.swift in Sources */,
 				OBJ_843 /* ArgumentMatchingTests.swift in Sources */,
+				499854542368AD0A0022D413 /* PathFnmatchTests.swift in Sources */,
 				OBJ_844 /* AsyncVerificationTests.swift in Sources */,
 				OBJ_845 /* CollectionArgumentMatchingTests.swift in Sources */,
 				OBJ_846 /* InitializerTests.swift in Sources */,

--- a/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
+++ b/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
@@ -16,15 +16,12 @@ extension Path {
   ///   - isDirectory: Whether this path is a directory, if known at call time.
   /// - Returns: True if the path matches, false otherwise.
   func matches(pattern: String, isDirectory: Bool? = nil) -> Bool {
-    // PathKit strips trailing slashes when normalizing which causes directory globs to fail.
-    let isDirectory = isDirectory ?? self.isDirectory
-    
-    guard let rawPattern = pattern.data(using: .utf8, allowLossyConversion: false)?.withUnsafeBytes({
-      return $0.bindMemory(to: Int8.self).baseAddress
-    }), let rawPathString = "\(self)\(isDirectory ? "/" : "")".data(using: .utf8, allowLossyConversion: false)?.withUnsafeBytes({
-      return $0.bindMemory(to: Int8.self).baseAddress
-    }) else { return false }
-    
-    return fnmatch(rawPattern, rawPathString, 0) == 0
+    // PathKit strips trailing slashes for normalized paths which can cause directory globs to fail.
+    let rawPathString = "\(self)"
+    let shouldAppendTrailingSlash = !rawPathString.hasSuffix("/")
+      && pattern.hasSuffix("/") // Only apply trailing slash fix-it to directory globs.
+      && (isDirectory ?? self.isDirectory)
+    let pathString = rawPathString + (shouldAppendTrailingSlash ? "/" : "")
+    return fnmatch(pattern, pathString, FNM_PATHNAME | FNM_PERIOD) != FNM_NOMATCH
   }
 }

--- a/MockingbirdTests/Generator/PathFnmatchTests.swift
+++ b/MockingbirdTests/Generator/PathFnmatchTests.swift
@@ -1,0 +1,96 @@
+//
+//  PathFnmatchTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 10/29/19.
+//
+
+import XCTest
+import PathKit
+@testable import MockingbirdGenerator
+
+class PathFnmatchTests: XCTestCase {
+  
+  // MARK: - Exact
+
+  func testFnmatch_matchesExactFile() {
+    let path = Path("/foo/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/bar.txt", isDirectory: false))
+  }
+
+  func testFnmatch_matchesExactDirectory_noTrailingSlash() {
+    let path = Path("/foo/bar")
+    XCTAssertTrue(path.matches(pattern: "/foo/bar/", isDirectory: true))
+  }
+  
+  func testFnmatch_matchesExactDirectory_withTrailingSlash() {
+    let path = Path("/foo/bar/")
+    XCTAssertTrue(path.matches(pattern: "/foo/bar/", isDirectory: true))
+  }
+  
+  func testFnmatch_matchesExactDirectory_rootDirectory() {
+    let path = Path("/")
+    XCTAssertTrue(path.matches(pattern: "/", isDirectory: true))
+  }
+  
+  // MARK: - Relative
+  
+  func testFnmatch_matchesRelativeFile() {
+    let path = Path("./foo/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "./foo/bar.txt", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesRelativeDirectory_noTrailingSlash() {
+    let path = Path("./foo/bar")
+    XCTAssertTrue(path.matches(pattern: "./foo/bar/", isDirectory: true))
+  }
+  
+  func testFnmatch_matchesRelativeDirectory_withTrailingSlash() {
+    let path = Path("./foo/bar/")
+    XCTAssertTrue(path.matches(pattern: "./foo/bar/", isDirectory: true))
+  }
+  
+  // MARK: - Wildcard
+  
+  func testFnmatch_matchesWildcardFilePath() {
+    let path = Path("/foo/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/*", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardFileName() {
+    let path = Path("/foo/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/*.txt", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardFileExtension() {
+    let path = Path("/foo/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/bar.*", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardDirectory_withSpecificFileName() {
+    let path = Path("/foo/baz/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/**/bar.txt", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardDirectory_withWildcardFilePath() {
+    let path = Path("/foo/baz/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/**/*", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardDirectory_withWildcardFileName() {
+    let path = Path("/foo/baz/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/**/*.txt", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardDirectory_withWildcardFileExtension() {
+    let path = Path("/foo/baz/bar.txt")
+    XCTAssertTrue(path.matches(pattern: "/foo/**/bar.*", isDirectory: false))
+  }
+  
+  func testFnmatch_matchesWildcardDirectory() {
+    let filePath = Path("/foo/bar.txt")
+    let directoryPath = Path("/foo/bar")
+    XCTAssertTrue(filePath.matches(pattern: "/foo/**", isDirectory: false))
+    XCTAssertTrue(directoryPath.matches(pattern: "/foo/**", isDirectory: true))
+  }
+}


### PR DESCRIPTION
## Summary
Fixes https://github.com/birdrides/mockingbird/issues/13

## Discussion
Something has changed with the way Swift handles C-style string coercion between macOS Mojave and Catalina. The following correctly encodes and creates a contiguous UTF-8 byte buffer in Mojave that can be passed to `fnmatch`, but breaks in Catalina:

```swift
pattern.data(using: .utf8).withUnsafeBytes({ $0.bindMemory(to: Int8.self).baseAddress })
```

When the encoding is changed to `.ascii` then `fnmatch` magically starts to work in Mojave… even though the `Data` returned is identical to `.utf8` (for the test case which is strictly ASCII).

None of the below work when passed to `fnmatch` in Catalina either:

```swift
pattern.cString(using: .utf8)
pattern.cString(using: .ascii)
pattern.utf8CString
```

The fix is to use the built-in Swift interop with C functions by simply passing the Swift string directly an argument to `UnsafePointer<Int8>` type parameters.