### PR TITLE
Fix matching closures with wildcard argument matchers

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		4904BDF5232F1AB30031E071 /* EmptyTypesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDF4232F1AB30031E071 /* EmptyTypesMockableTests.swift */; };
 		4904BDF7232F1E570031E071 /* ExternalModuleClassScopedTypesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDF6232F1E570031E071 /* ExternalModuleClassScopedTypesMockableTests.swift */; };
 		4904BDF9232F1F750031E071 /* ExternalModuleClassScopedTypesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904BDF8232F1F750031E071 /* ExternalModuleClassScopedTypesStubbableTests.swift */; };
+		491047AE2391FC0B00E837AE /* ClosureParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491047AD2391FC0B00E837AE /* ClosureParameterTests.swift */; };
 		491906392336CCCE00629F00 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491906382336CCCE00629F00 /* Generics.swift */; };
 		493ECA34232ECC92008BF44B /* ClassScopedTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493ECA33232ECC92008BF44B /* ClassScopedTypes.swift */; };
 		493ECA36232ECD99008BF44B /* Typealiasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493ECA35232ECD99008BF44B /* Typealiasing.swift */; };
@@ -952,6 +953,7 @@
 		4904BDF4232F1AB30031E071 /* EmptyTypesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTypesMockableTests.swift; sourceTree = "<group>"; };
 		4904BDF6232F1E570031E071 /* ExternalModuleClassScopedTypesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleClassScopedTypesMockableTests.swift; sourceTree = "<group>"; };
 		4904BDF8232F1F750031E071 /* ExternalModuleClassScopedTypesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleClassScopedTypesStubbableTests.swift; sourceTree = "<group>"; };
+		491047AD2391FC0B00E837AE /* ClosureParameterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureParameterTests.swift; sourceTree = "<group>"; };
 		491906382336CCCE00629F00 /* Generics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generics.swift; sourceTree = "<group>"; };
 		493ECA31232EC7CD008BF44B /* MockingbirdFramework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockingbirdFramework.xcconfig; sourceTree = "<group>"; };
 		493ECA32232EC7CD008BF44B /* MockingbirdCli.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockingbirdCli.xcconfig; sourceTree = "<group>"; };
@@ -1788,6 +1790,7 @@
 				OBJ_176 /* ArgumentCaptorTests.swift */,
 				OBJ_177 /* ArgumentMatchingTests.swift */,
 				OBJ_178 /* AsyncVerificationTests.swift */,
+				491047AD2391FC0B00E837AE /* ClosureParameterTests.swift */,
 				OBJ_179 /* CollectionArgumentMatchingTests.swift */,
 				OBJ_180 /* InitializerTests.swift */,
 				OBJ_181 /* LastSetValueStubTests.swift */,
@@ -3985,6 +3988,7 @@
 				OBJ_827 /* ExtensionsStubbableTests.swift in Sources */,
 				OBJ_828 /* GenericsMockableTests.swift in Sources */,
 				OBJ_829 /* GenericsStubbableTests.swift in Sources */,
+				491047AE2391FC0B00E837AE /* ClosureParameterTests.swift in Sources */,
 				OBJ_830 /* IgnoredSourceExclusionTests.swift in Sources */,
 				OBJ_831 /* InoutParametersMockableTests.swift in Sources */,
 				OBJ_832 /* InoutParametersStubbableTests.swift in Sources */,

--- a/MockingbirdFramework/DSL/TypeFacade.swift
+++ b/MockingbirdFramework/DSL/TypeFacade.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// It goes without saying that this should probably never be done in production.
 class TypeFacade {
-  static let shared = TypeFacade()
+  static let sharedBuffer = UnsafeMutableRawPointer.allocate(byteCount: 512000, alignment: 0)
   
   class StoredValue {
     var value: Any? {
@@ -41,10 +41,7 @@ func createTypeFacade<T>(_ value: Any?) -> T {
   
   // Trivial case where `T` is a non-nominal type such as `Any` or `AnyObject`.
   if let concreteType = AnyObjectFake() as? T { return concreteType }
-  return Unmanaged.passUnretained(TypeFacade.shared)
-    .toOpaque()
-    .bindMemory(to: T.self, capacity: 1)
-    .pointee
+  return TypeFacade.sharedBuffer.bindMemory(to: T.self, capacity: 1).pointee
 }
 
 /// Resolve `parameter` when `T` is _not_ known to be `Equatable`.

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -90,7 +90,7 @@ public func any<T>(_ type: T.Type = T.self) -> T {
   let base: T? = nil
   let description = "any<\(T.self)>()"
   let matcher = ArgumentMatcher(base, description: description, priority: .high) { (_, rhs) in
-    return rhs is T
+    return rhs is T || rhs is NonEscapingClosureProtocol
   }
   return createTypeFacade(matcher)
 }
@@ -146,7 +146,7 @@ public func notNil<T>(_ type: T.Type = T.self) -> T {
   let base: T? = nil
   let description = "notNil<\(T.self)>()"
   let matcher = ArgumentMatcher(base, description: description, priority: .high) { (_, rhs) in
-    return rhs is T && rhs != nil
+    return (rhs is T || rhs is NonEscapingClosureProtocol) && rhs != nil
   }
   return createTypeFacade(matcher)
 }

--- a/MockingbirdFramework/Verification/Invocation.swift
+++ b/MockingbirdFramework/Verification/Invocation.swift
@@ -54,4 +54,5 @@ struct Invocation: Equatable, CustomStringConvertible {
 
 /// Method parameters that are non-escaping closure types cannot be stored in an `Invocation`. An
 /// instance of a `NonEscapingClosure<T>` is stored instead, where `T` is the closure type.
-public struct NonEscapingClosure<T> {}
+protocol NonEscapingClosureProtocol {}
+public class NonEscapingClosure<T>: NonEscapingClosureProtocol {}

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -2981,10 +2981,10 @@ public final class ClosureParametersProtocolMock: MockingbirdTestsHost.ClosurePa
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (@escaping () -> Void) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
-  // MARK: Mocked `escapingTrivialReturningVoidClosure`(block: @escaping () -> Bool)
+  // MARK: Mocked `escapingTrivialReturningClosure`(block: @escaping () -> Bool)
 
-  public func `escapingTrivialReturningVoidClosure`(block: @escaping () -> Bool) -> Bool {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`escapingTrivialReturningVoidClosure`(block: @escaping () -> Bool) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+  public func `escapingTrivialReturningClosure`(block: @escaping () -> Bool) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`escapingTrivialReturningClosure`(block: @escaping () -> Bool) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
     if let concreteImplementation = implementation as? (@escaping () -> Bool) -> Bool {
@@ -2994,10 +2994,86 @@ public final class ClosureParametersProtocolMock: MockingbirdTestsHost.ClosurePa
     }
   }
 
-  public func `escapingTrivialReturningVoidClosure`(block: @escaping @autoclosure () -> () -> Bool) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (@escaping () -> Bool) -> Bool, Bool> {
+  public func `escapingTrivialReturningClosure`(block: @escaping @autoclosure () -> () -> Bool) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (@escaping () -> Bool) -> Bool, Bool> {
     let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`escapingTrivialReturningVoidClosure`(block: @escaping () -> Bool) -> Bool", arguments: arguments)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`escapingTrivialReturningClosure`(block: @escaping () -> Bool) -> Bool", arguments: arguments)
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (@escaping () -> Bool) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `implicitEscapingParameterizedClosure`(block: ((Bool) -> Void)?)
+
+  public func `implicitEscapingParameterizedClosure`(block: ((Bool) -> Void)?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingParameterizedClosure`(block: ((Bool) -> Void)?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (((Bool) -> Void)?) -> Bool {
+      return concreteImplementation(`block`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `implicitEscapingParameterizedClosure`(block: @escaping @autoclosure () -> ((Bool) -> Void)?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (((Bool) -> Void)?) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingParameterizedClosure`(block: ((Bool) -> Void)?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (((Bool) -> Void)?) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `implicitEscapingParameterizedReturningClosure`(block: ((Bool) -> Bool)?)
+
+  public func `implicitEscapingParameterizedReturningClosure`(block: ((Bool) -> Bool)?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingParameterizedReturningClosure`(block: ((Bool) -> Bool)?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (((Bool) -> Bool)?) -> Bool {
+      return concreteImplementation(`block`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `implicitEscapingParameterizedReturningClosure`(block: @escaping @autoclosure () -> ((Bool) -> Bool)?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (((Bool) -> Bool)?) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingParameterizedReturningClosure`(block: ((Bool) -> Bool)?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (((Bool) -> Bool)?) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `implicitEscapingTrivialClosure`(block: (() -> Void)?)
+
+  public func `implicitEscapingTrivialClosure`(block: (() -> Void)?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingTrivialClosure`(block: (() -> Void)?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? ((() -> Void)?) -> Bool {
+      return concreteImplementation(`block`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `implicitEscapingTrivialClosure`(block: @escaping @autoclosure () -> (() -> Void)?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, ((() -> Void)?) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingTrivialClosure`(block: (() -> Void)?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, ((() -> Void)?) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `implicitEscapingTrivialReturningClosure`(block: (() -> Bool)?)
+
+  public func `implicitEscapingTrivialReturningClosure`(block: (() -> Bool)?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingTrivialReturningClosure`(block: (() -> Bool)?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? ((() -> Bool)?) -> Bool {
+      return concreteImplementation(`block`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `implicitEscapingTrivialReturningClosure`(block: @escaping @autoclosure () -> (() -> Bool)?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, ((() -> Bool)?) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`implicitEscapingTrivialReturningClosure`(block: (() -> Bool)?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, ((() -> Bool)?) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
   // MARK: Mocked `parameterizedClosure`(block: (Bool) -> Void)
@@ -3074,6 +3150,25 @@ public final class ClosureParametersProtocolMock: MockingbirdTestsHost.ClosurePa
     let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`trivialReturningClosure`(block: () -> Bool) -> Bool", arguments: arguments)
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (() -> Bool) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `wrappedClosureParameter`(block: MockingbirdTestsHost.ClosureWrapper)
+
+  public func `wrappedClosureParameter`(block: MockingbirdTestsHost.ClosureWrapper) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`wrappedClosureParameter`(block: MockingbirdTestsHost.ClosureWrapper) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`block`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.ClosureWrapper) -> Bool {
+      return concreteImplementation(`block`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `wrappedClosureParameter`(block: @escaping @autoclosure () -> MockingbirdTestsHost.ClosureWrapper) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.ClosureWrapper) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`block`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`wrappedClosureParameter`(block: MockingbirdTestsHost.ClosureWrapper) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.ClosureWrapper) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 }
 

--- a/MockingbirdTests/E2E/ClosureParametersStubbableTests.swift
+++ b/MockingbirdTests/E2E/ClosureParametersStubbableTests.swift
@@ -23,12 +23,21 @@ private protocol StubbableClosureParametersProtocol {
   
   func escapingTrivialClosure(block: @escaping @autoclosure () -> () -> Void)
     -> Mockable<MethodDeclaration, (@escaping () -> Void) -> Bool, Bool>
-  func escapingTrivialReturningVoidClosure(block: @escaping @autoclosure () -> () -> Bool)
+  func escapingTrivialReturningClosure(block: @escaping @autoclosure () -> () -> Bool)
     -> Mockable<MethodDeclaration, (@escaping () -> Bool) -> Bool, Bool>
   func escapingParameterizedClosure(block: @escaping @autoclosure () -> (Bool) -> Void)
     -> Mockable<MethodDeclaration, (@escaping (Bool) -> Void) -> Bool, Bool>
   func escapingParameterizedReturningClosure(block: @escaping @autoclosure () -> (Bool) -> Bool)
     -> Mockable<MethodDeclaration, (@escaping (Bool) -> Bool) -> Bool, Bool>
+  
+  func implicitEscapingTrivialClosure(block: @escaping @autoclosure () -> (() -> Void)?)
+    -> Mockable<MethodDeclaration, ((() -> Void)?) -> Bool, Bool>
+  func implicitEscapingTrivialReturningClosure(block: @escaping @autoclosure () -> (() -> Bool)?)
+    -> Mockable<MethodDeclaration, ((() -> Bool)?) -> Bool, Bool>
+  func implicitEscapingParameterizedClosure(block: @escaping @autoclosure () -> ((Bool) -> Void)?)
+    -> Mockable<MethodDeclaration, (((Bool) -> Void)?) -> Bool, Bool>
+  func implicitEscapingParameterizedReturningClosure(block: @escaping @autoclosure () -> ((Bool) -> Bool)?)
+    -> Mockable<MethodDeclaration, (((Bool) -> Bool)?) -> Bool, Bool>
   
   func autoclosureTrivialClosure(block: @escaping @autoclosure () -> () -> Void)
     -> Mockable<MethodDeclaration, (@autoclosure () -> Void) -> Bool, Bool>

--- a/MockingbirdTests/Framework/ClosureParameterTests.swift
+++ b/MockingbirdTests/Framework/ClosureParameterTests.swift
@@ -1,0 +1,186 @@
+//
+//  ClosureParameterTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 11/29/19.
+//
+
+import XCTest
+import Mockingbird
+@testable import MockingbirdTestsHost
+
+class ClosureParameterTests: XCTestCase {
+  
+  var concreteMock: ClosureParametersProtocolMock!
+  
+  override func setUp() {
+    concreteMock = mock(ClosureParametersProtocol.self)
+  }
+  
+  // MARK: - any()
+  
+  // MARK: Non-escaping
+
+  func testTrivialClosure_anyWildcardMatching() {
+    given(concreteMock.trivialClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .trivialClosure(block: {}))
+    verify(concreteMock.trivialClosure(block: any())).wasCalled()
+  }
+  
+  func testTrivialReturningClosure_anyWildcardMatching() {
+    given(concreteMock.trivialReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .trivialReturningClosure(block: { fatalError() }))
+    verify(concreteMock.trivialReturningClosure(block: any())).wasCalled()
+  }
+  
+  func testParameterizedClosure_anyWildcardMatching() {
+    given(concreteMock.parameterizedClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .parameterizedClosure(block: { _ in }))
+    verify(concreteMock.parameterizedClosure(block: any())).wasCalled()
+  }
+  
+  func testParameterizedReturningClosure_anyWildcardMatching() {
+    given(concreteMock.parameterizedReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .parameterizedReturningClosure(block: { _ in fatalError() }))
+    verify(concreteMock.parameterizedReturningClosure(block: any())).wasCalled()
+  }
+  
+  // MARK: Escaping
+  
+  func testEscapingTrivialClosure_anyWildcardMatching() {
+    given(concreteMock.escapingTrivialClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .escapingTrivialClosure(block: {}))
+    verify(concreteMock.escapingTrivialClosure(block: any())).wasCalled()
+  }
+  
+  func testEscapingTrivialReturningClosure_anyWildcardMatching() {
+    given(concreteMock.escapingTrivialReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .escapingTrivialReturningClosure(block: { fatalError() }))
+    verify(concreteMock.escapingTrivialReturningClosure(block: any())).wasCalled()
+  }
+  
+  func testEscapingParameterizedClosure_anyWildcardMatching() {
+    given(concreteMock.escapingParameterizedClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .escapingParameterizedClosure(block: { _ in }))
+    verify(concreteMock.escapingParameterizedClosure(block: any())).wasCalled()
+  }
+  
+  func testEscapingParameterizedReturningClosure_anyWildcardMatching() {
+    given(concreteMock.escapingParameterizedReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .escapingParameterizedReturningClosure(block: { _ in fatalError() }))
+    verify(concreteMock.escapingParameterizedReturningClosure(block: any())).wasCalled()
+  }
+  
+  // MARK: Nullable
+  
+  func testImplicitEscapingTrivialClosure_anyWildcardMatching() {
+    given(concreteMock.implicitEscapingTrivialClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialClosure(block: {}))
+    verify(concreteMock.implicitEscapingTrivialClosure(block: any())).wasCalled()
+  }
+  
+  func testImplicitEscapingTrivialReturningClosure_anyWildcardMatching() {
+    given(concreteMock.implicitEscapingTrivialReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialReturningClosure(block: { fatalError() }))
+    verify(concreteMock.implicitEscapingTrivialReturningClosure(block: any())).wasCalled()
+  }
+  
+  func testImplicitEscapingParameterizedClosure_anyWildcardMatching() {
+    given(concreteMock.implicitEscapingParameterizedClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedClosure(block: { _ in }))
+    verify(concreteMock.implicitEscapingParameterizedClosure(block: any())).wasCalled()
+  }
+  
+  func testImplicitEscapingParameterizedReturningClosure_anyWildcardMatching() {
+    given(concreteMock.implicitEscapingParameterizedReturningClosure(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedReturningClosure(block: { _ in fatalError() }))
+    verify(concreteMock.implicitEscapingParameterizedReturningClosure(block: any())).wasCalled()
+  }
+  
+  // MARK: Wrapped
+  
+  func testWrappedClosureParameter_anyWildcardMatching() {
+    given(concreteMock.wrappedClosureParameter(block: any())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol).wrappedClosureParameter(block: ClosureWrapper()))
+    verify(concreteMock.wrappedClosureParameter(block: any())).wasCalled()
+  }
+  
+  
+  // MARK: - notNil()
+  
+  func testImplicitEscapingTrivialClosure_notNilWildcardMatching_matchesNotNil() {
+    given(concreteMock.implicitEscapingTrivialClosure(block: notNil())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialClosure(block: {}))
+    verify(concreteMock.implicitEscapingTrivialClosure(block: notNil())).wasCalled()
+  }
+  
+  func testImplicitEscapingTrivialClosure_notNilWildcardMatching_doesNotMatchNil() {
+    given(concreteMock.implicitEscapingTrivialClosure(block: any())) ~> true
+    given(concreteMock.implicitEscapingTrivialClosure(block: notNil())) ~> false
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialClosure(block: nil))
+    verify(concreteMock.implicitEscapingTrivialClosure(block: any())).wasCalled()
+    verify(concreteMock.implicitEscapingTrivialClosure(block: notNil())).wasNeverCalled()
+  }
+  
+  func testImplicitEscapingTrivialReturningClosure_notNilWildcardMatching_matchesNotNil() {
+    given(concreteMock.implicitEscapingTrivialReturningClosure(block: notNil())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialReturningClosure(block: { fatalError() }))
+    verify(concreteMock.implicitEscapingTrivialReturningClosure(block: notNil())).wasCalled()
+  }
+  
+  func testImplicitEscapingTrivialReturningClosure_notNilWildcardMatching_doesNotMatchNil() {
+    given(concreteMock.implicitEscapingTrivialReturningClosure(block: any())) ~> true
+    given(concreteMock.implicitEscapingTrivialReturningClosure(block: notNil())) ~> false
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingTrivialReturningClosure(block: nil))
+    verify(concreteMock.implicitEscapingTrivialReturningClosure(block: any())).wasCalled()
+    verify(concreteMock.implicitEscapingTrivialReturningClosure(block: notNil())).wasNeverCalled()
+  }
+  
+  func testImplicitEscapingParameterizedClosure_notNilWildcardMatching_matchesNotNil() {
+    given(concreteMock.implicitEscapingParameterizedClosure(block: notNil())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedClosure(block: { _ in }))
+    verify(concreteMock.implicitEscapingParameterizedClosure(block: notNil())).wasCalled()
+  }
+  
+  func testImplicitEscapingParameterizedClosure_notNilWildcardMatching_doesNotMatchNil() {
+    given(concreteMock.implicitEscapingParameterizedClosure(block: any())) ~> true
+    given(concreteMock.implicitEscapingParameterizedClosure(block: notNil())) ~> false
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedClosure(block: nil))
+    verify(concreteMock.implicitEscapingParameterizedClosure(block: any())).wasCalled()
+    verify(concreteMock.implicitEscapingParameterizedClosure(block: notNil())).wasNeverCalled()
+  }
+  
+  func testImplicitEscapingParameterizedReturningClosure_notNilWildcardMatching_matchesNotNil() {
+    given(concreteMock.implicitEscapingParameterizedReturningClosure(block: notNil())) ~> true
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedReturningClosure(block: { _ in fatalError() }))
+    verify(concreteMock.implicitEscapingParameterizedReturningClosure(block: notNil())).wasCalled()
+  }
+  
+  func testImplicitEscapingParameterizedReturningClosure_notNilWildcardMatching_doesNotMatchNil() {
+    given(concreteMock.implicitEscapingParameterizedReturningClosure(block: any())) ~> true
+    given(concreteMock.implicitEscapingParameterizedReturningClosure(block: notNil())) ~> false
+    XCTAssertTrue((concreteMock as ClosureParametersProtocol)
+      .implicitEscapingParameterizedReturningClosure(block: nil))
+    verify(concreteMock.implicitEscapingParameterizedReturningClosure(block: any())).wasCalled()
+    verify(concreteMock.implicitEscapingParameterizedReturningClosure(block: notNil())).wasNeverCalled()
+  }
+}

--- a/MockingbirdTestsHost/ClosureParameters.swift
+++ b/MockingbirdTestsHost/ClosureParameters.swift
@@ -7,6 +7,25 @@
 
 import Foundation
 
+struct ClosureWrapper {
+  let trivialClosure: () -> Void
+  let trivialReturningClosure: () -> Bool
+  let parameterizedClosure: (Bool) -> Void
+  let parameterizedReturningClosure: (Bool) -> Bool
+  
+  let nullableTrivialClosure: (() -> Void)? = nil
+  let nullableTrivialReturningClosure: (() -> Bool)? = nil
+  let nullableParameterizedClosure: ((Bool) -> Void)? = nil
+  let nullableParameterizedReturningClosure: ((Bool) -> Bool)? = nil
+  
+  init() {
+    self.trivialClosure = {}
+    self.trivialReturningClosure = { fatalError() }
+    self.parameterizedClosure = { _ in }
+    self.parameterizedReturningClosure = { _ in fatalError() }
+  }
+}
+
 protocol ClosureParametersProtocol {
   func trivialClosure(block: () -> Void) -> Bool
   func trivialReturningClosure(block: () -> Bool) -> Bool
@@ -14,9 +33,16 @@ protocol ClosureParametersProtocol {
   func parameterizedReturningClosure(block: (Bool) -> Bool) -> Bool
   
   func escapingTrivialClosure(block: @escaping () -> Void) -> Bool
-  func escapingTrivialReturningVoidClosure(block: @escaping () -> Bool) -> Bool
+  func escapingTrivialReturningClosure(block: @escaping () -> Bool) -> Bool
   func escapingParameterizedClosure(block: @escaping (Bool) -> Void) -> Bool
   func escapingParameterizedReturningClosure(block: @escaping (Bool) -> Bool) -> Bool
+  
+  func implicitEscapingTrivialClosure(block: (() -> Void)?) -> Bool
+  func implicitEscapingTrivialReturningClosure(block: (() -> Bool)?) -> Bool
+  func implicitEscapingParameterizedClosure(block: ((Bool) -> Void)?) -> Bool
+  func implicitEscapingParameterizedReturningClosure(block: ((Bool) -> Bool)?) -> Bool
+  
+  func wrappedClosureParameter(block: ClosureWrapper) -> Bool
   
   func autoclosureTrivialClosure(block: @autoclosure () -> Void) -> Bool
   func autoclosureTrivialReturningClosure(block: @autoclosure () -> Bool) -> Bool


### PR DESCRIPTION
Allow `any()` and `notNil()` to match non-escaping closures without additional boilerplate and fix memory management regression in type facade when wrapping closures and other implicitly retained types.

See also: https://birdopensource.slack.com/archives/CNR21LQCW/p1575076093002000