### PR TITLE
Ignore objc attributes for all generated hooks

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		9491824C23F0CE3A00429146 /* KeywordArgumentNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */; };
 		9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */; };
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
+		D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */; };
 		OBJ_1002 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* SWXMLHash.swift */; };
 		OBJ_1003 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
 		OBJ_1004 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* shim.swift */; };
@@ -990,6 +991,7 @@
 		9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesMockableTests.swift; sourceTree = "<group>"; };
 		9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesStubbableTests.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attributes+Sanitize.swift"; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdGenerator::Product" /* MockingbirdGenerator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockingbirdGenerator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1661,6 +1663,14 @@
 				49BA452E234189F4002BD9B5 /* CodableTarget.swift */,
 			);
 			path = Cache;
+			sourceTree = "<group>";
+		};
+		D3F076DB24021536002461E7 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		OBJ_10 /* Interface */ = {
@@ -2682,6 +2692,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_51 /* FileGenerator.swift */,
+				D3F076DB24021536002461E7 /* Extensions */,
 				OBJ_52 /* Operations */,
 				OBJ_55 /* Templates */,
 			);
@@ -3920,6 +3931,7 @@
 				OBJ_733 /* MockableTypeInitializerTemplate.swift in Sources */,
 				OBJ_734 /* MockableTypeTemplate.swift in Sources */,
 				OBJ_735 /* Template.swift in Sources */,
+				D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */,
 				OBJ_736 /* VariableTemplate.swift in Sources */,
 				OBJ_737 /* DeclaredType.swift in Sources */,
 				OBJ_738 /* GenericType.swift in Sources */,

--- a/MockingbirdGenerator/Generator/Extensions/Attributes+Sanitize.swift
+++ b/MockingbirdGenerator/Generator/Extensions/Attributes+Sanitize.swift
@@ -1,0 +1,27 @@
+//
+//  Attributes+Sanitize.swift
+//  MockingbirdGenerator
+//
+//  Created by Andrew Chang on 2/22/20.
+//
+
+import Foundation
+
+private enum Constants {
+  /// Ignore certain attributes that are implicitly applied through inheritance.
+  static let attributeNameBlacklist: Set<String> = [
+    "objc",
+  ]
+}
+
+extension Attributes {
+  var safeDeclarations: [String] {
+    return declarations.filter({ declaration in
+      guard
+        declaration.hasPrefix("@"),
+        let name = declaration.components(separatedBy: "(").first?.dropFirst()
+        else { return false }
+      return !Constants.attributeNameBlacklist.contains(String(name))
+    })
+  }
+}

--- a/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -145,7 +145,7 @@ class MethodTemplate: Template {
   }
 
   lazy var declarationAttributes: String = {
-    return method.attributes.declarations.joined(separator: " ")
+    return method.attributes.safeDeclarations.joined(separator: " ")
   }()
   
   /// Modifiers specifically for stubbing and verification methods.

--- a/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -99,7 +99,7 @@ class VariableTemplate: Template {
   }
   
   lazy var declarationAttributes: String = {
-    return variable.attributes.declarations.joined(separator: " ")
+    return variable.attributes.safeDeclarations.joined(separator: " ")
   }()
   
   lazy var modifiers: String = {

--- a/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
@@ -58,11 +58,13 @@ public class ProcessTypesOperation: BasicOperation {
         .compactMap({ $0.result.mockableType })
         .filter({ !$0.isContainedType })
         .filter({ mockableType -> Bool in
-          guard mockableType.kind == .class, mockableType.subclassesExternalType
-            else { return true }
-          // Ignore any types that simply cannot be initialized because they subclass an externally-
-          // defined type without available initializers and don't locally declare any initializers.
-          return mockableType.methods.contains(where: { $0.isInitializer })
+          guard mockableType.kind == .class, mockableType.subclassesExternalType else { return true }
+          // Ignore any types that simply cannot be initialized.
+          guard mockableType.methods.contains(where: { $0.isInitializer }) else {
+            logWarning("Ignoring `\(mockableType.name)` because it subclasses an externally-defined type without available initializers and does not locally declare any initializers")
+            return false
+          }
+          return true
         })
       result.imports = parseFilesResult.imports
       log("Created \(result.mockableTypes.count) mockable type\(result.mockableTypes.count != 1 ? "s" : "")")

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -9932,6 +9932,206 @@ public func mock(file: StaticString = #file, line: UInt = #line, _ type: Mocking
 
 #endif
 
+// MARK: - Mocked ObjectiveCClass
+
+public final class ObjectiveCClassMock: MockingbirdTestsHost.ObjectiveCClass, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ObjectiveCClassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  public enum InitializerProxy {
+    public static func initialize(__file: StaticString = #file, __line: UInt = #line) -> ObjectiveCClassMock {
+      let mock: ObjectiveCClassMock = ObjectiveCClassMock()
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
+
+  // MARK: Mocked nominalObjcVariable
+
+  override public var `nominalObjcVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getNominalObjcVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setNominalObjcVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked objcComputedVariable
+
+  override public var `objcComputedVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcComputedVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getObjcComputedVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcComputedVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked objcVariable
+
+  override public var `objcVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getObjcVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setObjcVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked variable
+
+  override public var `variable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked init()
+
+  public required override init() {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init() ", arguments: [])
+    mockingContext.didInvoke(invocation)
+  }
+
+  // MARK: Mocked `method`()
+
+  public override func `method`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `method`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `nominalObjcMethod`()
+
+  public override func `nominalObjcMethod`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `nominalObjcMethod`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `objcMethod`()
+
+  public override func `objcMethod`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`objcMethod`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `objcMethod`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`objcMethod`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ObjectiveCClass` class mock metatype.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ObjectiveCClass.Type) -> ObjectiveCClassMock.InitializerProxy.Type {
+  return ObjectiveCClassMock.InitializerProxy.self
+}
+
 // MARK: - Mocked ObjectiveCProtocolImplementer
 
 public final class ObjectiveCProtocolImplementerMock: MockingbirdTestsHost.ObjectiveCProtocolImplementer, Mockingbird.Mock {
@@ -9945,6 +10145,68 @@ public final class ObjectiveCProtocolImplementerMock: MockingbirdTestsHost.Objec
       stubbingContext.sourceLocation = newValue
       ObjectiveCProtocolImplementerMock.staticMock.stubbingContext.sourceLocation = newValue
     }
+  }
+
+  // MARK: Mocked nominalObjcVariable
+
+  override public var `nominalObjcVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getNominalObjcVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setNominalObjcVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked objcVariable
+
+  override public var `objcVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation, optional: true)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getObjcVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setObjcVariable(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "objcVariable.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
   }
 
   // MARK: Mocked variable
@@ -10001,6 +10263,42 @@ public final class ObjectiveCProtocolImplementerMock: MockingbirdTestsHost.Objec
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`() -> Bool", arguments: [])
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
+
+  // MARK: Mocked `nominalObjcMethod`()
+
+  public override func `nominalObjcMethod`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `nominalObjcMethod`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `objcMethod`()
+
+  public override func `objcMethod`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`objcMethod`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `objcMethod`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`objcMethod`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
 }
 
 /// Create a source-attributed `MockingbirdTestsHost.ObjectiveCProtocolImplementer` concrete class mock instance.
@@ -10021,6 +10319,21 @@ public final class ObjectiveCProtocolMock: MockingbirdTestsHost.ObjectiveCProtoc
       stubbingContext.sourceLocation = newValue
       ObjectiveCProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
     }
+  }
+
+  // MARK: Mocked nominalObjcVariable
+
+  public var `nominalObjcVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getNominalObjcVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "nominalObjcVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
   // MARK: Mocked objcVariable
@@ -10073,6 +10386,24 @@ public final class ObjectiveCProtocolMock: MockingbirdTestsHost.ObjectiveCProtoc
 
   public func `method`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`() -> Bool", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `nominalObjcMethod`()
+
+  public func `nominalObjcMethod`() -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? () -> Bool {
+      return concreteImplementation()
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `nominalObjcMethod`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`nominalObjcMethod`() -> Bool", arguments: [])
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
   }
 

--- a/MockingbirdSupport/Foundation/ObjectiveC/NSObject.swift
+++ b/MockingbirdSupport/Foundation/ObjectiveC/NSObject.swift
@@ -2,7 +2,9 @@ import ObjectiveC
 
 public protocol NSObjectProtocol {}
 
-open class NSObject : NSObjectProtocol {}
+open class NSObject : NSObjectProtocol {
+  public init() {}
+}
 
 public protocol NSCopying {
   func copy(with zone: NSZone?) -> Any

--- a/MockingbirdTestsHost/DeclarationAttributes.swift
+++ b/MockingbirdTestsHost/DeclarationAttributes.swift
@@ -26,23 +26,35 @@ class DeclarationAttributesClass {
   func multipleAttributesMethod(param: String) -> Bool { return true }
 }
 
-@objc protocol ObjectiveCProtocol {
-  @objc optional var objcVariable: Bool { get }
+@objc(MKBObjectiveCProtocol) protocol ObjectiveCProtocol {
+  @objc var objcVariable: Bool { get }
+  @objc(isNominalObjcVariable) var nominalObjcVariable: Bool { get }
   var variable: Bool { get }
   
-  @objc optional func objcMethod() -> Bool
+  @objc func objcMethod() -> Bool
+  @objc(isNominalObjcMethod) func nominalObjcMethod() -> Bool
   func method() -> Bool
 }
 
 class ObjectiveCProtocolImplementer: ObjectiveCProtocol {
+  var objcVariable: Bool = true
+  var nominalObjcVariable: Bool = true
   var variable: Bool = true
+  
+  func objcMethod() -> Bool { return true }
+  func nominalObjcMethod() -> Bool { return true }
   func method() -> Bool { return true }
 }
 
-@objc class ObjectiveCClass: Foundation.NSObject {
+@objc(MKBObjectiveCClass) class ObjectiveCClass: Foundation.NSObject {
   @objc var objcVariable = true
+  @objc(isNominalObjcVariable) var nominalObjcVariable = true
+  @objc var objcComputedVariable: Bool {
+    @objc(getIsObjcComputedVariable) get { return true }
+  }
   var variable: Bool = true
   
   @objc func objcMethod() -> Bool { return true }
+  @objc(isNominalObjcMethod) func nominalObjcMethod() -> Bool { return true }
   func method() -> Bool { return true }
 }


### PR DESCRIPTION
The attribute is implicitly added to overriding declarations when subclassing or satisfying a protocol with the objc attribute.

Fixes #38 

**PR stack:** 2/2 (depends on #44)