### PR TITLE
Fix compatibility with Swift 5.2

### DIFF
--- a/MockingbirdFramework/Matching/ArgumentMatcher.swift
+++ b/MockingbirdFramework/Matching/ArgumentMatcher.swift
@@ -62,14 +62,7 @@ public class ArgumentMatcher: CustomStringConvertible {
     self.baseType = type(of: base)
     self.priority = priority
     self.comparator = comparator ?? { $0 as AnyObject === $1 as AnyObject }
-    
-    let annotation: String
-    if comparator == nil && base != nil {
-      let memoryAddress = Unmanaged.passUnretained(base as AnyObject).toOpaque()
-      annotation = " (\(memoryAddress))"
-    } else {
-      annotation = ""
-    }
+    let annotation = comparator == nil ? " (by reference)" : ""
     self.description = description ?? "\(String.describe(base))\(annotation)"
   }
   

--- a/MockingbirdGenerator/Parser/Models/Method.swift
+++ b/MockingbirdGenerator/Parser/Models/Method.swift
@@ -47,8 +47,9 @@ struct Method {
     let isInitializer = name.hasPrefix("init(")
     self.isInitializer = isInitializer
     
-    guard let accessLevel = AccessLevel(from: dictionary),
-      accessLevel.isMockableMember(in: rootKind, withinSameModule: rawType.parsedFile.shouldMock)
+    let accessLevel = AccessLevel(from: dictionary) ?? .defaultLevel
+    guard accessLevel.isMockableMember(in: rootKind,
+                                       withinSameModule: rawType.parsedFile.shouldMock)
         || isInitializer && accessLevel.isMockable // Initializers cannot be `open`.
       else { return nil }
     self.accessLevel = accessLevel

--- a/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -64,9 +64,11 @@ class MockableType: Hashable, Comparable {
         rawTypeRepository: RawTypeRepository,
         typealiasRepository: TypealiasRepository) {
     guard let baseRawType = rawTypes.findBaseRawType(),
-      baseRawType.kind.isMockable,
-      let accessLevel = AccessLevel(from: baseRawType.dictionary),
-      accessLevel.isMockableType(withinSameModule: baseRawType.parsedFile.shouldMock)
+      baseRawType.kind.isMockable
+      else { return nil }
+    
+    let accessLevel = AccessLevel(from: baseRawType.dictionary) ?? .defaultLevel
+    guard accessLevel.isMockableType(withinSameModule: baseRawType.parsedFile.shouldMock)
       else { return nil }
     // Handle empty types (declared without any members).
     let substructure = baseRawType.dictionary[SwiftDocKey.substructure.rawValue]

--- a/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
+++ b/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
@@ -192,6 +192,9 @@ enum AccessLevel: String, CustomStringConvertible {
     }
   }
   
+  // In Swift 5.2, SourceKit no longer always returns an explicit access level for all structures.
+  static let defaultLevel = AccessLevel.internal
+  
   init?(from dictionary: StructureDictionary) {
     guard let rawAccessLevel = dictionary[AccessLevel.accessLevelKey] as? String else { return nil }
     self.init(rawValue: rawAccessLevel)

--- a/MockingbirdGenerator/Parser/Models/Variable.swift
+++ b/MockingbirdGenerator/Parser/Models/Variable.swift
@@ -47,9 +47,11 @@ struct Variable: Hashable, Comparable {
         || kind.typeScope == .class
         || (kind.typeScope == .static && rootKind == .protocol) else { return nil }
     
-    guard let name = dictionary[SwiftDocKey.name.rawValue] as? String,
-      let accessLevel = AccessLevel(from: dictionary),
-      accessLevel.isMockableMember(in: rootKind, withinSameModule: rawType.parsedFile.shouldMock)
+    guard let name = dictionary[SwiftDocKey.name.rawValue] as? String else { return nil }
+    
+    let accessLevel = AccessLevel(from: dictionary) ?? .defaultLevel
+    guard accessLevel.isMockableMember(in: rootKind,
+                                       withinSameModule: rawType.parsedFile.shouldMock)
       else { return nil }
     self.accessLevel = accessLevel
     

--- a/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
@@ -75,13 +75,17 @@ class ProcessStructuresOperation: BasicOperation {
     // For inheritance, contained types are stored in the root namespace as fully qualified types.
     containedTypes.forEach({ result.rawTypes.append($0) })
     
-    guard let kind = optionalKind, kind.isParsable,
-      let accessLevel = AccessLevel(from: dictionary), accessLevel.isMockable else { return [] }
+    guard let kind = optionalKind, kind.isParsable else { return [] }
+    
+    let accessLevel = AccessLevel(from: dictionary) ?? .defaultLevel
+    guard accessLevel.isMockable else { return [] }
+    
     let fullyQualifiedName = attributedContainingTypeNames.joined(separator: ".")
     let selfConformanceTypeNames = kind == .protocol
       ? parseSelfConformanceTypeNames(from: dictionary) : []
     let aliasedTypeNames = kind == .typealias
       ? parseAliasedTypeNames(from: dictionary): []
+    
     return [RawType(dictionary: dictionary,
                     name: name,
                     fullyQualifiedName: fullyQualifiedName,

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -1553,6 +1553,62 @@ public final class AssociatedTypeImplementerMock: MockingbirdTestsHost.Associate
     self.sourceLocation = sourceLocation
   }
 
+  #if swift(>=5.2)
+
+  // MARK: Mocked `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T)
+
+  public override func `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Bool, T.HashableType == String {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Bool, T.HashableType == String", arguments: [Mockingbird.ArgumentMatcher(`object`)])
+    return mockingContext.didInvoke(invocation) { () -> T.EquatableType in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (T) -> T.EquatableType {
+        return concreteImplementation(`object`)
+      } else if let concreteImplementation = implementation as? () -> T.EquatableType {
+        return concreteImplementation()
+      } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (T.EquatableType).self) {
+        return defaultValue
+      } else {
+        fatalError(stubbingContext.failTest(for: invocation))
+      }
+    }
+  }
+
+  public func `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T.EquatableType, T.EquatableType> where T.EquatableType == Bool, T.HashableType == String {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`object`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Bool, T.HashableType == String", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T.EquatableType, T.EquatableType>(mock: self, invocation: invocation)
+  }
+
+  #endif
+
+  #if swift(>=5.2)
+
+  // MARK: Mocked `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T)
+
+  public override func `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Int, T.HashableType == String {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Int, T.HashableType == String", arguments: [Mockingbird.ArgumentMatcher(`object`)])
+    return mockingContext.didInvoke(invocation) { () -> T.EquatableType in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (T) -> T.EquatableType {
+        return concreteImplementation(`object`)
+      } else if let concreteImplementation = implementation as? () -> T.EquatableType {
+        return concreteImplementation()
+      } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (T.EquatableType).self) {
+        return defaultValue
+      } else {
+        fatalError(stubbingContext.failTest(for: invocation))
+      }
+    }
+  }
+
+  public func `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: @escaping @autoclosure () -> T) -> Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T.EquatableType, T.EquatableType> where T.EquatableType == Int, T.HashableType == String {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`object`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> T.EquatableType where T.EquatableType == Int, T.HashableType == String", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.MethodDeclaration, (T) -> T.EquatableType, T.EquatableType>(mock: self, invocation: invocation)
+  }
+
+  #endif
+
   // MARK: Mocked `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T)
 
   public override func `request`<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`object`: T) -> Void where T.EquatableType == Int, T.HashableType == String {
@@ -12254,6 +12310,32 @@ public final class InitializerClassMock: MockingbirdTestsHost.InitializerClass, 
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init<T>(`param2`: T) throws where T: MockingbirdTestsHost.AssociatedTypeProtocol ", arguments: [Mockingbird.ArgumentMatcher(`param2`)])
     mockingContext.didInvoke(invocation)
   }
+
+  #if swift(>=5.2)
+
+  // MARK: Mocked init<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`param`: T)
+
+  public required override init<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`param`: T) {
+    super.init(param: `param`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init<T: MockingbirdTestsHost.AssociatedTypeProtocol>(`param`: T) ", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+  }
+
+  #endif
+
+  #if swift(>=5.2)
+
+  // MARK: Mocked init?<T>(`param`: T)
+
+  public required override init?<T>(`param`: T) {
+    super.init(param: `param`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init?<T>(`param`: T) ", arguments: [Mockingbird.ArgumentMatcher(`param`)])
+    mockingContext.didInvoke(invocation)
+  }
+
+  #endif
 
   // MARK: Mocked init?(`param`: Bool)
 

--- a/MockingbirdTests/E2E/GenericsMockableTests.swift
+++ b/MockingbirdTests/E2E/GenericsMockableTests.swift
@@ -32,6 +32,14 @@ extension AssociatedTypeImplementerProtocolMock: MockableAssociatedTypeImplement
 private protocol MockableAssociatedTypeImplementer {
   func request<T: AssociatedTypeProtocol>(object: T)
     where T.EquatableType == Int, T.HashableType == String
+  
+  #if swift(>=5.2) // This was fixed in Swift 5.2
+  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+    where T.EquatableType == Int, T.HashableType == String
+
+  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+    where T.EquatableType == Bool, T.HashableType == String
+  #endif
 }
 extension AssociatedTypeImplementerMock: MockableAssociatedTypeImplementer {}
 
@@ -58,6 +66,7 @@ extension GenericClassReferencerMock: MockableGenericClassReferencer {}
 
 // MARK: Non-mockable declarations
 
+#if swift(<5.2) // This was fixed in Swift 5.2
 private extension AssociatedTypeImplementerMock {
   func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Int, T.HashableType == String { return 1 }
@@ -65,3 +74,4 @@ private extension AssociatedTypeImplementerMock {
   func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Bool, T.HashableType == String { return true }
 }
+#endif


### PR DESCRIPTION
- Access level for extended members returned by SourceKit are no longer explicitly marked as `internal`
- Remove memory address printing for types matched by reference due to bad invocation error when handling optional strings
- Generate generically overloaded methods wrapped in `#if swift(>=5.2)`