### PR TITLE
Improve handling of members from external modules

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -3506,7 +3506,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/Users/andrew/Library/Developer/Xcode/DerivedData/Mockingbird-agsjxwhkkkzllxguwkxolnnkjhqj/Build/Products/Debug/MockingbirdCli generate \\\n  --targets 'MockingbirdTestsHost' \\\n  --outputs '/Users/andrew/Mockingbird/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift'\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-F4CD5279-5F60-46C7-B24B-FE43E99DB227'\n";
+			shellScript = "/Users/andrew/Library/Developer/Xcode/DerivedData/Mockingbird-agsjxwhkkkzllxguwkxolnnkjhqj/Build/Products/Debug/MockingbirdCli generate \\\n  --targets 'MockingbirdTestsHost' \\\n  --outputs '/Users/andrew/Mockingbird/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift' \\\n  --disable-cache \\\n  --verbose\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-F4CD5279-5F60-46C7-B24B-FE43E99DB227'\n";
 		};
 		E0C37AF4D09E1A81AA94E903 /* Clean Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -56,7 +56,7 @@ class MethodTemplate: Template {
   }
   
   var classInitializerProxy: String {
-    guard method.isInitializer, context.mockableType.kind == .class else { return "" }
+    guard method.isInitializer else { return "" }
     // We can't usually infer what concrete arguments to pass to the designated initializer.
     guard !method.attributes.contains(.convenience) else { return "" }
     let attributes = declarationAttributes.isEmpty ? "" : "    \(declarationAttributes)\n"

--- a/MockingbirdGenerator/Parser/Models/GenericType.swift
+++ b/MockingbirdGenerator/Parser/Models/GenericType.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct WhereClause: Equatable, Hashable, CustomStringConvertible {
+struct WhereClause: Equatable, Hashable, Comparable, CustomStringConvertible {
   enum Operator: String {
     case conforms = ":"
     case equals = "=="
@@ -20,6 +20,10 @@ struct WhereClause: Equatable, Hashable, CustomStringConvertible {
     case .conforms: return "\(constrainedTypeName)\(self.operator.rawValue) \(genericConstraint)"
     case .equals: return "\(constrainedTypeName) \(self.operator.rawValue) \(genericConstraint)"
     }
+  }
+  
+  static func < (lhs: WhereClause, rhs: WhereClause) -> Bool {
+    return "\(lhs)" < "\(rhs)"
   }
   
   let constrainedTypeName: String

--- a/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -120,6 +120,7 @@ class RawTypeRepository {
   func addRawType(_ rawType: RawType) {
     let name = rawType.fullyQualifiedName.removingGenericTyping()
     let moduleName = rawType.parsedFile.moduleName
+    log("Added raw type: `\(name)`, moduleName: `\(moduleName)`")
     rawTypes[name, default: [:]][moduleName, default: []].append(rawType)
     moduleTypes[moduleName, default: []].insert(name)
   }

--- a/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
+++ b/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
@@ -224,4 +224,13 @@ enum AccessLevel: String, CustomStringConvertible {
     case .fileprivate, .private: return false
     }
   }
+  
+  func isInheritableType(withinSameModule: Bool) -> Bool {
+    switch self {
+    case .open: return true
+    case .public: return withinSameModule
+    case .internal: return withinSameModule
+    case .fileprivate, .private: return false
+    }
+  }
 }

--- a/MockingbirdGenerator/Parser/Operations/ParseFilesOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ParseFilesOperation.swift
@@ -112,7 +112,7 @@ public class ParseFilesOperation: BasicOperation {
       let file = try sourcePath.path.getFile()
       
       let structure = try Structure(file: file)
-      let (imports, compilationDirectives) = shouldMock ? file.parse() : ([], [])
+      let (imports, compilationDirectives) = file.parse()
       let parsedFile = ParsedFile(file: file,
                                   path: sourcePath.path,
                                   moduleName: sourcePath.moduleName,
@@ -122,8 +122,8 @@ public class ParseFilesOperation: BasicOperation {
                                   shouldMock: shouldMock)
       ParseFilesOperation.SubOperation.memoizedParsedFiles.update { $0[sourcePath] = parsedFile }
       result.parsedFile = parsedFile
+      log("Parsed \(imports.count) import declaration\(imports.count != 1 ? "s" : "") in source file at \(sourcePath.path)")
       if shouldMock {
-        log("Parsed \(imports.count) import declaration\(imports.count != 1 ? "s" : "") in source file at \(sourcePath.path)")
         log("Parsed source structure for module `\(sourcePath.moduleName)` at \(sourcePath.path)")
       } else {
         log("Parsed dependency source structure for module `\(sourcePath.moduleName)` at \(sourcePath.path)")
@@ -149,7 +149,7 @@ public class ParseFilesOperation: BasicOperation {
       queue.addOperations(operations, waitUntilFinished: true)
       result.parsedFiles = operations.compactMap({ $0.result.parsedFile })
     }
-    result.imports = Set(result.parsedFiles.flatMap({ $0.imports }))
+    result.imports = Set(result.parsedFiles.filter({ $0.shouldMock }).flatMap({ $0.imports }))
     result.moduleDependencies = extractSourcesResult.moduleDependencies
   }
 }

--- a/MockingbirdGenerator/Utilities/Log.swift
+++ b/MockingbirdGenerator/Utilities/Log.swift
@@ -56,7 +56,10 @@ public func log(_ message: @autoclosure () -> String,
                 line: UInt = #line) {
   guard level.shouldLog(type) else { return }
   let logMessage = "[\(type)] " + message() + "\n"
-  loggingQueue.async { fputs(logMessage, output ?? type.output) }
+  loggingQueue.async {
+    fputs(logMessage, output ?? type.output)
+    fflush(output ?? type.output)
+  }
 }
 
 /// Convenience for logging a `.warn` message type

--- a/MockingbirdGenerator/Utilities/OperationQueue+Extensions.swift
+++ b/MockingbirdGenerator/Utilities/OperationQueue+Extensions.swift
@@ -12,7 +12,11 @@ public extension OperationQueue {
   @inlinable
   static func createForActiveProcessors() -> OperationQueue {
     let queue = OperationQueue()
+    #if DEBUG
+    queue.maxConcurrentOperationCount = 1
+    #else
     queue.maxConcurrentOperationCount = ProcessInfo.processInfo.activeProcessorCount
+    #endif
     return queue
   }
 }

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -3536,6 +3536,182 @@ public func mock(file: StaticString = #file, line: UInt = #line, _ type: Mocking
   return CompilationDirectiveProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked ConformingExternalClassConstrainedProtocol
+
+public final class ConformingExternalClassConstrainedProtocolMock: AppKit.NSViewController, MockingbirdTestsHost.ConformingExternalClassConstrainedProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ConformingExternalClassConstrainedProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  public enum InitializerProxy {
+    public static func initialize(coder: NSCoder, __file: StaticString = #file, __line: UInt = #line) -> ConformingExternalClassConstrainedProtocolMock? {
+      let mock: ConformingExternalClassConstrainedProtocolMock? = ConformingExternalClassConstrainedProtocolMock(coder: `coder`)
+      mock?.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+
+    public static func initialize(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?, __file: StaticString = #file, __line: UInt = #line) -> ConformingExternalClassConstrainedProtocolMock {
+      let mock: ConformingExternalClassConstrainedProtocolMock = ConformingExternalClassConstrainedProtocolMock(nibName: `nibNameOrNil`, bundle: `nibBundleOrNil`)
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
+
+  // MARK: Mocked init?(coder: NSCoder)
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: `coder`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init?(coder: NSCoder) ", arguments: [Mockingbird.ArgumentMatcher(`coder`)])
+    mockingContext.didInvoke(invocation)
+  }
+
+  // MARK: Mocked init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?)
+
+  public required override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: `nibNameOrNil`, bundle: `nibBundleOrNil`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) ", arguments: [Mockingbird.ArgumentMatcher(`nibNameOrNil`), Mockingbird.ArgumentMatcher(`nibBundleOrNil`)])
+    mockingContext.didInvoke(invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ConformingExternalClassConstrainedProtocol` class mock metatype.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ConformingExternalClassConstrainedProtocol.Protocol) -> ConformingExternalClassConstrainedProtocolMock.InitializerProxy.Type {
+  return ConformingExternalClassConstrainedProtocolMock.InitializerProxy.self
+}
+
+// MARK: - Mocked ConformingInitializableOpenClassConstrainedProtocol
+
+public final class ConformingInitializableOpenClassConstrainedProtocolMock: MockingbirdModuleTestsHost.InitializableOpenClass, MockingbirdTestsHost.ConformingInitializableOpenClassConstrainedProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ConformingInitializableOpenClassConstrainedProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  public enum InitializerProxy {
+    public static func initialize(__file: StaticString = #file, __line: UInt = #line) -> ConformingInitializableOpenClassConstrainedProtocolMock {
+      let mock: ConformingInitializableOpenClassConstrainedProtocolMock = ConformingInitializableOpenClassConstrainedProtocolMock()
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
+
+  // MARK: Mocked openVariable
+
+  override public var `openVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getOpenVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setOpenVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked init()
+
+  public required override init() {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init() ", arguments: [])
+    mockingContext.didInvoke(invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ConformingInitializableOpenClassConstrainedProtocol` class mock metatype.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ConformingInitializableOpenClassConstrainedProtocol.Protocol) -> ConformingInitializableOpenClassConstrainedProtocolMock.InitializerProxy.Type {
+  return ConformingInitializableOpenClassConstrainedProtocolMock.InitializerProxy.self
+}
+
+// MARK: - Mocked ConformingUninitializableOpenClassConstrainedProtocol
+
+public final class ConformingUninitializableOpenClassConstrainedProtocolMock: MockingbirdModuleTestsHost.OpenClass, MockingbirdTestsHost.ConformingUninitializableOpenClassConstrainedProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ConformingUninitializableOpenClassConstrainedProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  public enum InitializerProxy {}
+
+  // MARK: Mocked openVariable
+
+  override public var `openVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getOpenVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setOpenVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "openVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ConformingUninitializableOpenClassConstrainedProtocol` class mock metatype.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ConformingUninitializableOpenClassConstrainedProtocol.Protocol) -> ConformingUninitializableOpenClassConstrainedProtocolMock.InitializerProxy.Type {
+  return ConformingUninitializableOpenClassConstrainedProtocolMock.InitializerProxy.self
+}
+
 // MARK: - Mocked ConvenienceInitializerClass
 
 public final class ConvenienceInitializerClassMock: MockingbirdTestsHost.ConvenienceInitializerClass, Mockingbird.Mock {
@@ -9091,7 +9267,19 @@ public final class NSViewInheritingProtocolMock: AppKit.NSView, MockingbirdTests
     }
   }
 
-  public enum InitializerProxy {}
+  public enum InitializerProxy {
+    public static func initialize(coder: NSCoder, __file: StaticString = #file, __line: UInt = #line) -> NSViewInheritingProtocolMock? {
+      let mock: NSViewInheritingProtocolMock? = NSViewInheritingProtocolMock(coder: `coder`)
+      mock?.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+
+    public static func initialize(frame frameRect: NSRect, __file: StaticString = #file, __line: UInt = #line) -> NSViewInheritingProtocolMock {
+      let mock: NSViewInheritingProtocolMock = NSViewInheritingProtocolMock(frame: `frameRect`)
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
 
   // MARK: Mocked init?(coder: NSCoder)
 
@@ -9597,7 +9785,19 @@ public final class OpaqueClassSelfConstrainedAssociatedTypeProtocolMock: AppKit.
     }
   }
 
-  public enum InitializerProxy {}
+  public enum InitializerProxy {
+    public static func initialize(coder: NSCoder, __file: StaticString = #file, __line: UInt = #line) -> OpaqueClassSelfConstrainedAssociatedTypeProtocolMock? {
+      let mock: OpaqueClassSelfConstrainedAssociatedTypeProtocolMock? = OpaqueClassSelfConstrainedAssociatedTypeProtocolMock(coder: `coder`)
+      mock?.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+
+    public static func initialize(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?, __file: StaticString = #file, __line: UInt = #line) -> OpaqueClassSelfConstrainedAssociatedTypeProtocolMock {
+      let mock: OpaqueClassSelfConstrainedAssociatedTypeProtocolMock = OpaqueClassSelfConstrainedAssociatedTypeProtocolMock(nibName: `nibNameOrNil`, bundle: `nibBundleOrNil`)
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
 
   // MARK: Mocked init?(coder: NSCoder)
 

--- a/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
+++ b/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
@@ -40,6 +40,25 @@ private protocol MockableSubclassingExternalSubclassWithDesignatedInitializer: E
 }
 extension SubclassingExternalSubclassWithDesignatedInitializerMock: MockableSubclassingExternalSubclassWithDesignatedInitializer {}
 
+private protocol MockableConformingExternalClassConstrainedProtocol:
+ConformingExternalClassConstrainedProtocol {}
+extension ConformingExternalClassConstrainedProtocolMock:
+MockableConformingExternalClassConstrainedProtocol {}
+
+private protocol MockableConformingInitializableOpenClassConstrainedProtocol:
+ConformingInitializableOpenClassConstrainedProtocol {
+  var openVariable: Bool { get set }
+}
+extension ConformingInitializableOpenClassConstrainedProtocolMock:
+MockableConformingInitializableOpenClassConstrainedProtocol {}
+
+private protocol MockableConformingUninitializableOpenClassConstrainedProtocol:
+ConformingUninitializableOpenClassConstrainedProtocol {
+  var openVariable: Bool { get set }
+}
+extension ConformingUninitializableOpenClassConstrainedProtocolMock:
+MockableConformingUninitializableOpenClassConstrainedProtocol {}
+
 // MARK: - Non-mockable declarations
 
 class SubclassingExternalClass: ExternalClass {}

--- a/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
+++ b/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
@@ -24,7 +24,42 @@ private protocol StubbableSubclassingExternalClassWithInheritedIntializer {
   func getOpenVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>
   func openMethod() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Void, Void>
 }
-extension SubclassingExternalClassWithInheritedIntializerMock: StubbableSubclassingExternalClassWithInheritedIntializer {}
-extension SubclassingExternalSubclassWithInheritedInitializerMock: StubbableSubclassingExternalClassWithInheritedIntializer {}
-extension SubclassingExternalClassWithDesignatedIntializerMock: StubbableSubclassingExternalClassWithInheritedIntializer {}
-extension SubclassingExternalSubclassWithDesignatedInitializerMock: StubbableSubclassingExternalClassWithInheritedIntializer {}
+extension SubclassingExternalClassWithInheritedIntializerMock:
+StubbableSubclassingExternalClassWithInheritedIntializer {}
+extension SubclassingExternalSubclassWithInheritedInitializerMock:
+StubbableSubclassingExternalClassWithInheritedIntializer {}
+extension SubclassingExternalClassWithDesignatedIntializerMock:
+StubbableSubclassingExternalClassWithInheritedIntializer {}
+extension SubclassingExternalSubclassWithDesignatedInitializerMock:
+StubbableSubclassingExternalClassWithInheritedIntializer {}
+
+private protocol StubbableConformingInitializableOpenClassConstrainedProtocol {
+  func getOpenVariable() -> Mockable<VariableDeclaration, () -> Bool, Bool>
+  func setOpenVariable(_ newValue: @escaping @autoclosure () -> Bool)
+    -> Mockable<VariableDeclaration, (Bool) -> Void, Void>
+}
+extension ConformingInitializableOpenClassConstrainedProtocolMock:
+StubbableConformingInitializableOpenClassConstrainedProtocol {}
+
+private protocol StubbableConformingUninitializableOpenClassConstrainedProtocol {
+  func getOpenVariable() -> Mockable<VariableDeclaration, () -> Bool, Bool>
+  func setOpenVariable(_ newValue: @escaping @autoclosure () -> Bool)
+    -> Mockable<VariableDeclaration, (Bool) -> Void, Void>
+}
+extension ConformingUninitializableOpenClassConstrainedProtocolMock:
+StubbableConformingUninitializableOpenClassConstrainedProtocol {}
+
+
+// MARK: - Non-stubbable declarations
+
+extension ConformingInitializableOpenClassConstrainedProtocolMock {
+  func getPublicVariable() -> Mockable<VariableDeclaration, () -> Bool, Bool> { fatalError() }
+  func setPublicVariable(_ newValue: @escaping @autoclosure () -> Bool)
+    -> Mockable<VariableDeclaration, (Bool) -> Void, Void> { fatalError() }
+}
+
+extension ConformingUninitializableOpenClassConstrainedProtocolMock {
+  func getPublicVariable() -> Mockable<VariableDeclaration, () -> Bool, Bool> { fatalError() }
+  func setPublicVariable(_ newValue: @escaping @autoclosure () -> Bool)
+    -> Mockable<VariableDeclaration, (Bool) -> Void, Void> { fatalError() }
+}

--- a/MockingbirdTests/Framework/InitializerTests.swift
+++ b/MockingbirdTests/Framework/InitializerTests.swift
@@ -53,6 +53,8 @@ class InitializerTests: XCTestCase {
   var deprecatedClassOnlyProtocolWithInheritance: DeprecatedClassOnlyProtocolWithInheritanceMock!
   var classOnlyProtocol: ClassOnlyProtocolMock!
   var classOnlyProtocolWithInheritance: ClassOnlyProtocolWithInheritanceMock!
+  var openClassConstrainedProtocolMock: ConformingInitializableOpenClassConstrainedProtocolMock!
+  var nsObjectProtocolConformingProtocol: NSObjectProtocolConformingProtocolMock!
   
   func testDeprecatedClassOnlyProtocolInitialization() {
     deprecatedClassOnlyProtocol = mock(DeprecatedClassOnlyProtocol.self)
@@ -62,6 +64,9 @@ class InitializerTests: XCTestCase {
   func testClassOnlyProtocolInitialization() {
     classOnlyProtocol = mock(ClassOnlyProtocol.self)
     classOnlyProtocolWithInheritance = mock(ClassOnlyProtocolWithInheritance.self)
+    openClassConstrainedProtocolMock =
+      mock(ConformingInitializableOpenClassConstrainedProtocol.self).initialize()
+    nsObjectProtocolConformingProtocol = mock(NSObjectProtocolConformingProtocol.self)
   }
 }
 

--- a/MockingbirdTestsHost/ExternalModuleTypes.swift
+++ b/MockingbirdTestsHost/ExternalModuleTypes.swift
@@ -47,3 +47,10 @@ class SubclassingExternalSubclassWithDesignatedInitializer: ExternalSubclassWith
     super.init()
   }
 }
+
+// MARK: - Class constrained protocols
+
+protocol ConformingExternalClassConstrainedProtocol: ExternalClassConstrainedProtocol {}
+protocol ConformingInitializableOpenClassConstrainedProtocol: InitializableOpenClassConstrainedProtocol {}
+protocol ConformingUninitializableOpenClassConstrainedProtocol: UninitializableOpenClassConstrainedProtocol {}
+protocol ConformingUnmockablePublicClassConstrainedProtocol: UnmockablePublicClassConstrainedProtocol {}

--- a/MockingbirdTestsHost/Module/Generics.swift
+++ b/MockingbirdTestsHost/Module/Generics.swift
@@ -6,6 +6,31 @@
 //
 
 import Foundation
+import AppKit
 
 public class ReferencedGenericClass<T> {}
 public class ReferencedGenericClassWithConstraints<S: Sequence> where S.Element: Hashable {}
+
+public protocol ExternalClassConstrainedProtocol: NSViewController {}
+
+open class InitializableOpenClass {
+  open var openVariable = true
+  public var publicVariable = true
+  var internalVariable = true
+  public init() {}
+}
+public protocol InitializableOpenClassConstrainedProtocol: InitializableOpenClass {}
+
+open class OpenClass {
+  open var openVariable = true
+  public var publicVariable = true
+  var internalVariable = true
+}
+public protocol UninitializableOpenClassConstrainedProtocol: OpenClass {}
+
+public class PublicClass {
+  open var openVariable = true
+  public var publicVariable = true
+  var internalVariable = true
+}
+public protocol UnmockablePublicClassConstrainedProtocol: PublicClass {}


### PR DESCRIPTION
- Improve handling of types and constraints inherited from grandparents
- Parse imports from all source and dependency files
- De-dup generic where clause constraints
- Add access level checks on inherited members from external modules
- Improve logging for default empty initializer generation and add warnings when attempting to mock uninitializable protocols

(Fixes #22)