### PR TITLE
Match dot files with a wildcard in ignore rules

### DIFF
--- a/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
+++ b/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
@@ -22,6 +22,6 @@ extension Path {
       && pattern.hasSuffix("/") // Only apply trailing slash fix-it to directory globs.
       && (isDirectory ?? self.isDirectory)
     let pathString = rawPathString + (shouldAppendTrailingSlash ? "/" : "")
-    return fnmatch(pattern, pathString, FNM_PATHNAME | FNM_PERIOD) != FNM_NOMATCH
+    return fnmatch(pattern, pathString, FNM_PATHNAME) != FNM_NOMATCH
   }
 }

--- a/MockingbirdTests/Generator/PathFnmatchTests.swift
+++ b/MockingbirdTests/Generator/PathFnmatchTests.swift
@@ -93,4 +93,9 @@ class PathFnmatchTests: XCTestCase {
     XCTAssertTrue(filePath.matches(pattern: "/foo/**", isDirectory: false))
     XCTAssertTrue(directoryPath.matches(pattern: "/foo/**", isDirectory: true))
   }
+  
+  func testFnmatch_matchesDotFile_withWildcardFileName() {
+    let filePath = Path(".foo")
+    XCTAssertTrue(filePath.matches(pattern: "*foo", isDirectory: false))
+  }
 }


### PR DESCRIPTION
> Excluding Files
> You can exclude unwanted or problematic sources from being mocked by adding a .mockingbird-ignore file. Mockingbird follows the same pattern format as .gitignore and scopes ignore files to their enclosing directory.

`.gitignore` is not using `FNM_PERIOD` rule.