### PR TITLE
Remove automatic binary installation from pod install prepare_command

### DIFF
--- a/MockingbirdFramework.podspec
+++ b/MockingbirdFramework.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author                 = { 'Andrew Chang' => 'andrew.chang@bird.co' }
   s.source                 = { :git => s.homepage + '.git', :tag => s.version }
   s.source_files           = 'MockingbirdFramework/**/*.swift'
-  s.prepare_command        = 'make install-prebuilt'
+  s.prepare_command        = 'make download'
   s.ios.deployment_target  = '8.0'
   s.osx.deployment_target  = '10.9'
   s.tvos.deployment_target = '9.0'
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.user_target_xcconfig   = { 'FRAMEWORK_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
   s.pod_target_xcconfig    = { 'ENABLE_BITCODE' => 'NO' }
   s.swift_version          = '5.0'
-  s.preserve_paths         = '*'
+  s.preserve_paths         = 'README.md', 'LICENSE', 'Makefile', 'Codesigning/*', 'MockingbirdSupport/**/*', 'MockingbirdCli/Info.plist'
 end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ target 'ATestTarget' do
 end
 ```
 
-This will download and install the CLI during the next `pod install`.
+Then initialize the pod.
+
+```bash
+$ pod install
+```
+
+And install the CLI.
+
+```bash
+$ cd Pods/MockingbirdFramework
+$ make install-prebuilt
+```
 
 ### Carthage
 


### PR DESCRIPTION
Not all environments (e.g. CI) allow modifying `/usr/local/bin`. Rather than automatically installing the downloaded binary, allow the user to run `$ make install-prebuilt` as needed during the initial set up.