### PR TITLE
Fix classes with designated + implicitly synthesized initializers

### DIFF
--- a/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -352,12 +352,13 @@ class MockableType: Hashable, Comparable {
         
         methods = methods.union(mockableType.methods
           .filter({ method in
-            guard shouldInheritFromType || method.attributes.contains(.implicit)
-              else { return false }
+            let isImplicitlySynthesized = method.attributes.contains(.implicit)
+            guard shouldInheritFromType || isImplicitlySynthesized else { return false }
             return method.kind.typeScope.isMockable(in: baseRawType.kind) &&
               // Mocking a subclass with designated initializers shouldn't inherit the superclass'
               // initializers.
               (baseRawType.kind == .protocol
+                || isImplicitlySynthesized
                 || !definesDesignatedInitializer
                 || !method.isInitializer)
           })

--- a/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
+++ b/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
@@ -124,6 +124,9 @@ extension Attributes {
   /// It's necessary to abuse named attributes, e.g. `@objc(anything)` as custom attributes on older
   /// Swift versions results in an error rather than returning `source.decl.attribute._custom`.
   enum CustomAttributeDeclaration: String {
+    /// The method is defined by a protocol and can be synthesized by the Swift compiler. For
+    /// initializers like in `Decodable`, subclasses that define any designated initializers must
+    /// now override the synthesized required initializer.
     case implicit = "@objc(mkb_implicit)"
   }
   

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -19194,6 +19194,59 @@ public func mock(_ type: MockingbirdTestsHost.SubscriptedProtocol.Protocol, file
   return SubscriptedProtocolMock(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked SynthesizedRequiredInitializer
+
+public final class SynthesizedRequiredInitializerMock: MockingbirdTestsHost.SynthesizedRequiredInitializer, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SynthesizedRequiredInitializerMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  public enum InitializerProxy {
+    public static func initialize(`from` `decoder`: Decoder, __file: StaticString = #file, __line: UInt = #line) throws -> SynthesizedRequiredInitializerMock {
+      let mock: SynthesizedRequiredInitializerMock = try SynthesizedRequiredInitializerMock(from: `decoder`)
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+
+    public static func initialize(`with` `name`: String, __file: StaticString = #file, __line: UInt = #line) -> SynthesizedRequiredInitializerMock {
+      let mock: SynthesizedRequiredInitializerMock = SynthesizedRequiredInitializerMock(with: `name`)
+      mock.sourceLocation = SourceLocation(__file, __line)
+      return mock
+    }
+  }
+
+  // MARK: Mocked init(`from` `decoder`: Decoder)
+
+  public required init(`from` `decoder`: Decoder) throws {
+    try super.init(from: `decoder`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init(`from` `decoder`: Decoder) throws ", arguments: [Mockingbird.ArgumentMatcher(`decoder`)])
+    mockingContext.didInvoke(invocation)
+  }
+
+  // MARK: Mocked init(`with` `name`: String)
+
+  public required override init(`with` `name`: String) {
+    super.init(with: `name`)
+    Mockingbird.checkVersion(for: self)
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "init(`with` `name`: String) ", arguments: [Mockingbird.ArgumentMatcher(`name`)])
+    mockingContext.didInvoke(invocation)
+  }
+}
+
+/// Initialize an initializable class mock of `MockingbirdTestsHost.SynthesizedRequiredInitializer`.
+public func mock(_ type: MockingbirdTestsHost.SynthesizedRequiredInitializer.Type, file: StaticString = #file, line: UInt = #line) -> SynthesizedRequiredInitializerMock.InitializerProxy.Type {
+  return SynthesizedRequiredInitializerMock.InitializerProxy.self
+}
+
 // MARK: - Mocked TestCase
 
 public final class TestCaseMock: MockingbirdTestsHost.TestCase, Mockingbird.Mock {

--- a/MockingbirdTestsHost/OpaqueTypes.swift
+++ b/MockingbirdTestsHost/OpaqueTypes.swift
@@ -28,3 +28,8 @@ public class HashableConformingClass: Hashable {
   public func hash(into hasher: inout Hasher) { fatalError() }
 }
 public class CodableConformingClass: Codable {}
+
+/// Defines a designated initializer that should force the mock subclass to implement `Decodable`.
+public class SynthesizedRequiredInitializer: Decodable {
+  init(with name: String) {}
+}


### PR DESCRIPTION
Certain methods like `init(from:)` in `Decodable` can be synthesized by the Swift compiler and don't require explicit conformance. For initializers specifically, these synthesized methods can be inherited by subclasses _unless_ the subclass defines a designated initializer of its own or overrides the superclass' designated initializer.

Fixes #87 