### PR TITLE
Handle implicitly imported modules in mixed-source targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ bootstrap-carthage:
 	(cd Mockingbird.xcodeproj/xcshareddata/xcschemes && find . ! -name "MockingbirdFramework.xcscheme" ! -name "MockingbirdShared.xcscheme" -delete)
 
 build:
-	swift build $(SWIFT_BUILD_FLAGS)
+	swift build $(SWIFT_BUILD_FLAGS) --product mockingbird
 
 test:
 	$(BUILD_TOOL) -scheme 'MockingbirdTests' $(XCODEBUILD_FLAGS) test

--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -76,6 +76,10 @@
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
 		D3E4CFDB240DB1B40047BBEC /* CountMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */; };
 		D3E4CFDD240F3D970047BBEC /* FloatingPointMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */; };
+		D3E4CFCB240B424E0047BBEC /* ObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFCA240B424E0047BBEC /* ObjectiveC.swift */; };
+		D3E4CFD0240B48F30047BBEC /* MockingbirdModuleTestsHost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Mockingbird::MockingbirdModuleTestsHost::Product" /* MockingbirdModuleTestsHost.framework */; };
+		D3E4CFD2240B49390047BBEC /* MockingbirdTestsHost.h in Headers */ = {isa = PBXBuildFile; fileRef = D3E4CFC7240B3FCD0047BBEC /* MockingbirdTestsHost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3E4CFD7240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFD6240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift */; };
 		D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */; };
 		OBJ_1002 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* SWXMLHash.swift */; };
 		OBJ_1003 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
@@ -995,6 +999,9 @@
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountMatcherTests.swift; sourceTree = "<group>"; };
 		D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPointMatcherTests.swift; sourceTree = "<group>"; };
+		D3E4CFC7240B3FCD0047BBEC /* MockingbirdTestsHost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockingbirdTestsHost.h; sourceTree = "<group>"; };
+		D3E4CFCA240B424E0047BBEC /* ObjectiveC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
+		D3E4CFD6240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleImplicitlyImportedTypes.swift; sourceTree = "<group>"; };
 		D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attributes+Sanitize.swift"; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1588,6 +1595,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D3E4CFD0240B48F30047BBEC /* MockingbirdModuleTestsHost.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1667,6 +1675,13 @@
 				49BA452E234189F4002BD9B5 /* CodableTarget.swift */,
 			);
 			path = Cache;
+			sourceTree = "<group>";
+		};
+		D3E4CFCF240B48F30047BBEC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		D3F076DB24021536002461E7 /* Extensions */ = {
@@ -2691,6 +2706,7 @@
 				OBJ_503 /* Products */,
 				493ECA30232EC7CD008BF44B /* XCConfigs */,
 				2A3E4FEA8D2A60B993516C10 /* Generated Mocks */,
+				D3E4CFCF240B48F30047BBEC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2857,6 +2873,7 @@
 				OBJ_95 /* MockableTypes.swift */,
 				493ECA35232ECD99008BF44B /* Typealiasing.swift */,
 				491906382336CCCE00629F00 /* Generics.swift */,
+				D3E4CFCA240B424E0047BBEC /* ObjectiveC.swift */,
 			);
 			name = MockingbirdModuleTestsHost;
 			path = MockingbirdTestsHost/Module;
@@ -2891,6 +2908,7 @@
 				OBJ_112 /* Exceptions.swift */,
 				OBJ_113 /* Extensions.swift */,
 				493ECA3A232ECF03008BF44B /* ExternalModuleClassScopedTypes.swift */,
+				D3E4CFD6240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift */,
 				493ECA38232ECEF1008BF44B /* ExternalModuleTypealiasing.swift */,
 				493ECA3C232ECF10008BF44B /* ExternalModuleTypes.swift */,
 				OBJ_114 /* Generics.swift */,
@@ -2901,6 +2919,7 @@
 				OBJ_129 /* Initializers.swift */,
 				OBJ_130 /* InoutParameters.swift */,
 				9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */,
+				D3E4CFC7240B3FCD0047BBEC /* MockingbirdTestsHost.h */,
 				OBJ_131 /* ModuleImportCases.swift */,
 				OBJ_132 /* NestedFields.swift */,
 				4970D6772331E67C002EE154 /* OpaqueTypes.swift */,
@@ -2921,6 +2940,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		D3E4CFD1240B49250047BBEC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3E4CFD2240B49390047BBEC /* MockingbirdTestsHost.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_1017 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 0;
@@ -3127,6 +3154,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_882 /* Build configuration list for PBXNativeTarget "MockingbirdTestsHost" */;
 			buildPhases = (
+				D3E4CFD1240B49250047BBEC /* Headers */,
 				OBJ_885 /* Sources */,
 				OBJ_924 /* Frameworks */,
 			);
@@ -3475,6 +3503,11 @@
 			attributes = {
 				LastSwiftMigration = 9999;
 				LastUpgradeCheck = 1100;
+				TargetAttributes = {
+					"Mockingbird::MockingbirdTestsHost" = {
+						LastSwiftMigration = 1130;
+					};
+				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Mockingbird" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -3982,6 +4015,7 @@
 				493ECA36232ECD99008BF44B /* Typealiasing.swift in Sources */,
 				491906392336CCCE00629F00 /* Generics.swift in Sources */,
 				493ECA34232ECC92008BF44B /* ClassScopedTypes.swift in Sources */,
+				D3E4CFCB240B424E0047BBEC /* ObjectiveC.swift in Sources */,
 				OBJ_789 /* MockableTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4072,6 +4106,7 @@
 				OBJ_887 /* Child.swift in Sources */,
 				OBJ_888 /* ChildProtocol.swift in Sources */,
 				493ECA39232ECEF1008BF44B /* ExternalModuleTypealiasing.swift in Sources */,
+				D3E4CFD7240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift in Sources */,
 				OBJ_889 /* ClassInitializers.swift in Sources */,
 				OBJ_890 /* ClassScopedTypes.swift in Sources */,
 				4970D6AA23335ABE002EE154 /* CompilationDirectives.swift in Sources */,
@@ -4760,6 +4795,7 @@
 		4970D6302330AC27002EE154 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4849,6 +4885,8 @@
 		4970D6352330AC27002EE154 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6122,6 +6160,7 @@
 		OBJ_786 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6146,6 +6185,7 @@
 		OBJ_787 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6300,6 +6340,8 @@
 		OBJ_883 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6317,6 +6359,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = MockingbirdTestsHost;
 			};
@@ -6325,6 +6368,8 @@
 		OBJ_884 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -169,6 +169,12 @@ extension ArgumentParser {
                kind: Bool.self,
                usage: "Ignore cached mock information stored on disk.")
   }
+  
+  func addDisableRelaxedLinking() -> OptionArgument<Bool> {
+    return add(option: "--disable-relaxed-linking",
+               kind: Bool.self,
+               usage: "Only search explicitly imported modules.")
+  }
 }
 
 extension ArgumentParser.Result {

--- a/MockingbirdCli/Interface/Commands/GenerateCommand.swift
+++ b/MockingbirdCli/Interface/Commands/GenerateCommand.swift
@@ -31,6 +31,7 @@ final class GenerateCommand: BaseCommand {
   private let onlyMockProtocolsArgument: OptionArgument<Bool>
   private let disableSwiftlintArgument: OptionArgument<Bool>
   private let disableCacheArgument: OptionArgument<Bool>
+  private let disableRelaxedLinking: OptionArgument<Bool>
   
   required init(parser: ArgumentParser) {
     let subparser = parser.add(subparser: Constants.name, overview: Constants.overview)
@@ -47,6 +48,7 @@ final class GenerateCommand: BaseCommand {
     self.onlyMockProtocolsArgument = subparser.addOnlyProtocols()
     self.disableSwiftlintArgument = subparser.addDisableSwiftlint()
     self.disableCacheArgument = subparser.addDisableCache()
+    self.disableRelaxedLinking = subparser.addDisableRelaxedLinking()
     
     super.init(parser: subparser)
   }
@@ -80,7 +82,8 @@ final class GenerateCommand: BaseCommand {
       shouldImportModule: arguments.get(disableModuleImportArgument) != true,
       onlyMockProtocols: arguments.get(onlyMockProtocolsArgument) == true,
       disableSwiftlint: arguments.get(disableSwiftlintArgument) == true,
-      disableCache: arguments.get(disableCacheArgument) == true
+      disableCache: arguments.get(disableCacheArgument) == true,
+      disableRelaxedLinking: arguments.get(disableRelaxedLinking) == true
     )
     try Generator.generate(using: config)
   }

--- a/MockingbirdCli/Interface/Commands/InstallCommand.swift
+++ b/MockingbirdCli/Interface/Commands/InstallCommand.swift
@@ -34,6 +34,7 @@ final class InstallCommand: BaseCommand {
   private let onlyMockProtocolsArgument: OptionArgument<Bool>
   private let disableSwiftlintArgument: OptionArgument<Bool>
   private let disableCacheArgument: OptionArgument<Bool>
+  private let disableRelaxedLinking: OptionArgument<Bool>
   
   required init(parser: ArgumentParser) {
     let subparser = parser.add(subparser: Constants.name, overview: Constants.overview)
@@ -54,6 +55,7 @@ final class InstallCommand: BaseCommand {
     self.onlyMockProtocolsArgument = subparser.addOnlyProtocols()
     self.disableSwiftlintArgument = subparser.addDisableSwiftlint()
     self.disableCacheArgument = subparser.addDisableCache()
+    self.disableRelaxedLinking = subparser.addDisableRelaxedLinking()
     
     super.init(parser: subparser)
   }
@@ -91,7 +93,8 @@ final class InstallCommand: BaseCommand {
       asynchronousGeneration: arguments.get(asynchronousGenerationArgument) == true,
       onlyMockProtocols: arguments.get(onlyMockProtocolsArgument) == true,
       disableSwiftlint: arguments.get(disableSwiftlintArgument) == true,
-      disableCache: arguments.get(disableCacheArgument) == true
+      disableCache: arguments.get(disableCacheArgument) == true,
+      disableRelaxedLinking: arguments.get(disableRelaxedLinking) == true
     )
     try Installer.install(using: config)
     print("Installed Mockingbird to `\(destinationTarget)` in \(projectPath)")

--- a/MockingbirdCli/Interface/Generator.swift
+++ b/MockingbirdCli/Interface/Generator.swift
@@ -25,6 +25,7 @@ class Generator {
     let onlyMockProtocols: Bool
     let disableSwiftlint: Bool
     let disableCache: Bool
+    let disableRelaxedLinking: Bool
   }
   
   enum Failure: Error, CustomStringConvertible {
@@ -94,7 +95,8 @@ class Generator {
       parseFiles.addDependency(extractSources)
       
       let processTypes = ProcessTypesOperation(parseFilesResult: parseFiles.result,
-                                               checkCacheResult: checkCache?.result)
+                                               checkCacheResult: checkCache?.result,
+                                               useRelaxedLinking: !config.disableRelaxedLinking)
       processTypes.addDependency(parseFiles)
       
       let moduleName = inputTarget.productModuleName

--- a/MockingbirdCli/Interface/Installer.swift
+++ b/MockingbirdCli/Interface/Installer.swift
@@ -29,6 +29,7 @@ class Installer {
     let onlyMockProtocols: Bool
     let disableSwiftlint: Bool
     let disableCache: Bool
+    let disableRelaxedLinking: Bool
   }
   
   struct UninstallConfiguration {
@@ -264,6 +265,9 @@ class Installer {
       }
       if config.disableCache {
         options.append("--disable-cache")
+      }
+      if config.disableRelaxedLinking {
+        options.append("--disable-relaxed-linking")
       }
       if let logLevel = config.logLevel {
         switch logLevel {

--- a/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
@@ -13,6 +13,7 @@ import os.log
 public class ProcessTypesOperation: BasicOperation {
   let parseFilesResult: ParseFilesOperation.Result
   let checkCacheResult: CheckCacheOperation.Result?
+  let useRelaxedLinking: Bool
   
   public class Result {
     fileprivate(set) var mockableTypes = [MockableType]()
@@ -24,9 +25,11 @@ public class ProcessTypesOperation: BasicOperation {
   let typealiasRepository = TypealiasRepository()
   
   public init(parseFilesResult: ParseFilesOperation.Result,
-              checkCacheResult: CheckCacheOperation.Result?) {
+              checkCacheResult: CheckCacheOperation.Result?,
+              useRelaxedLinking: Bool) {
     self.parseFilesResult = parseFilesResult
     self.checkCacheResult = checkCacheResult
+    self.useRelaxedLinking = useRelaxedLinking
   }
   
   override func run() {
@@ -52,7 +55,8 @@ public class ProcessTypesOperation: BasicOperation {
         .map({ FlattenInheritanceOperation(rawType: $0,
                                            moduleDependencies: parseFilesResult.moduleDependencies,
                                            rawTypeRepository: rawTypeRepository,
-                                           typealiasRepository: typealiasRepository) })
+                                           typealiasRepository: typealiasRepository,
+                                           useRelaxedLinking: useRelaxedLinking) })
       queue.addOperations(flattenInheritanceOperations, waitUntilFinished: true)
       result.mockableTypes = flattenInheritanceOperations
         .compactMap({ $0.result.mockableType })

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -8086,6 +8086,47 @@ public func mock(file: StaticString = #file, line: UInt = #line, _ type: Mocking
   return ImplementingExternalModuleScopingMock.InitializerProxy.self
 }
 
+// MARK: - Mocked ImplicitlyImportedExternalObjectiveCType
+
+public final class ImplicitlyImportedExternalObjectiveCTypeMock: MockingbirdTestsHost.ImplicitlyImportedExternalObjectiveCType, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ImplicitlyImportedExternalObjectiveCTypeMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked variable
+
+  public var `variable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "variable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ImplicitlyImportedExternalObjectiveCType` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.ImplicitlyImportedExternalObjectiveCType.Protocol) -> ImplicitlyImportedExternalObjectiveCTypeMock {
+  return ImplicitlyImportedExternalObjectiveCTypeMock(sourceLocation: SourceLocation(file, line))
+}
+
 // MARK: - Mocked InheritedTypeQualificationProtocolGenericImplementer
 
 public final class InheritedTypeQualificationProtocolGenericImplementerMock<T>: MockingbirdTestsHost.InheritedTypeQualificationProtocolGenericImplementer<T>, Mockingbird.Mock {

--- a/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
+++ b/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
@@ -59,6 +59,11 @@ ConformingUninitializableOpenClassConstrainedProtocol {
 extension ConformingUninitializableOpenClassConstrainedProtocolMock:
 MockableConformingUninitializableOpenClassConstrainedProtocol {}
 
+private protocol MockableImplicitlyImportedExternalObjectiveCType:
+ExternalObjectiveCProtocol {}
+extension ImplicitlyImportedExternalObjectiveCTypeMock:
+MockableImplicitlyImportedExternalObjectiveCType {}
+
 // MARK: - Non-mockable declarations
 
 class SubclassingExternalClass: ExternalClass {}

--- a/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
+++ b/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
@@ -49,6 +49,12 @@ private protocol StubbableConformingUninitializableOpenClassConstrainedProtocol 
 extension ConformingUninitializableOpenClassConstrainedProtocolMock:
 StubbableConformingUninitializableOpenClassConstrainedProtocol {}
 
+private protocol StubbableImplicitlyImportedExternalObjectiveCType {
+  func getVariable() -> Mockable<VariableDeclaration, () -> Bool, Bool>
+}
+extension ImplicitlyImportedExternalObjectiveCTypeMock:
+StubbableImplicitlyImportedExternalObjectiveCType {}
+
 
 // MARK: - Non-stubbable declarations
 

--- a/MockingbirdTestsHost/ExternalModuleImplicitlyImportedTypes.swift
+++ b/MockingbirdTestsHost/ExternalModuleImplicitlyImportedTypes.swift
@@ -1,0 +1,11 @@
+//
+//  ExternalModuleImplicitlyImportedTypes.swift
+//  MockingbirdTestsHost
+//
+//  Created by Andrew Chang on 2/29/20.
+//
+
+import Foundation
+
+// Implicitly importing `ExternalObjectiveCProtocol` from `MockingbirdModuleTestsHost` via header.
+protocol ImplicitlyImportedExternalObjectiveCType: ExternalObjectiveCProtocol {}

--- a/MockingbirdTestsHost/MockingbirdTestsHost.h
+++ b/MockingbirdTestsHost/MockingbirdTestsHost.h
@@ -1,0 +1,9 @@
+//
+//  MockingbirdTestsHost.h
+//  Mockingbird
+//
+//  Created by Andrew Chang on 2/29/20.
+//
+
+// Enable implicit Swift module imports for `MockingbirdModuleTestsHost`.
+#import <MockingbirdModuleTestsHost/MockingbirdModuleTestsHost-Swift.h>

--- a/MockingbirdTestsHost/Module/ObjectiveC.swift
+++ b/MockingbirdTestsHost/Module/ObjectiveC.swift
@@ -1,0 +1,13 @@
+//
+//  ObjectiveC.swift
+//  MockingbirdModuleTestsHost
+//
+//  Created by Andrew Chang on 2/29/20.
+//
+
+import Foundation
+
+@objc(MKBExternalObjectiveCProtocol)
+public protocol ExternalObjectiveCProtocol {
+  var variable: Bool { get }
+}

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ MockingbirdSupport/
 │   └── ObjectiveC/
 │       └── NSObject.swift
 └── Swift/
-    └── Codable.swift
-    └── Comparable.swift
-    └── Equatable.swift
+    ├── Codable.swift
+    ├── Comparable.swift
+    ├── Equatable.swift
     └── Hashable.swift
 ```
 
@@ -427,6 +427,7 @@ Generate mocks for a set of targets in a project.
 | `--only-protocols` | Only generate mocks for protocols. |
 | `--disable-swiftlint` | Disable all SwiftLint rules in generated mocks. |
 | `--disable-cache` | Ignore cached mock information stored on disk. |
+| `--disable-relaxed-linking` | Only search explicitly imported modules. |
 
 ### Install
 
@@ -452,6 +453,7 @@ Set up a destination (unit test) target.
 | `--only-protocols` | Only generate mocks for protocols. |
 | `--disable-swiftlint` | Disable all SwiftLint rules in generated mocks. |
 | `--disable-cache` | Ignore cached mock information stored on disk. |
+| `--disable-relaxed-linking` | Only search explicitly imported modules. |
 
 ### Uninstall
 


### PR DESCRIPTION
ObjC interoperability allows `@objc` marked types to be implicitly imported in Swift files without an import declaration. Given a type declared as `@objc(MKBFoo) public protocol Foo {}` in ModuleA, it's possible for ModuleB to declare a header that imports ModuleA's ObjC generated interface header `#import <ModuleA/ModuleA-Swift.h>`.

ModuleB can then use `Foo` in any Swift files without declaring `import ModuleA` (!!)

The simple fix here relaxes the "linker" by allowing type resolution on any of the module dependencies. Modules explicitly imported from an import declaration are searched first (on a per-file basis). It's worth noting that relaxed linking allows _all_ types to be resolved implicitly not just those marked as `@objc`.

If needed, relaxed linking can be disabled with the generator flag `--disable-relaxed-linking`

It might be possible to parse and traverse all headers to determine exactly which modules should be treated as implicitly imported, but this seems difficult and error prone (e.g. compiler directives).