### PR TITLE
Improve integration of nominal count matchers

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		9491824C23F0CE3A00429146 /* KeywordArgumentNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */; };
 		9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */; };
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
+		D3E4CFDB240DB1B40047BBEC /* CountMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */; };
 		D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */; };
 		OBJ_1002 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* SWXMLHash.swift */; };
 		OBJ_1003 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
@@ -991,6 +992,7 @@
 		9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesMockableTests.swift; sourceTree = "<group>"; };
 		9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesStubbableTests.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountMatcherTests.swift; sourceTree = "<group>"; };
 		D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attributes+Sanitize.swift"; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1817,6 +1819,7 @@
 				OBJ_178 /* AsyncVerificationTests.swift */,
 				491047AD2391FC0B00E837AE /* ClosureParameterTests.swift */,
 				OBJ_179 /* CollectionArgumentMatchingTests.swift */,
+				D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */,
 				OBJ_180 /* InitializerTests.swift */,
 				OBJ_181 /* LastSetValueStubTests.swift */,
 				OBJ_182 /* OverloadedMethodTests.swift */,
@@ -4018,6 +4021,7 @@
 				OBJ_828 /* GenericsMockableTests.swift in Sources */,
 				OBJ_829 /* GenericsStubbableTests.swift in Sources */,
 				491047AE2391FC0B00E837AE /* ClosureParameterTests.swift in Sources */,
+				D3E4CFDB240DB1B40047BBEC /* CountMatcherTests.swift in Sources */,
 				OBJ_830 /* IgnoredSourceExclusionTests.swift in Sources */,
 				OBJ_831 /* InoutParametersMockableTests.swift in Sources */,
 				OBJ_832 /* InoutParametersStubbableTests.swift in Sources */,

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -231,18 +231,23 @@ public func notEmpty<T: Collection>(_ type: T.Type = T.self) -> T {
   return any(count: atLeast(1))
 }
 
+// MARK: - Nominal count matchers
+
+/// A count of zero.
+public let never: UInt = 0
+
+/// A count of one.
+public let once: UInt = 1
+
+/// A count of two.
+public let twice: UInt = 2
+
 // MARK: - Standard count matchers
 
 /// Matches an exact count.
 public func exactly(_ times: UInt) -> CountMatcher {
   return CountMatcher({ $0 == times }, describedBy: { "`\($1)` \($2 ? "≠" : "=") \(times)" })
 }
-
-/// Matches a single count.
-public var once: CountMatcher { return exactly(1) }
-
-/// Matches a count of zero.
-public var never: CountMatcher { return exactly(0) }
 
 /// Matches greater than or equal to some count.
 public func atLeast(_ times: UInt) -> CountMatcher {

--- a/MockingbirdFramework/Verification/Verification.swift
+++ b/MockingbirdFramework/Verification/Verification.swift
@@ -30,16 +30,23 @@ public struct Verification<I, R> {
     self.sourceLocation = sourceLocation
   }
 
-  /// Verify that the mock received the invocation some number of times.
+  /// Verify that the mock received the invocation some number of times using a count matcher.
   ///
   /// - Parameter countMathcer: A count matcher defining the number of invocations to verify.
-  public func wasCalled(_ countMatcher: CountMatcher = once) {
+  public func wasCalled(_ countMatcher: CountMatcher) {
     verify(using: countMatcher, for: sourceLocation)
+  }
+  
+  /// Verify that the mock received the invocation an exact number of times.
+  ///
+  /// - Parameter times: The exact number of invocations expected.
+  public func wasCalled(_ times: UInt = once) {
+    verify(using: exactly(times), for: sourceLocation)
   }
 
   /// Verify that the mock never received the invocation.
   public func wasNeverCalled() {
-    verify(using: never, for: sourceLocation)
+    verify(using: exactly(never), for: sourceLocation)
   }
   
   /// Disambiguate methods overloaded by return type.

--- a/MockingbirdTests/Framework/CountMatcherTests.swift
+++ b/MockingbirdTests/Framework/CountMatcherTests.swift
@@ -1,0 +1,140 @@
+//
+//  CountMatcherTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/2/20.
+//
+
+import Mockingbird
+import XCTest
+@testable import MockingbirdTestsHost
+
+// TODO: Create XFAIL equivalent for XCTestCase to test expected verification failures.
+class CountMatcherTests: XCTestCase {
+  
+  var child: ChildProtocolMock!
+  
+  override func setUp() {
+    child = mock(ChildProtocol.self)
+  }
+  
+  // MARK: - Nominal count matchers
+  
+  // MARK: Exact
+  
+  func testNominalCountMatcher_exactlyNever() {
+    verify(child.childTrivialInstanceMethod()).wasCalled(never)
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(never))
+    verify(child.childTrivialInstanceMethod()).wasNeverCalled()
+  }
+  
+  func testNominalCountMatcher_exactlyOnce() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(once)
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(once))
+  }
+  
+  func testNominalCountMatcher_exactlyTwice() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(twice)
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(twice))
+  }
+  
+  // MARK: Inequality
+  
+  func testNominalCountMatcher_atMostOnce() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atMost(once))
+  }
+  
+  func testNominalCountMatcher_atLeastOnce() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(once))
+  }
+  
+  func testNominalCountMatcher_atMostTwice() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atMost(twice))
+  }
+  
+  func testNominalCountMatcher_atLeastTwice() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(twice))
+  }
+  
+  // MARK: - Exact count matcher
+  
+  func testExactCountMatcher() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(3))
+  }
+  
+  func testExactCountMatcher_convenience() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(3)
+  }
+  
+  // MARK: - Inequality count matcher
+  
+  func testInequalityCountMatcher_atLeast_atThreshold() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(3))
+  }
+  
+  func testInequalityCountMatcher_atLeast_aboveThreshold() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(3))
+  }
+  
+  func testInequalityCountMatcher_atMost_atThreshold() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atMost(3))
+  }
+  
+  func testInequalityCountMatcher_atMost_belowThreshold() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(atMost(3))
+  }
+  
+  // MARK: - Composition
+  
+  func testCountMatcherComposition_orOperator() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(once).or(exactly(twice)))
+    
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(once).or(exactly(twice)))
+  }
+  
+  func testCountMatcherComposition_andOperator() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(exactly(once).and(atMost(twice)))
+  }
+  
+  func testCountMatcherComposition_notOperator() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(not(exactly(once)))
+  }
+  
+  func testCountMatcherComposition_notOperatorWithAndOperator() {
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    (child as ChildProtocol).childTrivialInstanceMethod()
+    verify(child.childTrivialInstanceMethod()).wasCalled(not(exactly(once).and(atMost(twice))))
+  }
+}


### PR DESCRIPTION
Nominal count matchers {`never`, `once`, `twice`} are now just `UInt` aliases which allows them to be passed directly into inequality count matchers like `atLeast`. This makes things a bit more readable:

`verify(foo.bar()).wasCalled(atLeast(1))`

becomes

`verify(foo.bar()).wasCalled(atLeast(once))`