### PR TITLE
Improve clarity and verboseness of test failure messages

### DIFF
--- a/MockingbirdFramework/Matching/ArgumentMatcher.swift
+++ b/MockingbirdFramework/Matching/ArgumentMatcher.swift
@@ -62,7 +62,14 @@ public class ArgumentMatcher: CustomStringConvertible {
     self.baseType = type(of: base)
     self.priority = priority
     self.comparator = comparator ?? { $0 as AnyObject === $1 as AnyObject }
-    let annotation = comparator == nil && base != nil ? " (by reference)" : ""
+    
+    let annotation: String
+    if comparator == nil && base != nil {
+      let memoryAddress = Unmanaged.passUnretained(base as AnyObject).toOpaque()
+      annotation = " (\(memoryAddress))"
+    } else {
+      annotation = ""
+    }
     self.description = description ?? "\(String.describe(base))\(annotation)"
   }
   

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -235,7 +235,7 @@ public func notEmpty<T: Collection>(_ type: T.Type = T.self) -> T {
 
 /// Matches an exact count.
 public func exactly(_ times: UInt) -> CountMatcher {
-  return CountMatcher({ $0 == times }, describedBy: { "`\($1)` \($2 ? "≠" : "=") \(times)" })
+  return CountMatcher({ $0 == times }, describedBy: { "n \($2 ? "≠" : "=") \(times)" })
 }
 
 /// Matches a single count.
@@ -246,12 +246,12 @@ public var never: CountMatcher { return exactly(0) }
 
 /// Matches greater than or equal to some count.
 public func atLeast(_ times: UInt) -> CountMatcher {
-  return CountMatcher({ $0 >= times }, describedBy: { "`\($1)` \($2 ? "<" : "≥") \(times)" })
+  return CountMatcher({ $0 >= times }, describedBy: { "n \($2 ? "<" : "≥") \(times)" })
 }
 
 /// Matches less than or equal to some count.
 public func atMost(_ times: UInt) -> CountMatcher {
-  return CountMatcher({ $0 <= times }, describedBy: { "`\($1)` \($2 ? ">" : "≤") \(times)" })
+  return CountMatcher({ $0 <= times }, describedBy: { "n \($2 ? ">" : "≤") \(times)" })
 }
 
 /// Matches counts that fall within a certain inclusive range.

--- a/MockingbirdFramework/Verification/Invocation.swift
+++ b/MockingbirdFramework/Verification/Invocation.swift
@@ -17,10 +17,16 @@ struct Invocation: Equatable, CustomStringConvertible {
     self.selectorName = selectorName
     self.arguments = arguments
   }
+  
+  /// Selector name without tickmark escaping.
+  var unwrappedSelectorName: String {
+    return selectorName.replacingOccurrences(of: "`", with: "")
+  }
 
   var description: String {
+    guard !arguments.isEmpty else { return "'\(unwrappedSelectorName)'" }
     let matchers = arguments.map({ String(describing: $0) }).joined(separator: ", ")
-    return "`\(selectorName)` matching (\(matchers))"
+    return "'\(unwrappedSelectorName)' with arguments [\(matchers)]"
   }
 
   static func == (lhs: Invocation, rhs: Invocation) -> Bool {

--- a/MockingbirdFramework/Verification/Verification.swift
+++ b/MockingbirdFramework/Verification/Verification.swift
@@ -132,14 +132,14 @@ func expect(_ mockingContext: MockingContext,
     return
   }
   
-  let allInvocations =
-    mockingContext.invocations(for: invocation.selectorName).filter({ $0 == invocation })
-  let actualCallCount = UInt(allInvocations.count)
+  let allInvocations = mockingContext.invocations(for: invocation.selectorName)
+  let allInvocationsMatchingArguments = allInvocations.filter({ $0 == invocation })
+  let actualCallCount = UInt(allInvocationsMatchingArguments.count)
   guard !expectation.countMatcher.matches(actualCallCount) else { return }
-  let description = expectation.countMatcher.describe(invocation: invocation,
-                                                      count: actualCallCount)
-  let failure = TestFailure.incorrectInvocationCount(invocation: invocation,
-                                                     description: description)
+  let failure = TestFailure.incorrectInvocationCount(invocationCount: actualCallCount,
+                                                     invocation: invocation,
+                                                     countMatcher: expectation.countMatcher,
+                                                     allInvocations: allInvocations)
   XCTFail(String(describing: failure),
           file: expectation.sourceLocation.file,
           line: expectation.sourceLocation.line)


### PR DESCRIPTION
Test failures now report all recorded invocations to that particular selector and make the expected invocation count clearer:

```
Got 0 invocations of 'chirp(volume: Int) -> Void' with arguments [42]
but expected n ≥ 2

All invocations of 'chirp(volume: Int) -> Void':
   (1) 'chirp(volume: Int) -> Void' with arguments [1]
   (2) 'chirp(volume: Int) -> Void' with arguments [2]
   (3) 'chirp(volume: Int) -> Void' with arguments [3]
```