### PR TITLE
Add in order verification for enforcing relative invocation ordering

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -74,6 +74,13 @@
 		9491824C23F0CE3A00429146 /* KeywordArgumentNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */; };
 		9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */; };
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
+		D30C880E2415F40000AB4E46 /* AsyncVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30C880D2415F40000AB4E46 /* AsyncVerification.swift */; };
+		D30C88102415F41100AB4E46 /* OrderedVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30C880F2415F41100AB4E46 /* OrderedVerification.swift */; };
+		D320BA832416225800B1F8CC /* OrderedVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D320BA822416225800B1F8CC /* OrderedVerificationTests.swift */; };
+		D320BA85241A0BC300B1F8CC /* XCTFailSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D320BA84241A0BC300B1F8CC /* XCTFailSwizzler.swift */; };
+		D320BA87241A0F1700B1F8CC /* XFailTestFailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D320BA86241A0F1700B1F8CC /* XFailTestFailer.swift */; };
+		D320BA8A241A129300B1F8CC /* XFailBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D320BA89241A129300B1F8CC /* XFailBaseTestCase.swift */; };
+		D344E0F8241B1AFC00E3E7E1 /* XFailOrderedVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D344E0F7241B1AFC00E3E7E1 /* XFailOrderedVerificationTests.swift */; };
 		D3E4CFCB240B424E0047BBEC /* ObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFCA240B424E0047BBEC /* ObjectiveC.swift */; };
 		D3E4CFD0240B48F30047BBEC /* MockingbirdModuleTestsHost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Mockingbird::MockingbirdModuleTestsHost::Product" /* MockingbirdModuleTestsHost.framework */; };
 		D3E4CFD2240B49390047BBEC /* MockingbirdTestsHost.h in Headers */ = {isa = PBXBuildFile; fileRef = D3E4CFC7240B3FCD0047BBEC /* MockingbirdTestsHost.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -997,6 +1004,13 @@
 		9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesMockableTests.swift; sourceTree = "<group>"; };
 		9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesStubbableTests.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D30C880D2415F40000AB4E46 /* AsyncVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncVerification.swift; sourceTree = "<group>"; };
+		D30C880F2415F41100AB4E46 /* OrderedVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedVerification.swift; sourceTree = "<group>"; };
+		D320BA822416225800B1F8CC /* OrderedVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedVerificationTests.swift; sourceTree = "<group>"; };
+		D320BA84241A0BC300B1F8CC /* XCTFailSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTFailSwizzler.swift; sourceTree = "<group>"; };
+		D320BA86241A0F1700B1F8CC /* XFailTestFailer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XFailTestFailer.swift; sourceTree = "<group>"; };
+		D320BA89241A129300B1F8CC /* XFailBaseTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XFailBaseTestCase.swift; sourceTree = "<group>"; };
+		D344E0F7241B1AFC00E3E7E1 /* XFailOrderedVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XFailOrderedVerificationTests.swift; sourceTree = "<group>"; };
 		D3E4CFC7240B3FCD0047BBEC /* MockingbirdTestsHost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockingbirdTestsHost.h; sourceTree = "<group>"; };
 		D3E4CFCA240B424E0047BBEC /* ObjectiveC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
 		D3E4CFD6240B4CE10047BBEC /* ExternalModuleImplicitlyImportedTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModuleImplicitlyImportedTypes.swift; sourceTree = "<group>"; };
@@ -1677,6 +1691,15 @@
 			path = Cache;
 			sourceTree = "<group>";
 		};
+		D320BA88241A127E00B1F8CC /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				D320BA86241A0F1700B1F8CC /* XFailTestFailer.swift */,
+				D320BA89241A129300B1F8CC /* XFailBaseTestCase.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		D3E4CFCF240B48F30047BBEC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1840,9 +1863,12 @@
 				D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */,
 				OBJ_180 /* InitializerTests.swift */,
 				OBJ_181 /* LastSetValueStubTests.swift */,
+				D320BA822416225800B1F8CC /* OrderedVerificationTests.swift */,
 				OBJ_182 /* OverloadedMethodTests.swift */,
 				OBJ_183 /* StubbingTests.swift */,
+				D320BA88241A127E00B1F8CC /* Utilities */,
 				OBJ_184 /* VariadicParametersTests.swift */,
+				D344E0F7241B1AFC00E3E7E1 /* XFailOrderedVerificationTests.swift */,
 			);
 			path = Framework;
 			sourceTree = "<group>";
@@ -2571,9 +2597,12 @@
 		OBJ_44 /* Verification */ = {
 			isa = PBXGroup;
 			children = (
+				D30C880D2415F40000AB4E46 /* AsyncVerification.swift */,
 				OBJ_45 /* Invocation.swift */,
+				D30C880F2415F41100AB4E46 /* OrderedVerification.swift */,
 				OBJ_46 /* TestFailure.swift */,
 				OBJ_47 /* Verification.swift */,
+				D320BA84241A0BC300B1F8CC /* XCTFailSwizzler.swift */,
 			);
 			path = Verification;
 			sourceTree = "<group>";
@@ -3946,13 +3975,16 @@
 				OBJ_713 /* StubbingContext.swift in Sources */,
 				OBJ_714 /* TestKiller.swift in Sources */,
 				OBJ_715 /* Array+Extensions.swift in Sources */,
+				D30C880E2415F40000AB4E46 /* AsyncVerification.swift in Sources */,
 				OBJ_716 /* DateFormatter+Extensions.swift in Sources */,
 				OBJ_717 /* String+Extensions.swift in Sources */,
 				OBJ_718 /* Synchronized.swift in Sources */,
 				OBJ_719 /* Version.swift in Sources */,
 				OBJ_720 /* VersionControl.swift in Sources */,
 				OBJ_721 /* Invocation.swift in Sources */,
+				D320BA85241A0BC300B1F8CC /* XCTFailSwizzler.swift in Sources */,
 				OBJ_722 /* TestFailure.swift in Sources */,
+				D30C88102415F41100AB4E46 /* OrderedVerification.swift in Sources */,
 				OBJ_723 /* Verification.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4065,8 +4097,11 @@
 				OBJ_833 /* TypealiasingMockableTests.swift in Sources */,
 				OBJ_834 /* TypealiasingStubbableTests.swift in Sources */,
 				OBJ_835 /* UndefinedArgumentLabelsMockableTests.swift in Sources */,
+				D320BA832416225800B1F8CC /* OrderedVerificationTests.swift in Sources */,
+				D320BA87241A0F1700B1F8CC /* XFailTestFailer.swift in Sources */,
 				OBJ_836 /* UndefinedArgumentLabelsStubbableTests.swift in Sources */,
 				OBJ_837 /* VariablesMockableTests.swift in Sources */,
+				D320BA8A241A129300B1F8CC /* XFailBaseTestCase.swift in Sources */,
 				OBJ_838 /* VariablesStubbableTests.swift in Sources */,
 				4904BDF3232F18A10031E071 /* InitializersMockableTests.swift in Sources */,
 				9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */,
@@ -4089,6 +4124,7 @@
 				OBJ_851 /* DeclaredTypeTests.swift in Sources */,
 				4904BDF5232F1AB30031E071 /* EmptyTypesMockableTests.swift in Sources */,
 				4904BDF9232F1F750031E071 /* ExternalModuleClassScopedTypesStubbableTests.swift in Sources */,
+				D344E0F8241B1AFC00E3E7E1 /* XFailOrderedVerificationTests.swift in Sources */,
 				D3E4CFDD240F3D970047BBEC /* FloatingPointMatcherTests.swift in Sources */,
 				OBJ_852 /* StringExtensionsTests.swift in Sources */,
 				4904BDF7232F1E570031E071 /* ExternalModuleClassScopedTypesMockableTests.swift in Sources */,

--- a/MockingbirdFramework/Matching/CountMatcher.swift
+++ b/MockingbirdFramework/Matching/CountMatcher.swift
@@ -12,17 +12,17 @@ public struct CountMatcher {
   let matcher: (UInt) -> Bool
 
   /// Creates a printable description of the expected call count.
-  let descriptionCreator: (Invocation, UInt, Bool) -> String
+  let descriptionCreator: (Invocation, Bool) -> String
 
   init(_ matcher: @escaping (UInt) -> Bool,
-       describedBy descriptionCreator: @escaping (Invocation, UInt, Bool) -> String) {
+       describedBy descriptionCreator: @escaping (Invocation, Bool) -> String) {
     self.matcher = matcher
     self.descriptionCreator = descriptionCreator
   }
 
   func matches(_ count: UInt) -> Bool { return matcher(count) }
 
-  func describe(invocation: Invocation, count: UInt, negated: Bool = false) -> String {
-    return descriptionCreator(invocation, count, negated)
+  func describe(invocation: Invocation, negated: Bool = false) -> String {
+    return descriptionCreator(invocation, negated)
   }
 }

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -293,6 +293,8 @@ extension CountMatcher {
         return "(\(matcherDescription)) \(operand) (\(otherMatcherDescription))"
     })
   }
+  
+  public func or(_ times: UInt) -> CountMatcher { return or(exactly(times)) }
 
   public func and(_ countMatcher: CountMatcher) -> CountMatcher {
     let matcherCopy = self
@@ -305,6 +307,8 @@ extension CountMatcher {
         return "(\(matcherDescription)) \(operand) (\(otherMatcherDescription))"
     })
   }
+  
+  public func and(_ times: UInt) -> CountMatcher { return and(exactly(times)) }
 
   public func xor(_ countMatcher: CountMatcher) -> CountMatcher {
     let matcherCopy = self
@@ -317,6 +321,8 @@ extension CountMatcher {
         return "(\(matcherDescription)) \(operand) (\(otherMatcherDescription))"
     })
   }
+  
+  public func xor(_ times: UInt) -> CountMatcher { return xor(exactly(times)) }
 }
 
 public func not(_ countMatcher: CountMatcher) -> CountMatcher {
@@ -327,3 +333,5 @@ public func not(_ countMatcher: CountMatcher) -> CountMatcher {
       return "\(matcherDescription)"
   })
 }
+
+public func not(_ times: UInt) -> CountMatcher { return not(exactly(times)) }

--- a/MockingbirdFramework/Stubbing/TestKiller.swift
+++ b/MockingbirdFramework/Stubbing/TestKiller.swift
@@ -37,9 +37,9 @@ class TestKiller: NSObject, XCTestObservation {
   
   func failTest(_ message: String, at sourceLocation: SourceLocation? = nil) {
     if let sourceLocation = sourceLocation {
-      XCTFail(message, file: sourceLocation.file, line: sourceLocation.line)
+      MKBFail(message, file: sourceLocation.file, line: sourceLocation.line)
     } else {
-      XCTFail(message)
+      MKBFail(message)
     }
     
     // `XCTest` execution should already be "gracefully" stopped by this point, EXCEPT that

--- a/MockingbirdFramework/Verification/AsyncVerification.swift
+++ b/MockingbirdFramework/Verification/AsyncVerification.swift
@@ -1,0 +1,57 @@
+//
+//  AsyncVerification.swift
+//  MockingbirdFramework
+//
+//  Created by Andrew Chang on 3/8/20.
+//
+
+import Foundation
+import XCTest
+
+/// Internal helper for `eventually` async verification scopes.
+///   1. Creates an attributed `DispatchQueue` scope which collects all verifications.
+///   2. Observes invocations on each mock and fulfills the test expectation if there is a match.
+func createAsyncContext(description: String?, block scope: () -> Void) -> XCTestExpectation {
+  let testExpectation = XCTestExpectation(description: description ?? "Async verification group")
+  let group = ExpectationGroup { group in
+    
+    testExpectation.expectedFulfillmentCount = group.expectations.count + group.subgroups.count
+    
+    group.expectations.forEach({ capturedExpectation in
+      let observer = InvocationObserver({ (invocation, mockingContext) -> Bool in
+        do {
+          try expect(mockingContext,
+                     handled: capturedExpectation.invocation,
+                     using: capturedExpectation.expectation)
+          testExpectation.fulfill()
+          return true
+        } catch {
+          return false
+        }
+      })
+      capturedExpectation.mockingContext
+        .addObserver(observer, for: capturedExpectation.invocation.selectorName)
+    })
+    
+    group.subgroups.forEach({ subgroup in
+      let observer = InvocationObserver({ (invocation, mockingContext) -> Bool in
+        do {
+          try subgroup.verify()
+          testExpectation.fulfill()
+          return true
+        } catch {
+          return false
+        }
+      })
+      subgroup.expectations.forEach({ $0.mockingContext.addObserver(observer) })
+    })
+  }
+  
+  let queue = DispatchQueue(label: "co.bird.mockingbird.async-verification-scope")
+  queue.setSpecific(key: Expectation.expectationGroupKey, value: group)
+  queue.sync { scope() }
+  
+  try? group.verify()
+  
+  return testExpectation
+}

--- a/MockingbirdFramework/Verification/Invocation.swift
+++ b/MockingbirdFramework/Verification/Invocation.swift
@@ -8,10 +8,11 @@
 import Foundation
 
 /// Mocks create invocations when receiving calls to methods or member methods.
-struct Invocation: Equatable, CustomStringConvertible {
+struct Invocation: CustomStringConvertible {
   let selectorName: String
   let arguments: [ArgumentMatcher]
   let timestamp = Date()
+  let identifier = UUID()
 
   init(selectorName: String, arguments: [ArgumentMatcher]) {
     self.selectorName = selectorName
@@ -27,14 +28,6 @@ struct Invocation: Equatable, CustomStringConvertible {
     guard !arguments.isEmpty else { return "'\(unwrappedSelectorName)'" }
     let matchers = arguments.map({ String(describing: $0) }).joined(separator: ", ")
     return "'\(unwrappedSelectorName)' with arguments [\(matchers)]"
-  }
-
-  static func == (lhs: Invocation, rhs: Invocation) -> Bool {
-    guard lhs.arguments.count == rhs.arguments.count else { return false }
-    for (index, argument) in lhs.arguments.enumerated() {
-      if argument != rhs.arguments[index] { return false }
-    }
-    return true
   }
   
   enum Constants {
@@ -55,6 +48,22 @@ struct Invocation: Equatable, CustomStringConvertible {
     let setterSelectorName = String(selectorName.dropLast(4) + Constants.setterSuffix)
     let matcher = ArgumentMatcher(description: "any()", priority: .high) { return true }
     return Invocation(selectorName: setterSelectorName, arguments: [matcher])
+  }
+}
+
+extension Invocation: Equatable {
+  static func == (lhs: Invocation, rhs: Invocation) -> Bool {
+    guard lhs.arguments.count == rhs.arguments.count else { return false }
+    for (index, argument) in lhs.arguments.enumerated() {
+      if argument != rhs.arguments[index] { return false }
+    }
+    return true
+  }
+}
+
+extension Invocation: Comparable {
+  static func < (lhs: Invocation, rhs: Invocation) -> Bool {
+    return lhs.timestamp < rhs.timestamp
   }
 }
 

--- a/MockingbirdFramework/Verification/OrderedVerification.swift
+++ b/MockingbirdFramework/Verification/OrderedVerification.swift
@@ -1,0 +1,191 @@
+//
+//  OrderedVerification.swift
+//  MockingbirdFramework
+//
+//  Created by Andrew Chang on 3/8/20.
+//
+
+import Foundation
+import XCTest
+
+public struct OrderedVerificationOptions: OptionSet {
+  public let rawValue: Int
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+  
+  public static let noInvocationsBefore = OrderedVerificationOptions(rawValue: 1 << 0)
+  public static let noInvocationsAfter = OrderedVerificationOptions(rawValue: 1 << 1)
+  public static let onlyConsecutiveInvocations = OrderedVerificationOptions(rawValue: 1 << 2)
+}
+
+private func getAllInvocations(in contexts: [UUID: MockingContext],
+                               after baseInvocation: Invocation?) -> [Invocation] {
+  return contexts.values
+    .flatMap({ $0.allInvocations.value })
+    .filter({
+      guard let baseInvocation = baseInvocation else { return true }
+      return $0 > baseInvocation
+    })
+    .sorted(by: <)
+}
+
+private func assertNoInvocationsBefore(_ capturedExpectation: CapturedExpectation,
+                                       baseInvocation: Invocation?,
+                                       contexts: [UUID: MockingContext]) throws {
+  let allInvocations = getAllInvocations(in: contexts, after: baseInvocation)
+  
+  // Failure if the first invocation in all contexts doesn't match the first expectation.
+  if let firstInvocation = allInvocations.first, firstInvocation != capturedExpectation.invocation {
+    let endIndex = allInvocations.firstIndex(where: { $0 == capturedExpectation.invocation })
+      ?? allInvocations.endIndex
+    let unexpectedInvocations = Array(allInvocations[allInvocations.startIndex..<endIndex])
+    
+    let failure = TestFailure.unexpectedInvocations(
+      baseInvocation: capturedExpectation.invocation,
+      unexpectedInvocations: unexpectedInvocations,
+      priorToBase: true
+    )
+    throw ExpectationGroup.Failure(error: failure,
+                                   sourceLocation: capturedExpectation.expectation.sourceLocation)
+  }
+}
+
+private func assertNoInvocationsAfter(_ capturedExpectation: CapturedExpectation,
+                                      baseInvocation: Invocation?,
+                                      contexts: [UUID: MockingContext]) throws {
+  let allInvocations = getAllInvocations(in: contexts, after: baseInvocation)
+  guard !allInvocations.isEmpty else { return }
+  
+  let failure = TestFailure.unexpectedInvocations(
+    baseInvocation: capturedExpectation.invocation,
+    unexpectedInvocations: allInvocations,
+    priorToBase: false
+  )
+  throw ExpectationGroup.Failure(error: failure,
+                                 sourceLocation: capturedExpectation.expectation.sourceLocation)
+}
+
+
+private struct Solution {
+  let firstInvocation: Invocation?
+  let lastInvocation: Invocation?
+  
+  enum Failure: Error {
+    case unsatisfiable
+  }
+}
+
+private func satisfy(_ capturedExpectations: [CapturedExpectation],
+                     at index: Int = 0,
+                     baseInvocation: Invocation? = nil,
+                     contexts: [UUID: MockingContext],
+                     options: OrderedVerificationOptions) throws -> Solution {
+  let capturedExpectation = capturedExpectations[index]
+  let allInvocations = findInvocations(in: capturedExpectation.mockingContext,
+                                       with: capturedExpectation.invocation.selectorName,
+                                       before: nil,
+                                       after: baseInvocation)
+  var nextInvocationIndex = 1
+  
+  while true {
+    if options.contains(.onlyConsecutiveInvocations), baseInvocation != nil {
+      try assertNoInvocationsBefore(capturedExpectation,
+                                    baseInvocation: baseInvocation,
+                                    contexts: contexts)
+    }
+
+    do {
+      // Try to satisfy the current expectations.
+      let allInvocations = try expect(capturedExpectation.mockingContext,
+                                      handled: capturedExpectation.invocation,
+                                      using: capturedExpectation.expectation,
+                                      before: allInvocations.get(nextInvocationIndex),
+                                      after: baseInvocation)
+      guard index+1 < capturedExpectations.count else { // Found a solution!
+        return Solution(firstInvocation: allInvocations.first, lastInvocation: allInvocations.last)
+      }
+      
+      // Potential match with the current base invocation, try satisfying the next expectation.
+      let allMatchingInvocations = allInvocations.filter({ $0 == capturedExpectation.invocation })
+      let result = try satisfy(capturedExpectations,
+                               at: index+1,
+                               baseInvocation: allMatchingInvocations.first,
+                               contexts: contexts,
+                               options: options)
+      
+      // Check if still satisfiable when using the next invocation as a constraint.
+      if let nextBaseInvocation = result.firstInvocation {
+        try expect(capturedExpectation.mockingContext,
+                   handled: capturedExpectation.invocation,
+                   using: capturedExpectation.expectation,
+                   before: nextBaseInvocation,
+                   after: baseInvocation)
+      }
+      
+      return Solution(firstInvocation: allInvocations.first, lastInvocation: result.lastInvocation)
+    } catch let error as ExpectationGroup.Failure { // Propagate the precondition failure.
+      throw error
+    } catch { // Unable to satisfy the current expectation.
+      guard nextInvocationIndex+1 <= allInvocations.count else {
+        throw Solution.Failure.unsatisfiable // Unable to grow the window further.
+      }
+      nextInvocationIndex += 1 // Grow the invocation window.
+    }
+  }
+}
+
+/// Internal helper for `inOrder` verification scopes.
+///   1. Creates an attributed `DispatchQueue` scope which collects all verifications.
+///   2. Checks invocations on each mock using the provided `options`.
+func createOrderedContext(at sourceLocation: SourceLocation,
+                          options: OrderedVerificationOptions,
+                          block scope: () -> Void) {
+  let group = ExpectationGroup { group in
+    let contexts = group.expectations.reduce(into: [UUID: MockingContext]()) {
+      (result, expectation) in
+      result[expectation.mockingContext.identifier] = expectation.mockingContext
+    }
+    
+    // Check for invocations prior to the first expectation's invocation(s).
+    if options.contains(.noInvocationsBefore), let firstExpectation = group.expectations.first {
+      try assertNoInvocationsBefore(firstExpectation, baseInvocation: nil, contexts: contexts)
+    }
+    
+    do {
+      let result = try satisfy(group.expectations, contexts: contexts, options: options)
+      
+      // Check for invocations after the last expectation's invocation(s).
+      if options.contains(.noInvocationsAfter), let lastExpectation = group.expectations.last {
+        try assertNoInvocationsAfter(lastExpectation,
+                                     baseInvocation: result.lastInvocation,
+                                     contexts: contexts)
+      }
+    } catch let error as ExpectationGroup.Failure {
+      throw error // Propagate wrapped precondition error.
+    } catch _ as Solution.Failure {
+      // It's difficult to clearly determine which expectation is breaking the group, so instead
+      // just throw an error at the group level instead.
+      let allInvocations = getAllInvocations(in: contexts, after: nil)
+      let failure = TestFailure.unsatisfiableExpectations(capturedExpectations: group.expectations,
+                                                          allInvocations: allInvocations)
+      throw ExpectationGroup.Failure(error: failure, sourceLocation: sourceLocation)
+    } catch {
+      fatalError("Unexpected error type") // This shouldn't happen.
+    }
+  }
+  
+  let queue = DispatchQueue(label: "co.bird.mockingbird.ordered-verification-scope")
+  queue.setSpecific(key: Expectation.expectationGroupKey, value: group)
+  queue.sync { scope() }
+  
+  do {
+    try group.verify()
+  } catch let error as ExpectationGroup.Failure {
+    MKBFail(String(describing: error),
+            file: error.sourceLocation.file,
+            line: error.sourceLocation.line)
+  } catch {
+    fatalError("Unexpected error type") // This shouldn't happen.
+  }
+}

--- a/MockingbirdFramework/Verification/TestFailure.swift
+++ b/MockingbirdFramework/Verification/TestFailure.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import XCTest
 
 /// Internal errors thrown due to a failed test assertion or precondition.
 enum TestFailure: Error, CustomStringConvertible {
@@ -15,27 +16,74 @@ enum TestFailure: Error, CustomStringConvertible {
     countMatcher: CountMatcher,
     allInvocations: [Invocation] // All captured invocations matching the selector.
   )
+  case unexpectedInvocations(
+    baseInvocation: Invocation,
+    unexpectedInvocations: [Invocation],
+    priorToBase: Bool // Whether the unexpected invocations happened before the base invocation.
+  )
+  case unsatisfiableExpectations(
+    capturedExpectations: [CapturedExpectation],
+    allInvocations: [Invocation]
+  )
   case missingStubbedImplementation(invocation: Invocation)
 
   var description: String {
     switch self {
-    case let .incorrectInvocationCount(invocationCount, invocation, countMatcher, allInvocations):
-      let countMatcherDescription = countMatcher.describe(invocation: invocation,
-                                                          count: invocationCount)
-      let invocationHistory = allInvocations.isEmpty ? "   No invocations recorded" :
-        allInvocations.enumerated()
-          .map({ "   (\($0.offset+1)) \($0.element)" })
-          .joined(separator: "\n")
+    case let .incorrectInvocationCount(invocationCount,
+                                       invocation,
+                                       countMatcher,
+                                       allInvocations):
+      let countMatcherDescription = countMatcher.describe(invocation: invocation)
       return """
       Got \(invocationCount) invocations of \(invocation) but expected \(countMatcherDescription)
       
       All invocations of '\(invocation.unwrappedSelectorName)':
-      \(invocationHistory)
+      \(allInvocations.indentedDescription)
+      """
+    case let .unexpectedInvocations(baseInvocation, unexpectedInvocations, priorToBase):
+      return """
+      Got unexpected invocations \(priorToBase ? "before" : "after") \(baseInvocation)
+      
+      Invocations:
+      \(unexpectedInvocations.indentedDescription)
+      """
+    case let .unsatisfiableExpectations(capturedExpectations, allInvocations):
+      return """
+      Unable to simultaneously satisfy expectations
+      
+      Expectations:
+      \(capturedExpectations.indentedDescription)
+      
+      All invocations:
+      \(allInvocations.indentedDescription)
       """
     case let .missingStubbedImplementation(invocation):
       return """
       Missing stubbed implementation for \(invocation))
       """
     }
+  }
+}
+
+private extension Array where Element == Invocation {
+  var indentedDescription: String {
+    guard !isEmpty else { return "   No invocations recorded" }
+    return self.enumerated()
+      .map({ "   (\($0.offset+1)) \($0.element)" })
+      .joined(separator: "\n")
+  }
+}
+
+private extension Array where Element == CapturedExpectation {
+  var indentedDescription: String {
+    guard !isEmpty else { return "   No expectations" }
+    return self.enumerated()
+      .map({
+        let capturedExpectation = $0.element
+        let countMatcherDescription = capturedExpectation.expectation.countMatcher
+          .describe(invocation: capturedExpectation.invocation)
+        return "   (\($0.offset+1)) \(capturedExpectation.invocation) called \(countMatcherDescription) times"
+      })
+      .joined(separator: "\n")
   }
 }

--- a/MockingbirdFramework/Verification/XCTFailSwizzler.swift
+++ b/MockingbirdFramework/Verification/XCTFailSwizzler.swift
@@ -1,0 +1,35 @@
+//
+//  XCTFailSwizzler.swift
+//  MockingbirdFramework
+//
+//  Created by Andrew Chang on 3/11/20.
+//
+
+import Foundation
+import XCTest
+
+public protocol TestFailer {
+  func fail(message: String, file: StaticString, line: UInt)
+}
+
+public func swizzleTestFailer(_ newTestFailer: TestFailer) {
+  if Thread.isMainThread {
+    testFailer = newTestFailer
+  } else {
+    DispatchQueue.main.sync { testFailer = newTestFailer }
+  }
+}
+
+public func MKBFail(_ message: String, file: StaticString = #file, line: UInt = #line) {
+  testFailer.fail(message: message, file: file, line: line)
+}
+
+// MARK: - Internal
+
+private class StandardTestFailer: TestFailer {
+  func fail(message: String, file: StaticString, line: UInt) {
+    XCTFail(message, file: file, line: line)
+  }
+}
+
+private var testFailer: TestFailer = StandardTestFailer()

--- a/MockingbirdTests/Framework/OrderedVerificationTests.swift
+++ b/MockingbirdTests/Framework/OrderedVerificationTests.swift
@@ -1,0 +1,195 @@
+//
+//  OrderedVerificationTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/9/20.
+//
+
+import XCTest
+import Mockingbird
+@testable import MockingbirdTestsHost
+
+class OrderedVerificationTests: XCTestCase {
+  
+  var child: ChildMock!
+  
+  override func setUp() {
+    child = mock(Child.self)
+    given(child.childParameterizedInstanceMethod(param1: any(), any())) ~> true
+  }
+  
+  // MARK: - Relative ordering
+  
+  func testRelativeOrderVerification_trivialComparison() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingBefore() {
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingBetween() {
+    (child as Child).childTrivialInstanceMethod()
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_multipleSameInvocationsBefore() {
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_multipleSameInvocationsAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesExactCountMatcher() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(twice)
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtLeastCountMatcher() {
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtMostCountMatcher() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(atMost(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesCompoundCountMatcher() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(not(once).and(not(twice)))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  
+  // MARK: - Only consecutive invocations
+  
+  func testOnlyConsecutiveInvocations() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .onlyConsecutiveInvocations) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testOnlyConsecutiveInvocations_paddingBefore() {
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .onlyConsecutiveInvocations) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testOnlyConsecutiveInvocations_paddingAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    inOrder(with: .onlyConsecutiveInvocations) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+}

--- a/MockingbirdTests/Framework/Utilities/XFailBaseTestCase.swift
+++ b/MockingbirdTests/Framework/Utilities/XFailBaseTestCase.swift
@@ -1,0 +1,25 @@
+//
+//  XFailBaseTestCase.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/11/20.
+//
+
+import Foundation
+import XCTest
+import Mockingbird
+
+class XFailBaseTestCase: XCTestCase {
+  private var testFailer: XFailTestFailer!
+  var expectedFailures: Int? = nil
+  
+  override func setUp() {
+    super.setUp()
+    testFailer = XFailTestFailer(testCase: self)
+    swizzleTestFailer(testFailer)
+  }
+
+  override func tearDown() {
+    testFailer.verify(expectedFailures: 1)
+  }
+}

--- a/MockingbirdTests/Framework/Utilities/XFailTestFailer.swift
+++ b/MockingbirdTests/Framework/Utilities/XFailTestFailer.swift
@@ -1,0 +1,55 @@
+//
+//  XFailTestFailer.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/11/20.
+//
+
+import Foundation
+import Mockingbird
+import XCTest
+
+class XFailTestFailer: TestFailer {
+  private var failures = [String]()
+  
+  private let sourceLocation: (file: String, line: Int)
+  private let testCase: XCTestCase
+  
+  init(file: String = #file, line: Int = #line, testCase: XCTestCase) {
+    self.sourceLocation = (file, line)
+    self.testCase = testCase
+  }
+  
+  func fail(message: String, file: StaticString, line: UInt) {
+    failures.append(message)
+  }
+  
+  func verify(expectedFailures: Int?) {
+    guard failures.count != (expectedFailures ?? failures.count) else { return }
+    let expectedFailuresDescription: String
+    if let expectedFailures = expectedFailures {
+      expectedFailuresDescription = "\(expectedFailures) failure\(expectedFailures == 1 ? "" : "s")"
+    } else {
+      expectedFailuresDescription = "at least 1 failure"
+    }
+    
+    let allFailures = failures.isEmpty ? "   No failures recorded" :
+      failures.enumerated()
+        .map({ (offset: Int, element: String) in
+          return "(\(offset+1)) =========\n\(element)"
+        })
+        .joined(separator: "\n\n")
+    
+    let description = """
+    Expected \(expectedFailuresDescription) but got \(failures.count)
+    
+    All failures:
+    \(allFailures)
+    """
+    
+    testCase.recordFailure(withDescription: description,
+                           inFile: sourceLocation.file,
+                           atLine: sourceLocation.line,
+                           expected: true)
+  }
+}

--- a/MockingbirdTests/Framework/XFailOrderedVerificationTests.swift
+++ b/MockingbirdTests/Framework/XFailOrderedVerificationTests.swift
@@ -1,0 +1,264 @@
+//
+//  XFailOrderedVerificationTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 3/12/20.
+//
+
+import XCTest
+import Mockingbird
+@testable import MockingbirdTestsHost
+
+class XFailOrderedVerificationTests: XFailBaseTestCase {
+  
+  var child: ChildMock!
+  
+  override func setUp() {
+    super.setUp()
+    expectedFailures = 1
+    
+    child = mock(Child.self)
+    given(child.childParameterizedInstanceMethod(param1: any(), any())) ~> true
+  }
+  
+  // MARK: - Relative ordering
+  
+  func testRelativeOrderVerification_trivialComparison() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingBefore() {
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingBetween() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_trivialComparisonWithPaddingAfter() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_multipleSameInvocationsBefore() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_multipleSameInvocationsAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesExactCountMatcher() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(twice)
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtLeastCountMatcher() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtLeastCountMatcher_validPaddingBefore() {
+    // Padding
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtLeastCountMatcher_validPaddingBetween() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childTrivialInstanceMethod()).wasCalled(atLeast(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtMostCountMatcher() {
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(atMost(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testRelativeOrderVerification_handlesAtMostCountMatcher_validPaddingBefore() {
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    (child as Child).childTrivialInstanceMethod()
+    
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder {
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+      verify(child.childTrivialInstanceMethod()).wasCalled(atMost(twice))
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  
+  // MARK: - Only consecutive invocations
+  
+  func testOnlyConsecutiveInvocations_paddingBetween() {
+    (child as Child).childTrivialInstanceMethod()
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .onlyConsecutiveInvocations) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  
+  // MARK: - No invocations before
+  
+  func testNoInvocationsBefore_arbitraryPaddingBefore() {
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .noInvocationsBefore) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testNoInvocationsBefore_validPaddingBefore() {
+    // Padding
+    (child as Child).childTrivialInstanceMethod()
+    
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .noInvocationsBefore) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  
+  // MARK: - No invocations after
+  
+  func testNoInvocationsBefore_arbitraryPaddingAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: false, 1337))
+    
+    inOrder(with: .noInvocationsAfter) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+  
+  func testNoInvocationsBefore_validPaddingAfter() {
+    (child as Child).childTrivialInstanceMethod()
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    // Padding
+    XCTAssertTrue((child as Child).childParameterizedInstanceMethod(param1: true, 42))
+    
+    inOrder(with: .noInvocationsAfter) {
+      verify(child.childTrivialInstanceMethod()).wasCalled()
+      verify(child.childParameterizedInstanceMethod(param1: true, 42)).wasCalled()
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -266,6 +266,16 @@ verify(bird.setName(nameCaptor.matcher)).wasCalled()
 assert(nameCaptor.value?.hasPrefix("R"))
 ```
 
+To enforce the relative order of invocations, use an `inOrder` block.
+
+```swift
+// Check that `fly` was called before `chirp`
+inOrder {
+  verify(bird.fly()).wasCalled()
+  verify(bird.chirp()).wasCalled()
+}
+```
+
 You can test asynchronous code by using an `eventually` block which returns an `XCTestExpectation`. 
 
 ```swift


### PR DESCRIPTION
(Stack 2 of 2)

Closes #48

- Refactor `AsyncVerificationGroup` into generalized `ExpectationGroup`
- Add `inOrder` verification group to DSL
- Add XFail infrastructure for asserting test cases should emit XCTFail

Basic example usage of `inOrder`:

```swift
// Given
let bird = mock(Bird.self)

// When
(bird as Bird).fly()
(bird as Bird).chirp()

// Then
inOrder {
  verify(bird.fly()).wasCalled()
  verify(bird.chirp()).wasCalled()
}
```

Ordered verification is greedy, so the following would _fail_:

```swift
// Given
let bird = mock(Bird.self)

// When
(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).fly()

(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).chirp()
(bird as Bird).fly()

// Then
inOrder {
  verify(bird.fly()).wasCalled()
  verify(bird.chirp()).wasCalled(twice)
  verify(bird.fly()).wasCalled()
}
```

But swap the invocation blocks, and the previous example will now pass:

```swift
// Given
let bird = mock(Bird.self)

// When
(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).chirp()
(bird as Bird).fly()

(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).fly()

// Then
inOrder {
  verify(bird.fly()).wasCalled()
  verify(bird.chirp()).wasCalled(twice)
  verify(bird.fly()).wasCalled()
}
```

For stricter checks, you can pass options to limit the acceptable invocations before, after, and in-between verifications. The following example would fail:

```swift
// Given
let bird = mock(Bird.self)

// When
(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).fly()

// Then
inOrder(with: .noInvocationsAfter) {
  verify(bird.fly()).wasCalled()
  verify(bird.chirp()).wasCalled()
}
```

In order verification also respects invocation count matchers, including inequalities and compound operators:

```swift
// Given
let bird = mock(Bird.self)

// When
(bird as Bird).fly()
(bird as Bird).chirp()
(bird as Bird).chirp()
(bird as Bird).chirp()
(bird as Bird).fly()

// Then
inOrder {
  verify(bird.fly()).wasCalled(atLeast(once))
  verify(bird.chirp()).wasCalled(not(once).and(not(twice)))
  verify(bird.fly()).wasCalled(atMost(twice))
}
```

It's also possible to nest asynchronous and ordered verification blocks like so:

```swift
// Given
let bird = mock(Bird.self)

// When
queue.async {
  (bird as Bird).fly()
  (bird as Bird).chirp()
}

// Then
let expectation =
eventually {
  inOrder {
    verify(bird.fly()).wasCalled()
    verify(bird.chirp()).wasCalled()
  }
}
wait(for: [expectation], timeout: 1.0)
```