### PR TITLE
Add fuzzy floating point matcher to standard testing library

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */; };
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
 		D3E4CFDB240DB1B40047BBEC /* CountMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */; };
+		D3E4CFDD240F3D970047BBEC /* FloatingPointMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */; };
 		D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */; };
 		OBJ_1002 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* SWXMLHash.swift */; };
 		OBJ_1003 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
@@ -993,6 +994,7 @@
 		9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesStubbableTests.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountMatcherTests.swift; sourceTree = "<group>"; };
+		D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPointMatcherTests.swift; sourceTree = "<group>"; };
 		D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attributes+Sanitize.swift"; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1820,6 +1822,7 @@
 				491047AD2391FC0B00E837AE /* ClosureParameterTests.swift */,
 				OBJ_179 /* CollectionArgumentMatchingTests.swift */,
 				D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */,
+				D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */,
 				OBJ_180 /* InitializerTests.swift */,
 				OBJ_181 /* LastSetValueStubTests.swift */,
 				OBJ_182 /* OverloadedMethodTests.swift */,
@@ -4052,6 +4055,7 @@
 				OBJ_851 /* DeclaredTypeTests.swift in Sources */,
 				4904BDF5232F1AB30031E071 /* EmptyTypesMockableTests.swift in Sources */,
 				4904BDF9232F1F750031E071 /* ExternalModuleClassScopedTypesStubbableTests.swift in Sources */,
+				D3E4CFDD240F3D970047BBEC /* FloatingPointMatcherTests.swift in Sources */,
 				OBJ_852 /* StringExtensionsTests.swift in Sources */,
 				4904BDF7232F1E570031E071 /* ExternalModuleClassScopedTypesMockableTests.swift in Sources */,
 				5D5FAC84DF438200D4E44D85 /* MockingbirdTestsHostMocks.generated.swift in Sources */,

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -231,6 +231,22 @@ public func notEmpty<T: Collection>(_ type: T.Type = T.self) -> T {
   return any(count: atLeast(1))
 }
 
+// MARK: Floating point matchers
+
+/// Matches floating point arguments within some tolerance.
+///
+/// - Parameters:
+///   - value: The expected value.
+///   - tolerance: Only matches if the absolute difference is strictly less than this value.
+public func around<T: FloatingPoint>(_ value: T, tolerance: T) -> T {
+  let description = "around<\(T.self)>()"
+  let matcher = ArgumentMatcher(value, description: description, priority: .high) { (lhs, rhs) in
+    guard let base = lhs as? T, let other = rhs as? T else { return false }
+    return abs(other - base) < tolerance
+  }
+  return createTypeFacade(matcher)
+}
+
 // MARK: - Nominal count matchers
 
 /// A count of zero.

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -57,6 +57,25 @@ public final class ArgumentMatchingProtocolMock: MockingbirdTestsHost.ArgumentMa
     return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.StructType?, MockingbirdTestsHost.ClassType?, MockingbirdTestsHost.EnumType?, String?, Bool?, P?, ClassType.Type?, Any?, Swift.AnyObject?) -> Bool, Bool>(mock: self, invocation: invocation)
   }
 
+  // MARK: Mocked `method`<T: FloatingPoint>(`param`: T)
+
+  public func `method`<T: FloatingPoint>(`param`: T) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<T: FloatingPoint>(`param`: T) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (T) -> Bool {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `method`<T: FloatingPoint>(`param`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`method`<T: FloatingPoint>(`param`: T) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
   // MARK: Mocked `method`<P: MockingbirdTestsHost.BaseProtocol>(`structType`: MockingbirdTestsHost.StructType, `classType`: MockingbirdTestsHost.ClassType, `enumType`: MockingbirdTestsHost.EnumType, `stringType`: String, `boolType`: Bool, `protocolType`: P, `metaType`: ClassType.Type, `anyType`: Any, `anyObjectType`: Swift.AnyObject)
 
   public func `method`<P: MockingbirdTestsHost.BaseProtocol>(`structType`: MockingbirdTestsHost.StructType, `classType`: MockingbirdTestsHost.ClassType, `enumType`: MockingbirdTestsHost.EnumType, `stringType`: String, `boolType`: Bool, `protocolType`: P, `metaType`: ClassType.Type, `anyType`: Any, `anyObjectType`: Swift.AnyObject) -> Bool {
@@ -11348,7 +11367,7 @@ public final class ParameterizedInitializerProtocolMock: MockingbirdTestsHost.Pa
   static let staticMock = Mockingbird.StaticMock()
   public let mockingContext = Mockingbird.MockingContext()
   public let stubbingContext = Mockingbird.StubbingContext()
-  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
   public var sourceLocation: Mockingbird.SourceLocation? {
     get { return stubbingContext.sourceLocation }
     set {
@@ -15126,7 +15145,7 @@ public final class VariadicProtocolMock: MockingbirdTestsHost.VariadicProtocol, 
   static let staticMock = Mockingbird.StaticMock()
   public let mockingContext = Mockingbird.MockingContext()
   public let stubbingContext = Mockingbird.StubbingContext()
-  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
   public var sourceLocation: Mockingbird.SourceLocation? {
     get { return stubbingContext.sourceLocation }
     set {
@@ -15248,7 +15267,7 @@ public final class ViewControllerExtensionReferencerMock: MockingbirdTestsHost.V
   static let staticMock = Mockingbird.StaticMock()
   public let mockingContext = Mockingbird.MockingContext()
   public let stubbingContext = Mockingbird.StubbingContext()
-  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.9.0", "module_name": "MockingbirdTestsHost"])
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
   public var sourceLocation: Mockingbird.SourceLocation? {
     get { return stubbingContext.sourceLocation }
     set {

--- a/MockingbirdTests/Framework/FloatingPointMatcherTests.swift
+++ b/MockingbirdTests/Framework/FloatingPointMatcherTests.swift
@@ -1,0 +1,47 @@
+//
+//  FloatingPointMatcherTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/3/20.
+//
+
+import Mockingbird
+import XCTest
+@testable import MockingbirdTestsHost
+
+class FloatingPointMatcherTests: XCTestCase {
+  
+  var floatingPoint: ArgumentMatchingProtocolMock!
+  
+  override func setUp() {
+    floatingPoint = mock(ArgumentMatchingProtocol.self)
+  }
+  
+  func testMethod_exactMatch() {
+    given(floatingPoint.method(param: 0.42)) ~> true
+    XCTAssertTrue((floatingPoint as ArgumentMatchingProtocol).method(param: 0.42))
+    verify(floatingPoint.method(param: 0.42)).wasCalled()
+    verify(floatingPoint.method(param: 0.421)).wasNeverCalled()
+  }
+  
+  func testMethod_fuzzyMatch_equalToTarget() {
+    given(floatingPoint.method(param: around(0.42, tolerance: 0.01))) ~> true
+    XCTAssertTrue((floatingPoint as ArgumentMatchingProtocol).method(param: 0.42))
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.01))).wasCalled()
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.001))).wasCalled()
+  }
+  
+  func testMethod_fuzzyMatch_aboveTarget() {
+    given(floatingPoint.method(param: around(0.42, tolerance: 0.01))) ~> true
+    XCTAssertTrue((floatingPoint as ArgumentMatchingProtocol).method(param: 0.429))
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.01))).wasCalled()
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.001))).wasNeverCalled()
+  }
+  
+  func testMethod_fuzzyMatch_belowTarget() {
+    given(floatingPoint.method(param: around(0.42, tolerance: 0.01))) ~> true
+    XCTAssertTrue((floatingPoint as ArgumentMatchingProtocol).method(param: 0.411))
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.01))).wasCalled()
+    verify(floatingPoint.method(param: around(0.42, tolerance: 0.001))).wasNeverCalled()
+  }
+}

--- a/MockingbirdTestsHost/ArgumentMatching.swift
+++ b/MockingbirdTestsHost/ArgumentMatching.swift
@@ -29,22 +29,24 @@ enum EnumType {
 
 protocol ArgumentMatchingProtocol {
   func method<P: BaseProtocol>(structType: StructType,
-              classType: ClassType,
-              enumType: EnumType,
-              stringType: String,
-              boolType: Bool,
-              protocolType: P,
-              metaType: ClassType.Type,
-              anyType: Any,
-              anyObjectType: AnyObject) -> Bool
+                               classType: ClassType,
+                               enumType: EnumType,
+                               stringType: String,
+                               boolType: Bool,
+                               protocolType: P,
+                               metaType: ClassType.Type,
+                               anyType: Any,
+                               anyObjectType: AnyObject) -> Bool
   
   func method<P: BaseProtocol>(optionalStructType: StructType?,
-              optionalClassType: ClassType?,
-              optionalEnumType: EnumType?,
-              optionalStringType: String?,
-              optionalBoolType: Bool?,
-              optionalProtocolType: P?,
-              optionalMetaType: ClassType.Type?,
-              optionalAnyType: Any?,
-              optionalAnyObjectType: AnyObject?) -> Bool
+                               optionalClassType: ClassType?,
+                               optionalEnumType: EnumType?,
+                               optionalStringType: String?,
+                               optionalBoolType: Bool?,
+                               optionalProtocolType: P?,
+                               optionalMetaType: ClassType.Type?,
+                               optionalAnyType: Any?,
+                               optionalAnyObjectType: AnyObject?) -> Bool
+  
+  func method<T: FloatingPoint>(param: T) -> Bool
 }

--- a/README.md
+++ b/README.md
@@ -340,6 +340,13 @@ any(count: atMost(42))    // Matches any collection with at most 42 elements
 notEmpty()                // Matches any non-empty collection
 ```
 
+Operations on floating point numbers cause unexpected behavior, so consider using `around` to fuzzily match floating
+point arguments with some tolerance.
+
+```swift
+around(10.0, tolerance: 0.01)
+```
+
 If you provide a concrete instance of an `Equatable` type, argument values will be compared using equality. 
 Types that don’t conform to `Equatable` will be compared by reference.
 


### PR DESCRIPTION
Usage: `around(10.0, tolerance: 0.01)`