### PR TITLE
Invalidate cached mocked modules when the CLI version changes

### DIFF
--- a/MockingbirdCli/Interface/Generator.swift
+++ b/MockingbirdCli/Interface/Generator.swift
@@ -206,6 +206,7 @@ class Generator {
         try pipelines.forEach({
           try cachePipeline($0,
                             projectHash: projectHash,
+                            cliVersion: "\(mockingbirdVersion)",
                             sourceRoot: config.sourceRoot,
                             cacheDirectory: cacheDirectory)
         })
@@ -247,6 +248,7 @@ class Generator {
   
   static func cachePipeline(_ pipeline: Pipeline,
                             projectHash: String,
+                            cliVersion: String,
                             sourceRoot: Path,
                             cacheDirectory: Path) throws {
     guard !pipeline.usedCache,
@@ -263,6 +265,7 @@ class Generator {
                                  outputHash: pipeline.outputPath.read().generateSha1Hash(),
                                  targetPathsHash: result.generateTargetPathsHash(),
                                  dependencyPathsHash: result.generateDependencyPathsHash(),
+                                 cliVersion: cliVersion,
                                  ignoredDependencies: &ignoredDependencies)
     } else if let pipelineTarget = pipeline.inputTarget as? PBXTarget {
       target = try CodableTarget(from: pipelineTarget,
@@ -272,6 +275,7 @@ class Generator {
                                  outputHash: pipeline.outputPath.read().generateSha1Hash(),
                                  targetPathsHash: result.generateTargetPathsHash(),
                                  dependencyPathsHash: result.generateDependencyPathsHash(),
+                                 cliVersion: cliVersion,
                                  ignoredDependencies: &ignoredDependencies)
     } else {
       throw Failure.internalError(

--- a/MockingbirdGenerator/Parser/Cache/CodableTarget.swift
+++ b/MockingbirdGenerator/Parser/Cache/CodableTarget.swift
@@ -69,6 +69,7 @@ public class CodableTarget: Target, Codable {
   public let outputHash: String?
   public let targetPathsHash: String?
   public let dependencyPathsHash: String?
+  public let cliVersion: String?
   
   public init<T: Target>(from target: T,
                          sourceRoot: Path,
@@ -77,6 +78,7 @@ public class CodableTarget: Target, Codable {
                          outputHash: String? = nil,
                          targetPathsHash: String? = nil,
                          dependencyPathsHash: String? = nil,
+                         cliVersion: String? = nil,
                          ignoredDependencies: inout Set<String>) throws {
     self.name = target.name
     self.productModuleName = target.productModuleName
@@ -99,6 +101,7 @@ public class CodableTarget: Target, Codable {
     self.sourceRoot = "\(sourceRoot.absolute())"
     self.projectHash = projectHash
     self.outputHash = outputHash
+    self.cliVersion = cliVersion
   }
   
   public func findSourceFilePaths(sourceRoot: Path) -> [Path] {

--- a/MockingbirdGenerator/Parser/Operations/CheckCacheOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/CheckCacheOperation.swift
@@ -39,6 +39,7 @@ public class CheckCacheOperation: BasicOperation {
         })
       
       guard changedFiles.isEmpty,
+        codableTarget.cliVersion == "\(mockingbirdVersion)",
         let targetPathsHash = codableTarget.targetPathsHash,
         let dependencyPathsHash = codableTarget.dependencyPathsHash,
         let outputHash = codableTarget.outputHash,
@@ -48,7 +49,7 @@ public class CheckCacheOperation: BasicOperation {
           log("Detected \(changedFiles.count) changed source file\(changedFiles.count != 1 ? "s" : "") for target `\(codableTarget.name)` - \(changedFiles.map({ "\($0.path.absolute())" }))")
           return
       }
-      log("Ignoring target `\(codableTarget.name)` because no source files were changed and the generated mock file matches the expected SHA-1 hash of `\(outputHash)`")
+      log("Ignoring target `\(codableTarget.name)` because no source files were changed, the CLI version matches `\(mockingbirdVersion)`, and the generated mock file matches the expected SHA-1 hash of `\(outputHash)`")
       result.isCached = true
     }
   }


### PR DESCRIPTION
CLI version changes can result in breaking changes between the generated mocks and framework, so cached mocks should be invalidated.