### PR TITLE
Rewrite type facade to use execution context approach

### DIFF
--- a/MockingbirdFramework/Stubbing/StubbingContext.swift
+++ b/MockingbirdFramework/Stubbing/StubbingContext.swift
@@ -30,6 +30,7 @@ public class StubbingContext {
         if !optional {
           TestKiller().failTest(.missingStubbedImplementation(invocation: invocation),
                                 at: sourceLocation)
+          fatalError("Missing stubbed implementation, but unable to force XCTest case to fail")
         }
         return nil
       }

--- a/MockingbirdFramework/Stubbing/TestKiller.swift
+++ b/MockingbirdFramework/Stubbing/TestKiller.swift
@@ -13,7 +13,11 @@ import XCTest
 class TestKiller: NSObject, XCTestObservation {
   override init() {
     super.init()
-    XCTestObservationCenter.shared.addTestObserver(self)
+    if Thread.isMainThread {
+      XCTestObservationCenter.shared.addTestObserver(self)
+    } else {
+      DispatchQueue.main.sync { XCTestObservationCenter.shared.addTestObserver(self) }
+    }
   }
   
   private var testCase: XCTestCase?
@@ -21,6 +25,8 @@ class TestKiller: NSObject, XCTestObservation {
                 didFailWithDescription description: String,
                 inFile filePath: String?,
                 atLine lineNumber: Int) {
+    // TODO: This doesn't synchronously stop the current test case on failure if the invocation
+    // happens from outside of the main thread. Dispatching to main doesn't solve the issue.
     testCase.continueAfterFailure = false
     self.testCase = testCase
   }

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -38,42 +38,42 @@ public final class ArgumentMatchingProtocolMock: MockingbirdTestsHost.ArgumentMa
     self.sourceLocation = sourceLocation
   }
 
-  // MARK: Mocked `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?)
+  // MARK: Mocked `method`<P: MockingbirdTestsHost.BaseProtocol>(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalProtocolType: P?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?)
 
-  public func `method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`optionalStructType`), Mockingbird.ArgumentMatcher(`optionalClassType`), Mockingbird.ArgumentMatcher(`optionalEnumType`), Mockingbird.ArgumentMatcher(`optionalStringType`), Mockingbird.ArgumentMatcher(`optionalBoolType`), Mockingbird.ArgumentMatcher(`optionalMetaType`), Mockingbird.ArgumentMatcher(`optionalAnyType`), Mockingbird.ArgumentMatcher(`optionalAnyObjectType`)])
+  public func `method`<P: MockingbirdTestsHost.BaseProtocol>(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalProtocolType: P?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<P: MockingbirdTestsHost.BaseProtocol>(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalProtocolType: P?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`optionalStructType`), Mockingbird.ArgumentMatcher(`optionalClassType`), Mockingbird.ArgumentMatcher(`optionalEnumType`), Mockingbird.ArgumentMatcher(`optionalStringType`), Mockingbird.ArgumentMatcher(`optionalBoolType`), Mockingbird.ArgumentMatcher(`optionalProtocolType`), Mockingbird.ArgumentMatcher(`optionalMetaType`), Mockingbird.ArgumentMatcher(`optionalAnyType`), Mockingbird.ArgumentMatcher(`optionalAnyObjectType`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool {
-      return concreteImplementation(`optionalStructType`, `optionalClassType`, `optionalEnumType`, `optionalStringType`, `optionalBoolType`, `optionalMetaType`, `optionalAnyType`, `optionalAnyObjectType`)
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, P?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool {
+      return concreteImplementation(`optionalStructType`, `optionalClassType`, `optionalEnumType`, `optionalStringType`, `optionalBoolType`, `optionalProtocolType`, `optionalMetaType`, `optionalAnyType`, `optionalAnyObjectType`)
     } else {
       return (implementation as! () -> Bool)()
     }
   }
 
-  public func `method`(optionalStructType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType?, optionalClassType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType?, optionalEnumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType?, optionalStringType: @escaping @autoclosure () -> String?, optionalBoolType: @escaping @autoclosure () -> Bool?, optionalMetaType: @escaping @autoclosure () -> ClassType.Type?, optionalAnyType: @escaping @autoclosure () -> Any?, optionalAnyObjectType: @escaping @autoclosure () -> Swift.AnyObject?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool> {
-    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`optionalStructType`), Mockingbird.resolve(`optionalClassType`), Mockingbird.resolve(`optionalEnumType`), Mockingbird.resolve(`optionalStringType`), Mockingbird.resolve(`optionalBoolType`), Mockingbird.resolve(`optionalMetaType`), Mockingbird.resolve(`optionalAnyType`), Mockingbird.resolve(`optionalAnyObjectType`)]
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: arguments)
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool>(mock: self, invocation: invocation)
+  public func `method`<P: MockingbirdTestsHost.BaseProtocol>(optionalStructType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType?, optionalClassType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType?, optionalEnumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType?, optionalStringType: @escaping @autoclosure () -> String?, optionalBoolType: @escaping @autoclosure () -> Bool?, optionalProtocolType: @escaping @autoclosure () -> P?, optionalMetaType: @escaping @autoclosure () -> ClassType.Type?, optionalAnyType: @escaping @autoclosure () -> Any?, optionalAnyObjectType: @escaping @autoclosure () -> Swift.AnyObject?) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, P?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`optionalStructType`), Mockingbird.resolve(`optionalClassType`), Mockingbird.resolve(`optionalEnumType`), Mockingbird.resolve(`optionalStringType`), Mockingbird.resolve(`optionalBoolType`), Mockingbird.resolve(`optionalProtocolType`), Mockingbird.resolve(`optionalMetaType`), Mockingbird.resolve(`optionalAnyType`), Mockingbird.resolve(`optionalAnyObjectType`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<P: MockingbirdTestsHost.BaseProtocol>(optionalStructType: MockingbirdTestsHost.StructType?, optionalClassType: MockingbirdTestsHost.ClassType?, optionalEnumType: MockingbirdTestsHost.EnumType?, optionalStringType: String?, optionalBoolType: Bool?, optionalProtocolType: P?, optionalMetaType: ClassType.Type?, optionalAnyType: Any?, optionalAnyObjectType: Swift.AnyObject?) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, P?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
-  // MARK: Mocked `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject)
+  // MARK: Mocked `method`<P: MockingbirdTestsHost.BaseProtocol>(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, protocolType: P, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject)
 
-  public func `method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`structType`), Mockingbird.ArgumentMatcher(`classType`), Mockingbird.ArgumentMatcher(`enumType`), Mockingbird.ArgumentMatcher(`stringType`), Mockingbird.ArgumentMatcher(`boolType`), Mockingbird.ArgumentMatcher(`metaType`), Mockingbird.ArgumentMatcher(`anyType`), Mockingbird.ArgumentMatcher(`anyObjectType`)])
+  public func `method`<P: MockingbirdTestsHost.BaseProtocol>(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, protocolType: P, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<P: MockingbirdTestsHost.BaseProtocol>(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, protocolType: P, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`structType`), Mockingbird.ArgumentMatcher(`classType`), Mockingbird.ArgumentMatcher(`enumType`), Mockingbird.ArgumentMatcher(`stringType`), Mockingbird.ArgumentMatcher(`boolType`), Mockingbird.ArgumentMatcher(`protocolType`), Mockingbird.ArgumentMatcher(`metaType`), Mockingbird.ArgumentMatcher(`anyType`), Mockingbird.ArgumentMatcher(`anyObjectType`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool {
-      return concreteImplementation(`structType`, `classType`, `enumType`, `stringType`, `boolType`, `metaType`, `anyType`, `anyObjectType`)
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, P, ClassType.Type, Any, Swift.AnyObject) -> Bool {
+      return concreteImplementation(`structType`, `classType`, `enumType`, `stringType`, `boolType`, `protocolType`, `metaType`, `anyType`, `anyObjectType`)
     } else {
       return (implementation as! () -> Bool)()
     }
   }
 
-  public func `method`(structType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType, classType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType, enumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType, stringType: @escaping @autoclosure () -> String, boolType: @escaping @autoclosure () -> Bool, metaType: @escaping @autoclosure () -> ClassType.Type, anyType: @escaping @autoclosure () -> Any, anyObjectType: @escaping @autoclosure () -> Swift.AnyObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool> {
-    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`structType`), Mockingbird.resolve(`classType`), Mockingbird.resolve(`enumType`), Mockingbird.resolve(`stringType`), Mockingbird.resolve(`boolType`), Mockingbird.resolve(`metaType`), Mockingbird.resolve(`anyType`), Mockingbird.resolve(`anyObjectType`)]
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: arguments)
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool>(mock: self, invocation: invocation)
+  public func `method`<P: MockingbirdTestsHost.BaseProtocol>(structType: @escaping @autoclosure () -> MockingbirdTestsHost.StructType, classType: @escaping @autoclosure () -> MockingbirdTestsHost.ClassType, enumType: @escaping @autoclosure () -> MockingbirdTestsHost.EnumType, stringType: @escaping @autoclosure () -> String, boolType: @escaping @autoclosure () -> Bool, protocolType: @escaping @autoclosure () -> P, metaType: @escaping @autoclosure () -> ClassType.Type, anyType: @escaping @autoclosure () -> Any, anyObjectType: @escaping @autoclosure () -> Swift.AnyObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, P, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`structType`), Mockingbird.resolve(`classType`), Mockingbird.resolve(`enumType`), Mockingbird.resolve(`stringType`), Mockingbird.resolve(`boolType`), Mockingbird.resolve(`protocolType`), Mockingbird.resolve(`metaType`), Mockingbird.resolve(`anyType`), Mockingbird.resolve(`anyObjectType`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<P: MockingbirdTestsHost.BaseProtocol>(structType: MockingbirdTestsHost.StructType, classType: MockingbirdTestsHost.ClassType, enumType: MockingbirdTestsHost.EnumType, stringType: String, boolType: Bool, protocolType: P, metaType: ClassType.Type, anyType: Any, anyObjectType: Swift.AnyObject) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType, MockingbirdTestsHost.ClassType, MockingbirdTestsHost.EnumType, String, Bool, P, ClassType.Type, Any, Swift.AnyObject) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 }
 
@@ -1057,6 +1057,51 @@ public final class AssociatedTypeSelfReferencingProtocolMock<SequenceType: Seque
 /// Create a source-attributed `MockingbirdTestsHost.AssociatedTypeSelfReferencingProtocol<SequenceType>` concrete protocol mock instance.
 public func mock<SequenceType: Sequence & Swift.Hashable>(file: StaticString = #file, line: UInt = #line, _ type: AssociatedTypeSelfReferencingProtocolMock<SequenceType>.Type) -> AssociatedTypeSelfReferencingProtocolMock<SequenceType> {
   return AssociatedTypeSelfReferencingProtocolMock<SequenceType>(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked BaseProtocol
+
+public final class BaseProtocolMock: MockingbirdTestsHost.BaseProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      BaseProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked ==(_ lhs: BaseProtocolMock, _ rhs: BaseProtocolMock)
+
+  public static func ==(_ lhs: BaseProtocolMock, _ rhs: BaseProtocolMock) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "==(_ lhs: BaseProtocolMock, _ rhs: BaseProtocolMock) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`lhs`), Mockingbird.ArgumentMatcher(`rhs`)])
+    staticMock.mockingContext.didInvoke(invocation)
+    let implementation = staticMock.stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (BaseProtocolMock, BaseProtocolMock) -> Bool {
+      return concreteImplementation(`lhs`, `rhs`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public static func _equalTo(_ lhs: @escaping @autoclosure () -> BaseProtocolMock, _ rhs: @escaping @autoclosure () -> BaseProtocolMock) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (BaseProtocolMock, BaseProtocolMock) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`lhs`), Mockingbird.resolve(`rhs`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "==(_ lhs: BaseProtocolMock, _ rhs: BaseProtocolMock) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (BaseProtocolMock, BaseProtocolMock) -> Bool, Bool>(mock: staticMock, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.BaseProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: BaseProtocolMock.Type) -> BaseProtocolMock {
+  return BaseProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked Bird

--- a/MockingbirdTests/Framework/ArgumentCaptorTests.swift
+++ b/MockingbirdTests/Framework/ArgumentCaptorTests.swift
@@ -17,20 +17,22 @@ class ArgumentCaptorTests: XCTestCase {
     concreteMock = mock(ArgumentMatchingProtocol.self)
   }
   
-  func callMethod(on object: ArgumentMatchingProtocol,
-                  structType: StructType = StructType(),
-                  classType: ClassType = ClassType(),
-                  enumType: EnumType = .success,
-                  stringType: String = "foo-bar",
-                  boolType: Bool = true,
-                  metaType: ClassType.Type = ClassType.self,
-                  anyType: Any = true,
-                  anyObjectType: AnyObject = ClassType()) -> Bool {
+  func callMethod<P: BaseProtocol>(on object: ArgumentMatchingProtocol,
+                                   structType: StructType = StructType(),
+                                   classType: ClassType = ClassType(),
+                                   enumType: EnumType = .success,
+                                   stringType: String = "foo-bar",
+                                   boolType: Bool = true,
+                                   protocolType: P,
+                                   metaType: ClassType.Type = ClassType.self,
+                                   anyType: Any = true,
+                                   anyObjectType: AnyObject = ClassType()) -> Bool {
     return object.method(structType: structType,
                          classType: classType,
                          enumType: enumType,
                          stringType: stringType,
                          boolType: boolType,
+                         protocolType: protocolType,
                          metaType: metaType,
                          anyType: anyType,
                          anyObjectType: anyObjectType)
@@ -43,10 +45,13 @@ class ArgumentCaptorTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 99)))
+    XCTAssertTrue(callMethod(on: concreteMock,
+                             structType: StructType(value: 99),
+                             protocolType: ClassType()))
     XCTAssert(structTypeCaptor.value?.value == 99)
   }
   
@@ -57,11 +62,16 @@ class ArgumentCaptorTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 99)))
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 42)))
+    XCTAssertTrue(callMethod(on: concreteMock,
+                             structType: StructType(value: 99),
+                             protocolType: ClassType()))
+    XCTAssertTrue(callMethod(on: concreteMock,
+                             structType: StructType(value: 42),
+                             protocolType: ClassType()))
     XCTAssert(structTypeCaptor.value?.value == 42)
   }
   
@@ -72,11 +82,16 @@ class ArgumentCaptorTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 99)))
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 42)))
+    XCTAssertTrue(callMethod(on: concreteMock,
+                             structType: StructType(value: 99),
+                             protocolType: ClassType()))
+    XCTAssertTrue(callMethod(on: concreteMock,
+                             structType: StructType(value: 42),
+                             protocolType: ClassType()))
     XCTAssert(structTypeCaptor.allValues.map({ $0.value }) == [99, 42])
   }
 }

--- a/MockingbirdTests/Framework/ArgumentMatchingTests.swift
+++ b/MockingbirdTests/Framework/ArgumentMatchingTests.swift
@@ -20,12 +20,13 @@ class ArgumentMatchingTests: XCTestCase {
     concreteMock = mock(ArgumentMatchingProtocol.self)
   }
   
-  func callMethod(on object: ArgumentMatchingProtocol,
+  func callMethod<P: BaseProtocol>(on object: ArgumentMatchingProtocol,
                   structType: StructType = StructType(),
                   classType: ClassType = ClassType(),
                   enumType: EnumType = .success,
                   stringType: String = "foo-bar",
                   boolType: Bool = true,
+                  protocolType: P,
                   metaType: ClassType.Type = ClassType.self,
                   anyType: Any = true,
                   anyObjectType: AnyObject = ClassType()) -> Bool {
@@ -34,17 +35,19 @@ class ArgumentMatchingTests: XCTestCase {
                          enumType: enumType,
                          stringType: stringType,
                          boolType: boolType,
+                         protocolType: protocolType,
                          metaType: metaType,
                          anyType: anyType,
                          anyObjectType: anyObjectType)
   }
   
-  func callOptionalMethod(on object: ArgumentMatchingProtocol,
+  func callOptionalMethod<P: BaseProtocol>(on object: ArgumentMatchingProtocol,
                           optionalStructType: StructType? = StructType(),
                           optionalClassType: ClassType? = ClassType(),
                           optionalEnumType: EnumType? = .success,
                           optionalStringType: String? = "foo-bar",
                           optionalBoolType: Bool? = true,
+                          optionalProtocolType: P?,
                           optionalMetaType: ClassType.Type? = ClassType.self,
                           optionalAnyType: Any? = true,
                           optionalAnyObjectType: AnyObject? = ClassType()) -> Bool {
@@ -53,6 +56,7 @@ class ArgumentMatchingTests: XCTestCase {
                          optionalEnumType: optionalEnumType,
                          optionalStringType: optionalStringType,
                          optionalBoolType: optionalBoolType,
+                         optionalProtocolType: optionalProtocolType,
                          optionalMetaType: optionalMetaType,
                          optionalAnyType: optionalAnyType,
                          optionalAnyObjectType: optionalAnyObjectType)
@@ -66,15 +70,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType()))
+    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(), protocolType: ClassType()))
     verify(concreteMock.method(structType: StructType(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -87,15 +93,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, classType: classTypeReference))
+    XCTAssertTrue(callMethod(on: concreteMock, classType: classTypeReference, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: classTypeReference,
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -107,15 +115,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: .failure,
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, enumType: .failure))
+    XCTAssertTrue(callMethod(on: concreteMock, enumType: .failure, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: .failure,
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -127,15 +137,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: "hello-world",
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, stringType: "hello-world"))
+    XCTAssertTrue(callMethod(on: concreteMock, stringType: "hello-world", protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: "hello-world",
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -147,18 +159,87 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: false,
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, boolType: false))
+    XCTAssertTrue(callMethod(on: concreteMock, boolType: false, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: false,
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
+  }
+  
+  func testArgumentMatching_protocolType_classImplementation() {
+    let classTypeReference = ClassType()
+    given(concreteMock.method(structType: any(),
+                              classType: any(),
+                              enumType: any(),
+                              stringType: any(),
+                              boolType: any(),
+                              protocolType: classTypeReference,
+                              metaType: any(),
+                              anyType: any(),
+                              anyObjectType: any())) ~> true
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: classTypeReference))
+    verify(concreteMock.method(structType: any(),
+                               classType: any(),
+                               enumType: any(),
+                               stringType: any(),
+                               boolType: any(),
+                               protocolType: classTypeReference,
+                               metaType: any(),
+                               anyType: any(),
+                               anyObjectType: any())).wasCalled()
+  }
+  
+  func testArgumentMatching_protocolType_structImplementation() {
+    given(concreteMock.method(structType: any(),
+                              classType: any(),
+                              enumType: any(),
+                              stringType: any(),
+                              boolType: any(),
+                              protocolType: StructType(),
+                              metaType: any(),
+                              anyType: any(),
+                              anyObjectType: any())) ~> true
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: StructType()))
+    verify(concreteMock.method(structType: any(),
+                               classType: any(),
+                               enumType: any(),
+                               stringType: any(),
+                               boolType: any(),
+                               protocolType: StructType(),
+                               metaType: any(),
+                               anyType: any(),
+                               anyObjectType: any())).wasCalled()
+  }
+  
+  func testArgumentMatching_protocolType_mixedImplementation() {
+    given(concreteMock.method(structType: any(),
+                              classType: any(),
+                              enumType: any(),
+                              stringType: any(),
+                              boolType: any(),
+                              protocolType: StructType(),
+                              metaType: any(),
+                              anyType: any(),
+                              anyObjectType: any())) ~> true
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: StructType()))
+    verify(concreteMock.method(structType: any(),
+                               classType: any(),
+                               enumType: any(),
+                               stringType: any(),
+                               boolType: any(),
+                               protocolType: ClassType(),
+                               metaType: any(),
+                               anyType: any(),
+                               anyObjectType: any())).wasNeverCalled()
   }
   
   func testArgumentMatching_metaType() {
@@ -167,15 +248,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: ClassType.self,
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, metaType: ClassType.self))
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: ClassType(), metaType: ClassType.self))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: ClassType.self,
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -187,15 +270,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(of: 1),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, anyType: 1))
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: ClassType(), anyType: 1))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(of: 1),
                                anyObjectType: any())).wasCalled()
@@ -208,15 +293,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(of: ConcreteAnyType()),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, anyType: ConcreteAnyType()))
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: ClassType(), anyType: ConcreteAnyType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(of: ConcreteAnyType()),
                                anyObjectType: any())).wasCalled()
@@ -230,15 +317,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStructType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStructType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: nil,
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -250,15 +339,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalClassType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalClassType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: nil,
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -270,15 +361,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: nil,
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalEnumType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalEnumType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: nil,
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -290,15 +383,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: nil,
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStringType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStringType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: nil,
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -310,15 +405,39 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: nil,
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalBoolType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalBoolType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: nil,
+                               optionalProtocolType: notNil(ClassType.self),
+                               optionalMetaType: notNil(),
+                               optionalAnyType: notNil(),
+                               optionalAnyObjectType: notNil())).wasCalled()
+  }
+  
+  func testArgumentMatching_optionalProtocolType_usingStrictMatching() {
+    given(concreteMock.method(optionalStructType: notNil(),
+                              optionalClassType: notNil(),
+                              optionalEnumType: notNil(),
+                              optionalStringType: notNil(),
+                              optionalBoolType: notNil(),
+                              optionalProtocolType: Optional<ClassType>(nil),
+                              optionalMetaType: notNil(),
+                              optionalAnyType: notNil(),
+                              optionalAnyObjectType: notNil())) ~> true
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: Optional<ClassType>(nil)))
+    verify(concreteMock.method(optionalStructType: notNil(),
+                               optionalClassType: notNil(),
+                               optionalEnumType: notNil(),
+                               optionalStringType: notNil(),
+                               optionalBoolType: notNil(),
+                               optionalProtocolType: Optional<ClassType>(nil),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -330,15 +449,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: nil,
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalMetaType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalMetaType: nil))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: nil,
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -350,15 +471,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: nil,
                               optionalAnyObjectType: notNil())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalAnyType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalAnyType: nil))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: nil,
                                optionalAnyObjectType: notNil())).wasCalled()
@@ -370,15 +493,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: notNil(),
                               optionalStringType: notNil(),
                               optionalBoolType: notNil(),
+                              optionalProtocolType: notNil(ClassType.self),
                               optionalMetaType: notNil(),
                               optionalAnyType: notNil(),
                               optionalAnyObjectType: nil)) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalAnyObjectType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalAnyObjectType: nil))
     verify(concreteMock.method(optionalStructType: notNil(),
                                optionalClassType: notNil(),
                                optionalEnumType: notNil(),
                                optionalStringType: notNil(),
                                optionalBoolType: notNil(),
+                               optionalProtocolType: notNil(ClassType.self),
                                optionalMetaType: notNil(),
                                optionalAnyType: notNil(),
                                optionalAnyObjectType: nil)).wasCalled()
@@ -392,15 +517,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStructType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStructType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -412,15 +539,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalClassType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalClassType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -432,15 +561,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalEnumType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalEnumType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -452,15 +583,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStringType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalStringType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -472,15 +605,39 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalBoolType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalBoolType: nil, optionalProtocolType: ClassType()))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
+                               optionalMetaType: any(),
+                               optionalAnyType: any(),
+                               optionalAnyObjectType: any())).wasCalled()
+  }
+  
+  func testArgumentMatching_optionalProtocolType_usingWildcardMatching() {
+    given(concreteMock.method(optionalStructType: any(),
+                              optionalClassType: any(),
+                              optionalEnumType: any(),
+                              optionalStringType: any(),
+                              optionalBoolType: any(),
+                              optionalProtocolType: any(Optional<ClassType>.self),
+                              optionalMetaType: any(),
+                              optionalAnyType: any(),
+                              optionalAnyObjectType: any())) ~> true
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: Optional<ClassType>(nil)))
+    verify(concreteMock.method(optionalStructType: any(),
+                               optionalClassType: any(),
+                               optionalEnumType: any(),
+                               optionalStringType: any(),
+                               optionalBoolType: any(),
+                               optionalProtocolType: any(Optional<ClassType>.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -492,15 +649,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalMetaType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalMetaType: nil))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -512,15 +671,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalAnyType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalAnyType: nil))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -532,15 +693,17 @@ class ArgumentMatchingTests: XCTestCase {
                               optionalEnumType: any(),
                               optionalStringType: any(),
                               optionalBoolType: any(),
+                              optionalProtocolType: any(ClassType.self),
                               optionalMetaType: any(),
                               optionalAnyType: any(),
                               optionalAnyObjectType: any())) ~> true
-    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalAnyObjectType: nil))
+    XCTAssertTrue(callOptionalMethod(on: concreteMock, optionalProtocolType: ClassType(), optionalAnyObjectType: nil))
     verify(concreteMock.method(optionalStructType: any(),
                                optionalClassType: any(),
                                optionalEnumType: any(),
                                optionalStringType: any(),
                                optionalBoolType: any(),
+                               optionalProtocolType: any(ClassType.self),
                                optionalMetaType: any(),
                                optionalAnyType: any(),
                                optionalAnyObjectType: any())).wasCalled()
@@ -554,15 +717,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 1)))
+    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 1), protocolType: ClassType()))
     verify(concreteMock.method(structType: any(of: StructType(value: 0), StructType(value: 1)),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -576,15 +741,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, classType: classType))
+    XCTAssertTrue(callMethod(on: concreteMock, classType: classType, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(of: otherClassType, classType),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -596,15 +763,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(of: .success, .failure),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, enumType: .failure))
+    XCTAssertTrue(callMethod(on: concreteMock, enumType: .failure, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(of: .success, .failure),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -616,15 +785,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(of: "foo", "bar", "hello-world"),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, stringType: "hello-world"))
+    XCTAssertTrue(callMethod(on: concreteMock, stringType: "hello-world", protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(of: "foo", "bar", "hello-world"),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -636,15 +807,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(of: true, false),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, boolType: false))
+    XCTAssertTrue(callMethod(on: concreteMock, boolType: false, protocolType: ClassType()))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(of: true, false),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()
@@ -656,15 +829,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(of: true, "hello", StructType(), ClassType()),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, anyType: "hello"))
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: ClassType(), anyType: "hello"))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(of: true, "hello", StructType(), ClassType()),
                                anyObjectType: any())).wasCalled()
@@ -677,15 +852,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any(of: ClassType(), classTypeReference))) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, anyObjectType: classTypeReference))
+    XCTAssertTrue(callMethod(on: concreteMock, protocolType: ClassType(), anyObjectType: classTypeReference))
     verify(concreteMock.method(structType: any(),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any(of: ClassType(), classTypeReference))).wasCalled()
@@ -699,15 +876,17 @@ class ArgumentMatchingTests: XCTestCase {
                               enumType: any(),
                               stringType: any(),
                               boolType: any(),
+                              protocolType: any(ClassType.self),
                               metaType: any(),
                               anyType: any(),
                               anyObjectType: any())) ~> true
-    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 100)))
+    XCTAssertTrue(callMethod(on: concreteMock, structType: StructType(value: 100), protocolType: ClassType()))
     verify(concreteMock.method(structType: any(where: { $0.value > 99 }),
                                classType: any(),
                                enumType: any(),
                                stringType: any(),
                                boolType: any(),
+                               protocolType: any(ClassType.self),
                                metaType: any(),
                                anyType: any(),
                                anyObjectType: any())).wasCalled()

--- a/MockingbirdTestsHost/ArgumentMatching.swift
+++ b/MockingbirdTestsHost/ArgumentMatching.swift
@@ -8,15 +8,17 @@
 
 import Foundation
 
-struct StructType: Equatable {
-  let identifier: String = "foo-bar"
+protocol BaseProtocol: Equatable {}
+
+struct StructType: BaseProtocol {
   let value: Int
   init(value: Int = 42) {
     self.value = value
   }
 }
 
-class ClassType {
+class ClassType: BaseProtocol {
+  static func == (lhs: ClassType, rhs: ClassType) -> Bool { return true }
   let identifier: String = "foo-bar"
   let value: Int = 42
 }
@@ -26,20 +28,22 @@ enum EnumType {
 }
 
 protocol ArgumentMatchingProtocol {
-  func method(structType: StructType,
+  func method<P: BaseProtocol>(structType: StructType,
               classType: ClassType,
               enumType: EnumType,
               stringType: String,
               boolType: Bool,
+              protocolType: P,
               metaType: ClassType.Type,
               anyType: Any,
               anyObjectType: AnyObject) -> Bool
   
-  func method(optionalStructType: StructType?,
+  func method<P: BaseProtocol>(optionalStructType: StructType?,
               optionalClassType: ClassType?,
               optionalEnumType: EnumType?,
               optionalStringType: String?,
               optionalBoolType: Bool?,
+              optionalProtocolType: P?,
               optionalMetaType: ClassType.Type?,
               optionalAnyType: Any?,
               optionalAnyObjectType: AnyObject?) -> Bool


### PR DESCRIPTION
Value witness table for protocol'd structs breaks the unsafe pointee approach. Using a temporary execution context for runtime resolution of type facade closures is safer and more robust.

Fixes #33