### PR TITLE
Fixed instance var type inference for initialized types

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		49F60A9F232F477100B51A7C /* FlattenInheritanceOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F60A9E232F477100B51A7C /* FlattenInheritanceOperation.swift */; };
 		49F60AA123305F5A00B51A7C /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F60AA023305F5A00B51A7C /* Log.swift */; };
 		5D5FAC84DF438200D4E44D85 /* MockingbirdTestsHostMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93974737AF2D18DBCBCCA8F1 /* MockingbirdTestsHostMocks.generated.swift */; };
+		94854768245230BC00689FA1 /* InferTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94854767245230BC00689FA1 /* InferTypeTests.swift */; };
 		9491824C23F0CE3A00429146 /* KeywordArgumentNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */; };
 		9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */; };
 		9491825023F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */; };
@@ -1022,6 +1023,7 @@
 		49F60A9E232F477100B51A7C /* FlattenInheritanceOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlattenInheritanceOperation.swift; sourceTree = "<group>"; };
 		49F60AA023305F5A00B51A7C /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		93974737AF2D18DBCBCCA8F1 /* MockingbirdTestsHostMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = MockingbirdTestsHostMocks.generated.swift; path = MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift; sourceTree = "<group>"; };
+		94854767245230BC00689FA1 /* InferTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferTypeTests.swift; sourceTree = "<group>"; };
 		9491824B23F0CE3A00429146 /* KeywordArgumentNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNames.swift; sourceTree = "<group>"; };
 		9491824D23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesMockableTests.swift; sourceTree = "<group>"; };
 		9491824F23F0D9B600429146 /* KeywordArgumentNamesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordArgumentNamesStubbableTests.swift; sourceTree = "<group>"; };
@@ -1955,6 +1957,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_186 /* DeclaredTypeTests.swift */,
+				94854767245230BC00689FA1 /* InferTypeTests.swift */,
 				499854532368AD0A0022D413 /* PathFnmatchTests.swift */,
 				3B7716CD2364AE3500B339EB /* PBXTargetTests.swift */,
 				OBJ_187 /* StringExtensionsTests.swift */,
@@ -4198,6 +4201,7 @@
 				3B7716CE2364AE3500B339EB /* PBXTargetTests.swift in Sources */,
 				OBJ_840 /* VariadicParametersStubbableTests.swift in Sources */,
 				OBJ_842 /* ArgumentCaptorTests.swift in Sources */,
+				94854768245230BC00689FA1 /* InferTypeTests.swift in Sources */,
 				OBJ_843 /* ArgumentMatchingTests.swift in Sources */,
 				9491824E23F0D71000429146 /* KeywordArgumentNamesMockableTests.swift in Sources */,
 				499854542368AD0A0022D413 /* PathFnmatchTests.swift in Sources */,

--- a/MockingbirdGenerator/Parser/Sourcery/InferType.swift
+++ b/MockingbirdGenerator/Parser/Sourcery/InferType.swift
@@ -110,7 +110,7 @@ func inferType(from string: String) -> String? {
     }
     
     // get everything before `(`
-    let components = string.components(separatedBy: "(", excluding: .allGroups)
+    let components = string.components(separatedBy: "(", excluding: .nonParenthesisGroups)
     let lastCharacter = string.last
     if components.count > 1 && lastCharacter == ")" {
       //initializer without `init`

--- a/MockingbirdGenerator/Utilities/String+Extensions.swift
+++ b/MockingbirdGenerator/Utilities/String+Extensions.swift
@@ -12,6 +12,10 @@ public extension Dictionary where Key == Character, Value == Character {
   static var allGroups: [Character: Character] {
     return ["(": ")", "[": "]", "<": ">"]
   }
+
+  static var nonParenthesisGroups: [Character: Character] {
+    return ["[": "]", "<": ">"]
+  }
 }
 
 public extension Set where Element == Character {

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -20119,6 +20119,84 @@ public final class VariablesContainerMock: MockingbirdTestsHost.VariablesContain
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
   }
 
+  // MARK: Mocked storedVariableWithComplexConstructedImplicitType
+
+  override public var `storedVariableWithComplexConstructedImplicitType`: Array<(String, String)> {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithComplexConstructedImplicitType.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> Array<(String, String)> in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> Array<(String, String)> {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (Array<(String, String)>).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithComplexConstructedImplicitType.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (Array<(String, String)>) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getStoredVariableWithComplexConstructedImplicitType() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Array<(String, String)>, Array<(String, String)>> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithComplexConstructedImplicitType.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Array<(String, String)>, Array<(String, String)>>(mock: self, invocation: invocation)
+  }
+
+  public func setStoredVariableWithComplexConstructedImplicitType(_ newValue: @escaping @autoclosure () -> Array<(String, String)>) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Array<(String, String)>) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithComplexConstructedImplicitType.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Array<(String, String)>) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked storedVariableWithConstructedImplicitType
+
+  override public var `storedVariableWithConstructedImplicitType`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithConstructedImplicitType.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> Bool in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> Bool {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (Bool).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithConstructedImplicitType.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getStoredVariableWithConstructedImplicitType() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithConstructedImplicitType.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setStoredVariableWithConstructedImplicitType(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithConstructedImplicitType.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
   // MARK: Mocked storedVariableWithExplicitType
 
   override public var `storedVariableWithExplicitType`: Bool {
@@ -20156,6 +20234,45 @@ public final class VariablesContainerMock: MockingbirdTestsHost.VariablesContain
     let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
     let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithExplicitType.set", arguments: arguments)
     return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked storedVariableWithImplicitTupleType
+
+  override public var `storedVariableWithImplicitTupleType`: (Bool, Bool) {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithImplicitTupleType.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> (Bool, Bool) in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> (Bool, Bool) {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: ((Bool, Bool)).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithImplicitTupleType.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? ((Bool, Bool)) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getStoredVariableWithImplicitTupleType() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> (Bool, Bool), (Bool, Bool)> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithImplicitTupleType.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> (Bool, Bool), (Bool, Bool)>(mock: self, invocation: invocation)
+  }
+
+  public func setStoredVariableWithImplicitTupleType(_ newValue: @escaping @autoclosure () -> (Bool, Bool)) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, ((Bool, Bool)) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "storedVariableWithImplicitTupleType.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, ((Bool, Bool)) -> Void, Void>(mock: self, invocation: invocation)
   }
 
   // MARK: Mocked storedVariableWithImplicitType

--- a/MockingbirdTests/E2E/VariablesMockableTests.swift
+++ b/MockingbirdTests/E2E/VariablesMockableTests.swift
@@ -22,7 +22,14 @@ private protocol MockableVariablesContainer: Mock {
   var computedVariableWithWillSetObserver: Bool { get set }
   
   var storedVariableWithImplicitType: Bool { get set }
+  var storedVariableWithImplicitTupleType: (Bool, Bool) { get set }
+  var storedVariableWithConstructedImplicitType: Bool { get set }
+  var storedVariableWithComplexConstructedImplicitType: Array<(String, String)> { get set }
+
   var storedVariableWithExplicitType: Bool { get set }
+
+  var constantVariableWithImplicitType: Bool { get }
+  var constantVariableWithExplicitType: Bool { get }
   
   var weakVariable: VariablesContainer? { get set }
   

--- a/MockingbirdTests/E2E/VariablesStubbableTests.swift
+++ b/MockingbirdTests/E2E/VariablesStubbableTests.swift
@@ -44,7 +44,22 @@ private protocol StubbableVariablesContainer {
     -> Mockable<VariableDeclaration, () -> Bool, Bool>
   func setStoredVariableWithImplicitType(_ newValue: @escaping @autoclosure () -> Bool)
     -> Mockable<VariableDeclaration, (Bool) -> Void, Void>
-  
+
+  func getStoredVariableWithImplicitTupleType()
+    -> Mockable<VariableDeclaration, () -> (Bool, Bool), (Bool, Bool)>
+  func setStoredVariableWithImplicitTupleType(_ newValue: @escaping @autoclosure () -> (Bool, Bool))
+    -> Mockable<VariableDeclaration, ((Bool, Bool)) -> Void, Void>
+
+  func getStoredVariableWithConstructedImplicitType()
+    -> Mockable<VariableDeclaration, () -> Bool, Bool>
+  func setStoredVariableWithConstructedImplicitType(_ newValue: @escaping @autoclosure () -> Bool)
+    -> Mockable<VariableDeclaration, (Bool) -> Void, Void>
+
+  func getStoredVariableWithComplexConstructedImplicitType()
+    -> Mockable<VariableDeclaration, () -> Array<(String, String)>, Array<(String, String)>>
+  func setStoredVariableWithComplexConstructedImplicitType(_ newValue: @escaping @autoclosure () -> Array<(String, String)>)
+    -> Mockable<VariableDeclaration, (Array<(String, String)>) -> Void, Void>
+
   func getStoredVariableWithExplicitType()
     -> Mockable<VariableDeclaration, () -> Bool, Bool>
   func setStoredVariableWithExplicitType(_ newValue: @escaping @autoclosure () -> Bool)

--- a/MockingbirdTests/Generator/InferTypeTests.swift
+++ b/MockingbirdTests/Generator/InferTypeTests.swift
@@ -1,0 +1,27 @@
+//
+//  InferTypeTests.swift
+//  MockingbirdTests
+//
+//  Created by Ryan Meisters on 4/23/20.
+//
+
+import XCTest
+
+@testable import MockingbirdGenerator
+
+class InferTypeTests: XCTestCase {
+  func testInferType_InitializedType() {
+    let input = "Bool(booleanLiteral: true)"
+    XCTAssertEqual(inferType(from: input), "Bool")
+  }
+
+  func testInferType_InitializedTypeExplicitInit() {
+    let input = "Bool.init(booleanLiteral: true)"
+    XCTAssertEqual(inferType(from: input), "Bool")
+  }
+
+  func testInferType_ComplexGenericType() {
+    let input = "Array<(String, String)>(arrayLiteral: (\"Test\", \"Test\"))"
+    XCTAssertEqual(inferType(from: input), "Array<(String, String)>")
+  }
+}

--- a/MockingbirdTestsHost/Variables.swift
+++ b/MockingbirdTestsHost/Variables.swift
@@ -30,16 +30,21 @@ class VariablesContainer: VariablesContainerProtocol {
   }
   
   var storedVariableWithImplicitType = true
+  var storedVariableWithImplicitTupleType = (true, true)
+  var storedVariableWithConstructedImplicitType = Bool(booleanLiteral: true)
+  var storedVariableWithComplexConstructedImplicitType = Array<(String, String)>(arrayLiteral: ("Test", "Test"))
+
   var storedVariableWithExplicitType: Bool = true
   
   let constantVariableWithImplicitType = true
   let constantVariableWithExplicitType: Bool = true
-  
+
   weak var weakVariable: VariablesContainer?
   
   lazy var lazyVariableWithImplicitType = true
+
   lazy var lazyVariableWithExplicitType: Bool = { return true }()
-  
+
   lazy var lazyVariableWithComplexImplicitType = weakVariable.map { $0 === self }
   
   init() {


### PR DESCRIPTION
This fixes a small bug where type was not being inferred from code such as:

    var storedVariableWithConstructedImplicitType = Bool(booleanLiteral: true)

Problem was that the `inferType(..)` code was trying to split on the first `(` character, but was also including `()` in groups to ignore. I think it's safe to do the split only excluding <> and [] groups--can't think of any other case where a `(` would not delineate the type from its init params (tuples are handled by earlier code paths).
