### PR TITLE
Specialize members inherited from generic classes

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		D3E4CFDB240DB1B40047BBEC /* CountMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */; };
 		D3E4CFDD240F3D970047BBEC /* FloatingPointMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */; };
 		D3F076DA240214AD002461E7 /* Attributes+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */; };
+		D3F2F45B242CB5CB000F3ECA /* Specializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F2F45A242CB5CB000F3ECA /* Specializable.swift */; };
 		OBJ_1002 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* SWXMLHash.swift */; };
 		OBJ_1003 /* XMLIndexer+XMLIndexerDeserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* XMLIndexer+XMLIndexerDeserializable.swift */; };
 		OBJ_1004 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* shim.swift */; };
@@ -1021,6 +1022,7 @@
 		D3E4CFDA240DB1B40047BBEC /* CountMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountMatcherTests.swift; sourceTree = "<group>"; };
 		D3E4CFDC240F3D970047BBEC /* FloatingPointMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPointMatcherTests.swift; sourceTree = "<group>"; };
 		D3F076D9240214AD002461E7 /* Attributes+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attributes+Sanitize.swift"; sourceTree = "<group>"; };
+		D3F2F45A242CB5CB000F3ECA /* Specializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Specializable.swift; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdGenerator::Product" /* MockingbirdGenerator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockingbirdGenerator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2830,6 +2832,7 @@
 				D35B2BE4242AED9D001AC612 /* Parser */,
 				OBJ_64 /* GenericType.swift */,
 				OBJ_65 /* Method.swift */,
+				D3F2F45A242CB5CB000F3ECA /* Specializable.swift */,
 				49732AEF232F322B0090E1A9 /* MethodParameter.swift */,
 				OBJ_66 /* MockableType.swift */,
 				OBJ_67 /* Primitives.swift */,
@@ -4037,6 +4040,7 @@
 				49BA452A23415F6A002BD9B5 /* String+SHA1.swift in Sources */,
 				49F60AA123305F5A00B51A7C /* Log.swift in Sources */,
 				OBJ_748 /* ExtractSourcesOperation.swift in Sources */,
+				D3F2F45B242CB5CB000F3ECA /* Specializable.swift in Sources */,
 				OBJ_749 /* ParseFilesOperation.swift in Sources */,
 				OBJ_750 /* ProcessTypesOperation.swift in Sources */,
 				OBJ_751 /* InferType.swift in Sources */,

--- a/MockingbirdGenerator/Parser/Models/Parser/Single.swift
+++ b/MockingbirdGenerator/Parser/Models/Parser/Single.swift
@@ -31,6 +31,13 @@ indirect enum Single: CustomStringConvertible, CustomDebugStringConvertible, Ser
     }
   }
   
+  var genericTypes: [DeclaredType] {
+    switch self {
+    case .generic(_, _, let genericTypes): return genericTypes
+    case .list, .map, .function: return []
+    }
+  }
+  
   var description: String {
     switch self {
     case let .generic(typeName, qualification, genericTypes):

--- a/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -96,6 +96,16 @@ class RawType {
   }
 }
 
+extension RawType: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(fullyQualifiedModuleName)
+  }
+  
+  static func == (lhs: RawType, rhs: RawType) -> Bool {
+    return lhs.fullyQualifiedModuleName == rhs.fullyQualifiedModuleName
+  }
+}
+
 extension Array where Element == RawType {
   /// Given an array of partial `RawType` objects, return the root declaration (not an extension).
   func findBaseRawType() -> RawType? {

--- a/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
+++ b/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
@@ -42,6 +42,7 @@ struct SerializationRequest {
     let rawTypeRepository: RawTypeRepository?
     let typealiasRepository: TypealiasRepository?
     let genericTypeContext: [[String]]
+    
     init(moduleNames: [String],
          referencingModuleName: String?,
          containingTypeNames: ArraySlice<String>,
@@ -69,6 +70,23 @@ struct SerializationRequest {
                 rawTypeRepository: rawTypeRepository,
                 typealiasRepository: typealiasRepository,
                 genericTypeContext: rawType.genericTypeContext + [rawType.genericTypes])
+    }
+    
+    convenience init(from context: Context,
+                     moduleNames: [String]? = nil,
+                     referencingModuleName: String? = nil,
+                     containingTypeNames: ArraySlice<String>? = nil,
+                     containingScopes: ArraySlice<String>? = nil,
+                     rawTypeRepository: RawTypeRepository? = nil,
+                     typealiasRepository: TypealiasRepository? = nil,
+                     genericTypeContext: [[String]]? = nil) {
+      self.init(moduleNames: moduleNames ?? context.moduleNames,
+                referencingModuleName: referencingModuleName ?? context.referencingModuleName,
+                containingTypeNames: containingTypeNames ?? context.containingTypeNames,
+                containingScopes: containingScopes ?? context.containingScopes,
+                rawTypeRepository: rawTypeRepository ?? context.rawTypeRepository,
+                typealiasRepository: typealiasRepository ?? context.typealiasRepository,
+                genericTypeContext: genericTypeContext ?? context.genericTypeContext)
     }
     
     convenience init() {

--- a/MockingbirdGenerator/Parser/Models/Specializable.swift
+++ b/MockingbirdGenerator/Parser/Models/Specializable.swift
@@ -1,0 +1,32 @@
+//
+//  Specializable.swift
+//  MockingbirdGenerator
+//
+//  Created by Andrew Chang on 3/26/20.
+//
+
+import Foundation
+
+struct SpecializationContext {
+  /// Mapping from generic type name to a serializable `DeclaredType`
+  let specializations: [String: DeclaredType]
+  
+  /// Ordered list of the remapped generic types.
+  let typeList: [DeclaredType]
+}
+
+protocol Specializable {
+  /// Perform class-level specialization on all referenced types.
+  /// - Parameter context: Context for specializing generic type names.
+  /// - Parameter moduleNames: Module names referenced from this context.
+  /// - Parameter genericTypeContext: Additional generic type context from referencing type.
+  /// - Parameter excludedGenericTypeNames: Generic type names that should not be specialized.
+  /// - Parameter rawTypeRepository: Raw types used for resolving nominal type specializations.
+  /// - Parameter typealiasRepository: Type aliases used for resolving nominal type specializations.
+  func specialize(using context: SpecializationContext,
+                  moduleNames: [String],
+                  genericTypeContext: [[String]],
+                  excludedGenericTypeNames: Set<String>,
+                  rawTypeRepository: RawTypeRepository,
+                  typealiasRepository: TypealiasRepository) -> Self
+}

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -18,6 +18,74 @@ import Swift
 
 private var genericTypesStaticMocks = Mockingbird.Synchronized<[String: Mockingbird.StaticMock]>([:])
 
+// MARK: - Mocked AbstractSpecializedGenericProtocol
+
+public final class AbstractSpecializedGenericProtocolMock<EquatableType: Swift.Equatable>: MockingbirdTestsHost.GenericBaseClass<Bool>, MockingbirdTestsHost.AbstractSpecializedGenericProtocol, Mockingbird.Mock {
+  static var staticMock: Mockingbird.StaticMock {
+    let runtimeGenericTypeNames = ["\(EquatableType.self)"].joined(separator: ",")
+    let staticMockIdentifier = "AbstractSpecializedGenericProtocolMock<EquatableType: Swift.Equatable>," + runtimeGenericTypeNames
+    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    let staticMock = Mockingbird.StaticMock()
+    genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
+    return staticMock
+  }
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      AbstractSpecializedGenericProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: Bool)
+
+  public override func `baseMethod`(`param`: Bool) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (Bool) -> Bool {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.AbstractSpecializedGenericProtocol` concrete protocol mock instance.
+public func mock<EquatableType: Swift.Equatable>(file: StaticString = #file, line: UInt = #line, _ type: AbstractSpecializedGenericProtocolMock<EquatableType>.Type) -> AbstractSpecializedGenericProtocolMock<EquatableType> {
+  return AbstractSpecializedGenericProtocolMock<EquatableType>(sourceLocation: SourceLocation(file, line))
+}
+
 // MARK: - Mocked ArgumentMatchingProtocol
 
 public final class ArgumentMatchingProtocolMock: MockingbirdTestsHost.ArgumentMatchingProtocol, Mockingbird.Mock {
@@ -4056,6 +4124,74 @@ public func mock(file: StaticString = #file, line: UInt = #line, _ type: Mocking
   return ConformingUninitializableOpenClassConstrainedProtocolMock.InitializerProxy.self
 }
 
+// MARK: - Mocked ConstrainedUnspecializedGenericSubclass
+
+public final class ConstrainedUnspecializedGenericSubclassMock<T: Swift.Equatable>: MockingbirdTestsHost.ConstrainedUnspecializedGenericSubclass<T>, Mockingbird.Mock {
+  static var staticMock: Mockingbird.StaticMock {
+    let runtimeGenericTypeNames = ["\(T.self)"].joined(separator: ",")
+    let staticMockIdentifier = "ConstrainedUnspecializedGenericSubclassMock<T: Swift.Equatable>," + runtimeGenericTypeNames
+    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    let staticMock = Mockingbird.StaticMock()
+    genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
+    return staticMock
+  }
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ConstrainedUnspecializedGenericSubclassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: T {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> T)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: T)
+
+  public override func `baseMethod`(`param`: T) -> T {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (T) -> T {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> T)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.ConstrainedUnspecializedGenericSubclass<T>` concrete class mock instance.
+public func mock<T: Swift.Equatable>(file: StaticString = #file, line: UInt = #line, _ type: ConstrainedUnspecializedGenericSubclassMock<T>.Type) -> ConstrainedUnspecializedGenericSubclassMock<T> {
+  return ConstrainedUnspecializedGenericSubclassMock<T>(sourceLocation: SourceLocation(file, line))
+}
+
 // MARK: - Mocked ConvenienceInitializerClass
 
 public final class ConvenienceInitializerClassMock: MockingbirdTestsHost.ConvenienceInitializerClass, Mockingbird.Mock {
@@ -7163,6 +7299,21 @@ public final class GenericBaseClassMock<T>: MockingbirdTestsHost.GenericBaseClas
       stubbingContext.sourceLocation = newValue
       GenericBaseClassMock.staticMock.stubbingContext.sourceLocation = newValue
     }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: T {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> T)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T>(mock: self, invocation: invocation)
   }
 
   fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
@@ -12822,40 +12973,42 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
     self.sourceLocation = sourceLocation
   }
 
-  // MARK: Mocked `shadowedClassScope`()
+  // MARK: Mocked `shadowedClassScope`(`param`: ShadowedType)
 
-  public override func `shadowedClassScope`() -> ShadowedType {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
+  public override func `shadowedClassScope`(`param`: ShadowedType) -> ShadowedType {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? () -> ShadowedType {
-      return concreteImplementation()
+    if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+      return concreteImplementation(`param`)
     } else {
       return (implementation as! () -> ShadowedType)()
     }
   }
 
-  public func `shadowedClassScope`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+  public func `shadowedClassScope`(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
   }
 
-  // MARK: Mocked `shadowedFunctionScope`<ShadowedType>()
+  // MARK: Mocked `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType)
 
-  public override func `shadowedFunctionScope`<ShadowedType>() -> ShadowedType {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
+  public override func `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
     mockingContext.didInvoke(invocation)
     let implementation = stubbingContext.implementation(for: invocation, optional: false)
-    if let concreteImplementation = implementation as? () -> ShadowedType {
-      return concreteImplementation()
+    if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+      return concreteImplementation(`param`)
     } else {
       return (implementation as! () -> ShadowedType)()
     }
   }
 
-  public func `shadowedFunctionScope`<ShadowedType>() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
-    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+  public func `shadowedFunctionScope`<ShadowedType>(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
   }
 
   // MARK: - Mocked NestedShadowedGenericType
@@ -12886,40 +13039,42 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
       self.sourceLocation = sourceLocation
     }
 
-    // MARK: Mocked `shadowedClassScope`()
+    // MARK: Mocked `shadowedClassScope`(`param`: ShadowedType)
 
-    public override func `shadowedClassScope`() -> ShadowedType {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
+    public override func `shadowedClassScope`(`param`: ShadowedType) -> ShadowedType {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
       mockingContext.didInvoke(invocation)
       let implementation = stubbingContext.implementation(for: invocation, optional: false)
-      if let concreteImplementation = implementation as? () -> ShadowedType {
-        return concreteImplementation()
+      if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+        return concreteImplementation(`param`)
       } else {
         return (implementation as! () -> ShadowedType)()
       }
     }
 
-    public func `shadowedClassScope`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
-      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+    public func `shadowedClassScope`(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+      let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
     }
 
-    // MARK: Mocked `shadowedFunctionScope`<ShadowedType>()
+    // MARK: Mocked `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType)
 
-    public override func `shadowedFunctionScope`<ShadowedType>() -> ShadowedType {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
+    public override func `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
       mockingContext.didInvoke(invocation)
       let implementation = stubbingContext.implementation(for: invocation, optional: false)
-      if let concreteImplementation = implementation as? () -> ShadowedType {
-        return concreteImplementation()
+      if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+        return concreteImplementation(`param`)
       } else {
         return (implementation as! () -> ShadowedType)()
       }
     }
 
-    public func `shadowedFunctionScope`<ShadowedType>() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
-      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+    public func `shadowedFunctionScope`<ShadowedType>(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+      let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
     }
   }
 
@@ -12951,40 +13106,42 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
       self.sourceLocation = sourceLocation
     }
 
-    // MARK: Mocked `shadowedClassScope`()
+    // MARK: Mocked `shadowedClassScope`(`param`: ShadowedType)
 
-    public override func `shadowedClassScope`() -> ShadowedType {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
+    public override func `shadowedClassScope`(`param`: ShadowedType) -> ShadowedType {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
       mockingContext.didInvoke(invocation)
       let implementation = stubbingContext.implementation(for: invocation, optional: false)
-      if let concreteImplementation = implementation as? () -> ShadowedType {
-        return concreteImplementation()
+      if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+        return concreteImplementation(`param`)
       } else {
         return (implementation as! () -> ShadowedType)()
       }
     }
 
-    public func `shadowedClassScope`() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`() -> ShadowedType", arguments: [])
-      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+    public func `shadowedClassScope`(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+      let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
     }
 
-    // MARK: Mocked `shadowedFunctionScope`<ShadowedType>()
+    // MARK: Mocked `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType)
 
-    public override func `shadowedFunctionScope`<ShadowedType>() -> ShadowedType {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
+    public override func `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
       mockingContext.didInvoke(invocation)
       let implementation = stubbingContext.implementation(for: invocation, optional: false)
-      if let concreteImplementation = implementation as? () -> ShadowedType {
-        return concreteImplementation()
+      if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+        return concreteImplementation(`param`)
       } else {
         return (implementation as! () -> ShadowedType)()
       }
     }
 
-    public func `shadowedFunctionScope`<ShadowedType>() -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType> {
-      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>() -> ShadowedType", arguments: [])
-      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, () -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+    public func `shadowedFunctionScope`<ShadowedType>(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+      let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+      return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
     }
   }
 }
@@ -13002,6 +13159,258 @@ public func mock<ShadowedGenericType_ShadowedType>(file: StaticString = #file, l
 /// Create a source-attributed `NestedDoublyShadowedGenericType<ShadowedType>` concrete class mock instance.
 public func mock<ShadowedGenericType_ShadowedType, ShadowedType>(file: StaticString = #file, line: UInt = #line, _ type: ShadowedGenericTypeMock<ShadowedGenericType_ShadowedType>.NestedDoublyShadowedGenericTypeMock<ShadowedType>.Type) -> ShadowedGenericTypeMock<ShadowedGenericType_ShadowedType>.NestedDoublyShadowedGenericTypeMock<ShadowedType> {
   return ShadowedGenericTypeMock<ShadowedGenericType_ShadowedType>.NestedDoublyShadowedGenericTypeMock<ShadowedType>(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked SpecializedGenericProtocol
+
+public final class SpecializedGenericProtocolMock: MockingbirdTestsHost.GenericBaseClass<Bool>, MockingbirdTestsHost.SpecializedGenericProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SpecializedGenericProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: Bool)
+
+  public override func `baseMethod`(`param`: Bool) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (Bool) -> Bool {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.SpecializedGenericProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.SpecializedGenericProtocol.Protocol) -> SpecializedGenericProtocolMock {
+  return SpecializedGenericProtocolMock(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked SpecializedGenericSubclass
+
+public final class SpecializedGenericSubclassMock: MockingbirdTestsHost.SpecializedGenericSubclass, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SpecializedGenericSubclassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> Bool)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: Bool)
+
+  public override func `baseMethod`(`param`: Bool) -> Bool {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (Bool) -> Bool {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> Bool)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: Bool) -> Bool", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (Bool) -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.SpecializedGenericSubclass` concrete class mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.SpecializedGenericSubclass.Type) -> SpecializedGenericSubclassMock {
+  return SpecializedGenericSubclassMock(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked SpecializedShadowedGenericProtocol
+
+public final class SpecializedShadowedGenericProtocolMock: MockingbirdTestsHost.ShadowedGenericType<MockingbirdTestsHost.NSObject>, MockingbirdTestsHost.SpecializedShadowedGenericProtocol, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SpecializedShadowedGenericProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject)
+
+  public override func `shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> MockingbirdTestsHost.NSObject)()
+    }
+  }
+
+  public func `shadowedClassScope`(`param`: @escaping @autoclosure () -> MockingbirdTestsHost.NSObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject, MockingbirdTestsHost.NSObject> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject, MockingbirdTestsHost.NSObject>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType)
+
+  public override func `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> ShadowedType)()
+    }
+  }
+
+  public func `shadowedFunctionScope`<ShadowedType>(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.SpecializedShadowedGenericProtocol` concrete protocol mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.SpecializedShadowedGenericProtocol.Protocol) -> SpecializedShadowedGenericProtocolMock {
+  return SpecializedShadowedGenericProtocolMock(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked SpecializedShadowedGenericSubclass
+
+public final class SpecializedShadowedGenericSubclassMock: MockingbirdTestsHost.SpecializedShadowedGenericSubclass, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SpecializedShadowedGenericSubclassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject)
+
+  public override func `shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> MockingbirdTestsHost.NSObject)()
+    }
+  }
+
+  public func `shadowedClassScope`(`param`: @escaping @autoclosure () -> MockingbirdTestsHost.NSObject) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject, MockingbirdTestsHost.NSObject> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedClassScope`(`param`: MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (MockingbirdTestsHost.NSObject) -> MockingbirdTestsHost.NSObject, MockingbirdTestsHost.NSObject>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType)
+
+  public override func `shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (ShadowedType) -> ShadowedType {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> ShadowedType)()
+    }
+  }
+
+  public func `shadowedFunctionScope`<ShadowedType>(`param`: @escaping @autoclosure () -> ShadowedType) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`shadowedFunctionScope`<ShadowedType>(`param`: ShadowedType) -> ShadowedType", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (ShadowedType) -> ShadowedType, ShadowedType>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.SpecializedShadowedGenericSubclass` concrete class mock instance.
+public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.SpecializedShadowedGenericSubclass.Type) -> SpecializedShadowedGenericSubclassMock {
+  return SpecializedShadowedGenericSubclassMock(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked SubclassingExternalClassWithDesignatedIntializer
@@ -15203,6 +15612,142 @@ public final class UndefinedArgumentLabelsMock: MockingbirdTestsHost.UndefinedAr
 /// Create a source-attributed `MockingbirdTestsHost.UndefinedArgumentLabels` concrete protocol mock instance.
 public func mock(file: StaticString = #file, line: UInt = #line, _ type: MockingbirdTestsHost.UndefinedArgumentLabels.Protocol) -> UndefinedArgumentLabelsMock {
   return UndefinedArgumentLabelsMock(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked UnspecializedGenericSubclass
+
+public final class UnspecializedGenericSubclassMock<T>: MockingbirdTestsHost.UnspecializedGenericSubclass<T>, Mockingbird.Mock {
+  static var staticMock: Mockingbird.StaticMock {
+    let runtimeGenericTypeNames = ["\(T.self)"].joined(separator: ",")
+    let staticMockIdentifier = "UnspecializedGenericSubclassMock<T>," + runtimeGenericTypeNames
+    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    let staticMock = Mockingbird.StaticMock()
+    genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
+    return staticMock
+  }
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      UnspecializedGenericSubclassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: T {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> T)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: T)
+
+  public override func `baseMethod`(`param`: T) -> T {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (T) -> T {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> T)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.UnspecializedGenericSubclass<T>` concrete class mock instance.
+public func mock<T>(file: StaticString = #file, line: UInt = #line, _ type: UnspecializedGenericSubclassMock<T>.Type) -> UnspecializedGenericSubclassMock<T> {
+  return UnspecializedGenericSubclassMock<T>(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked UnspecializedMultipleGenericSubclass
+
+public final class UnspecializedMultipleGenericSubclassMock<T, R>: MockingbirdTestsHost.UnspecializedMultipleGenericSubclass<T, R>, Mockingbird.Mock {
+  static var staticMock: Mockingbird.StaticMock {
+    let runtimeGenericTypeNames = ["\(R.self)", "\(T.self)"].joined(separator: ",")
+    let staticMockIdentifier = "UnspecializedMultipleGenericSubclassMock<T, R>," + runtimeGenericTypeNames
+    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    let staticMock = Mockingbird.StaticMock()
+    genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
+    return staticMock
+  }
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.10.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      UnspecializedMultipleGenericSubclassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked baseVariable
+
+  override public var `baseVariable`: T {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+      mockingContext.didInvoke(invocation)
+      return (stubbingContext.implementation(for: invocation) as! () -> T)()
+    }
+  }
+
+  public func getBaseVariable() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "baseVariable.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> T, T>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    super.init()
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `baseMethod`(`param`: T)
+
+  public override func `baseMethod`(`param`: T) -> T {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+    let implementation = stubbingContext.implementation(for: invocation, optional: false)
+    if let concreteImplementation = implementation as? (T) -> T {
+      return concreteImplementation(`param`)
+    } else {
+      return (implementation as! () -> T)()
+    }
+  }
+
+  public func `baseMethod`(`param`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`param`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`baseMethod`(`param`: T) -> T", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T, T>(mock: self, invocation: invocation)
+  }
+}
+
+/// Create a source-attributed `MockingbirdTestsHost.UnspecializedMultipleGenericSubclass<T, R>` concrete class mock instance.
+public func mock<T, R>(file: StaticString = #file, line: UInt = #line, _ type: UnspecializedMultipleGenericSubclassMock<T, R>.Type) -> UnspecializedMultipleGenericSubclassMock<T, R> {
+  return UnspecializedMultipleGenericSubclassMock<T, R>(sourceLocation: SourceLocation(file, line))
 }
 
 // MARK: - Mocked VariablesContainerProtocol

--- a/MockingbirdTestsHost/Generics.swift
+++ b/MockingbirdTestsHost/Generics.swift
@@ -128,23 +128,38 @@ public class UnalphabetizedGenericClass<C, B, A> {
 }
 
 public class GenericBaseClass<T> {
+  var baseVariable: T { fatalError() }
   func baseMethod(param: T) -> T { fatalError() }
 }
 
 public struct ShadowedType {}
 
 public class ShadowedGenericType<ShadowedType> {
-  func shadowedClassScope() -> ShadowedType { fatalError() }
-  func shadowedFunctionScope<ShadowedType>() -> ShadowedType { fatalError() }
+  func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
+  func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
   
   public class NestedShadowedGenericType {
-    func shadowedClassScope() -> ShadowedType { fatalError() }
-    func shadowedFunctionScope<ShadowedType>() -> ShadowedType { fatalError() }
+    func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
+    func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
   }
   
   public class NestedDoublyShadowedGenericType<ShadowedType> {
-    func shadowedClassScope() -> ShadowedType { fatalError() }
-    func shadowedFunctionScope<ShadowedType>() -> ShadowedType { fatalError() }
+    func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
+    func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
   }
 }
 
+class SpecializedGenericSubclass: GenericBaseClass<Bool> {}
+protocol SpecializedGenericProtocol: GenericBaseClass<Bool> {}
+protocol AbstractSpecializedGenericProtocol: GenericBaseClass<Bool> {
+  associatedtype EquatableType: Equatable
+}
+
+class SpecializedShadowedGenericSubclass: ShadowedGenericType<NSObject> {}
+protocol SpecializedShadowedGenericProtocol: ShadowedGenericType<NSObject> {}
+
+class UnspecializedGenericSubclass<T>: GenericBaseClass<T> {}
+
+class ConstrainedUnspecializedGenericSubclass<T: Equatable>: GenericBaseClass<T> {}
+
+class UnspecializedMultipleGenericSubclass<T, R>: GenericBaseClass<T> {}


### PR DESCRIPTION
Fixes #62

Generic type specialization requires mapping from some declared generic type parameter to another type, e.g. mapping `T` to `Bool`:

```swift
// Subclass implicitly has `func method(param: Bool) -> Bool`
class Base<T> {
  func method(param: T) -> T
}
class Subclass: Base<Bool> {}
```

This of course also holds true when mapping to a generic type defined by the subclass instead of a nominal type.

```swift
// Subclass implicitly has `func method(param: R) -> R`
class Base<T> {
  func method(param: T) -> T
}
class Subclass<R>: Base<R> {}
```

With shadowing, mapping to the correct fully qualified type becomes slightly more complex. For example, the generic type from the subclass can shadow valid module-level types.

```swift
class Base<T> {
  func method(param: T) -> T
}
class Subclass<NSObject>: Base<NSObject> {}
```

Function-level generics can also shadow the specialization mapping.

```swift
class Base<T> {
  func method<NSObject>(param: NSObject) -> NSObject
}
class Subclass: Base<NSObject> {}
```

There are also nuances with protocol class conformance to generic class types, specifically around synthesizing the type inheritance clause.