### PR TITLE
Log warning when trying to mock a non-initializable class

### DIFF
--- a/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
@@ -58,11 +58,13 @@ public class ProcessTypesOperation: BasicOperation {
         .compactMap({ $0.result.mockableType })
         .filter({ !$0.isContainedType })
         .filter({ mockableType -> Bool in
-          guard mockableType.kind == .class, mockableType.subclassesExternalType
-            else { return true }
-          // Ignore any types that simply cannot be initialized because they subclass an externally-
-          // defined type without available initializers and don't locally declare any initializers.
-          return mockableType.methods.contains(where: { $0.isInitializer })
+          guard mockableType.kind == .class, mockableType.subclassesExternalType else { return true }
+          // Ignore any types that simply cannot be initialized.
+          guard mockableType.methods.contains(where: { $0.isInitializer }) else {
+            logWarning("Ignoring `\(mockableType.name)` because it subclasses an externally-defined type without available initializers and does not locally declare any initializers")
+            return false
+          }
+          return true
         })
       result.imports = parseFilesResult.imports
       log("Created \(result.mockableTypes.count) mockable type\(result.mockableTypes.count != 1 ? "s" : "")")

--- a/MockingbirdSupport/Foundation/ObjectiveC/NSObject.swift
+++ b/MockingbirdSupport/Foundation/ObjectiveC/NSObject.swift
@@ -2,7 +2,9 @@ import ObjectiveC
 
 public protocol NSObjectProtocol {}
 
-open class NSObject : NSObjectProtocol {}
+open class NSObject : NSObjectProtocol {
+  public init() {}
+}
 
 public protocol NSCopying {
   func copy(with zone: NSZone?) -> Any


### PR DESCRIPTION
Also update `NSObject` supporting source declaration to include `init`

**PR stack:** 1/2