### PR TITLE
Fix type coercion regression in type facade resolution method

### DIFF
--- a/MockingbirdFramework/DSL/TypeFacade.swift
+++ b/MockingbirdFramework/DSL/TypeFacade.swift
@@ -68,6 +68,7 @@ func resolve<T>(_ parameter: @escaping () -> T) -> ArgumentMatcher {
   context.start()
   semaphore.wait()
   if let matcher = result.value as? ArgumentMatcher { return matcher }
+  if let typedValue = result.value as? T { return ArgumentMatcher(typedValue) }
   return ArgumentMatcher(result.value)
 }
 
@@ -79,6 +80,7 @@ func resolve<T: Equatable>(_ parameter: @escaping () -> T) -> ArgumentMatcher {
   context.start()
   semaphore.wait()
   if let matcher = result.value as? ArgumentMatcher { return matcher }
+  if let typedValue = result.value as? T { return ArgumentMatcher(typedValue) }
   return ArgumentMatcher(result.value)
 }
 


### PR DESCRIPTION
Types conforming to `Equatable` are losing static type information and transforming into `Any?` upon resolution. This currently doesn’t (seem to) break anything because type information is restored from the mocked call site and previous argument matchers are coerced at verification time into the right type.