### PR TITLE
Use types access level for mocked type access level

### DIFF
--- a/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
@@ -76,10 +76,11 @@ struct MockableTypeInitializerTemplate: Template {
       returnObject = "\(mockedScopedName)(sourceLocation: SourceLocation(file, line))"
       returnTypeDescription = "concrete protocol mock instance"
     }
+    let accessLevel = mockableTypeTemplate.mockableType.accessLevel == .public ? "public" : "internal"
     
     return """
     /// Create a source-attributed `\(mockableTypeTemplate.fullyQualifiedName)\(allGenericTypes)` \(returnTypeDescription).
-    public func mock\(genericMethodAttribute)(file: StaticString = #file, line: UInt = #line, _ type: \(metatype)) -> \(returnType) {
+    \(accessLevel) func mock\(genericMethodAttribute)(file: StaticString = #file, line: UInt = #line, _ type: \(metatype)) -> \(returnType) {
       return \(returnObject)
     }
     """

--- a/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -46,10 +46,11 @@ class MockableTypeTemplate: Template {
     let (start, end) = compilationDirectiveDeclaration
     let preprocessorStart = start.isEmpty ? "" : "\n\(start)\n"
     let preprocessorEnd = end.isEmpty ? "" : "\n\n\(end)"
+    let accessLevel = mockableType.accessLevel == .public ? "public" : "internal"
     return """
     // MARK: - Mocked \(mockableType.name)
     \(preprocessorStart)
-    public final class \(mockableType.name)Mock\(allSpecializedGenericTypes): \(allInheritedTypes)\(allGenericConstraints) {
+    \(accessLevel) final class \(mockableType.name)Mock\(allSpecializedGenericTypes): \(allInheritedTypes)\(allGenericConstraints) {
     \(staticMockingContext)
       public let mockingContext = Mockingbird.MockingContext()
       public let stubbingContext = Mockingbird.StubbingContext()

--- a/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -14,6 +14,7 @@ class MockableType: Hashable, Comparable {
   let name: String
   let moduleName: String
   let fullyQualifiedModuleName: String
+  let accessLevel: AccessLevel?
   let kind: SwiftDeclarationKind
   let methods: Set<Method>
   let methodsCount: [Method.Reduced: UInt] // For de-duping generic methods.
@@ -74,6 +75,7 @@ class MockableType: Hashable, Comparable {
     self.name = baseRawType.name
     self.moduleName = baseRawType.parsedFile.moduleName
     self.fullyQualifiedModuleName = baseRawType.fullyQualifiedModuleName
+    self.accessLevel = baseRawType.accessLevel
     self.kind = baseRawType.kind
     self.isContainedType = !baseRawType.containingTypeNames.isEmpty
     self.hasOpaqueInheritedType = hasOpaqueInheritedType

--- a/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -30,6 +30,8 @@ class RawType {
   /// Fully qualified with respect to other modules.
   var fullyQualifiedModuleName: String { return parsedFile.moduleName + "." + fullyQualifiedName }
   
+  var accessLevel: AccessLevel? { AccessLevel(from: dictionary) }
+
   /// Returns a set of qualified and optional/generic type preserving names.
   ///
   /// - Parameters:


### PR DESCRIPTION
Uses source types and its methods access levels for mocked type and
methods access levels.

---

Not sure if it would be useful for others too, but in our case we want to generate some mocks into the same framework they are defined in. But at the moment it is not possible with internal types.