### PR TITLE
Add functions to disambiguate synthesized method/property/subscript

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		D372A46A2454E92B0000E80A /* SubscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D372A4692454E92B0000E80A /* SubscriptTests.swift */; };
 		D372A46C2454E9810000E80A /* SubscriptMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D372A46B2454E9810000E80A /* SubscriptMockableTests.swift */; };
 		D372A46E2454EB520000E80A /* SubscriptStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D372A46D2454EB520000E80A /* SubscriptStubbableTests.swift */; };
+		D372A4702454EF4D0000E80A /* AmbiguousSynthesizedMembers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D372A46F2454EF4D0000E80A /* AmbiguousSynthesizedMembers.swift */; };
+		D372A4722454EF690000E80A /* AmbiguousSynthesizedMembersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D372A4712454EF690000E80A /* AmbiguousSynthesizedMembersTests.swift */; };
 		D3D936F22450F61400078751 /* MockingbirdTestsHost.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* MockingbirdTestsHost.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D3D936F62450F85100078751 /* ParsedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D936F52450F85100078751 /* ParsedFile.swift */; };
 		D3D936F82451606000078751 /* ParseSingleFileOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D936F72451606000078751 /* ParseSingleFileOperation.swift */; };
@@ -1126,6 +1128,8 @@
 		D372A4692454E92B0000E80A /* SubscriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptTests.swift; sourceTree = "<group>"; };
 		D372A46B2454E9810000E80A /* SubscriptMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptMockableTests.swift; sourceTree = "<group>"; };
 		D372A46D2454EB520000E80A /* SubscriptStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptStubbableTests.swift; sourceTree = "<group>"; };
+		D372A46F2454EF4D0000E80A /* AmbiguousSynthesizedMembers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmbiguousSynthesizedMembers.swift; sourceTree = "<group>"; };
+		D372A4712454EF690000E80A /* AmbiguousSynthesizedMembersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmbiguousSynthesizedMembersTests.swift; sourceTree = "<group>"; };
 		D3A53F412450C59F00A1DB4B /* MockingbirdTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockingbirdTests.xcconfig; sourceTree = "<group>"; };
 		D3A53F422450C59F00A1DB4B /* MockingbirdModuleTestsHost.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockingbirdModuleTestsHost.xcconfig; sourceTree = "<group>"; };
 		D3A53F432450C59F00A1DB4B /* MockingbirdFramework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockingbirdFramework.xcconfig; sourceTree = "<group>"; };
@@ -2044,6 +2048,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_130 /* MockingbirdTestsHost.h */,
+				D372A46F2454EF4D0000E80A /* AmbiguousSynthesizedMembers.swift */,
 				OBJ_131 /* ArgumentMatching.swift */,
 				OBJ_132 /* Child.swift */,
 				OBJ_133 /* ChildProtocol.swift */,
@@ -2250,6 +2255,7 @@
 		OBJ_235 /* Framework */ = {
 			isa = PBXGroup;
 			children = (
+				D372A4712454EF690000E80A /* AmbiguousSynthesizedMembersTests.swift */,
 				OBJ_236 /* ArgumentCaptorTests.swift */,
 				OBJ_237 /* ArgumentMatchingTests.swift */,
 				OBJ_238 /* AsyncVerificationTests.swift */,
@@ -4175,6 +4181,7 @@
 				OBJ_1092 /* Exceptions.swift in Sources */,
 				OBJ_1093 /* Extensions.swift in Sources */,
 				OBJ_1094 /* ExternalModuleClassScopedTypes.swift in Sources */,
+				D372A4702454EF4D0000E80A /* AmbiguousSynthesizedMembers.swift in Sources */,
 				OBJ_1095 /* ExternalModuleImplicitlyImportedTypes.swift in Sources */,
 				OBJ_1096 /* ExternalModuleTypealiasing.swift in Sources */,
 				OBJ_1097 /* ExternalModuleTypes.swift in Sources */,
@@ -4859,6 +4866,7 @@
 				OBJ_1016 /* VariablesStubbableTests.swift in Sources */,
 				OBJ_1017 /* VariadicParametersMockableTests.swift in Sources */,
 				OBJ_1018 /* VariadicParametersStubbableTests.swift in Sources */,
+				D372A4722454EF690000E80A /* AmbiguousSynthesizedMembersTests.swift in Sources */,
 				OBJ_1019 /* ArgumentCaptorTests.swift in Sources */,
 				OBJ_1020 /* ArgumentMatchingTests.swift in Sources */,
 				OBJ_1021 /* AsyncVerificationTests.swift in Sources */,

--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -10,11 +10,40 @@ import XCTest
 
 // MARK: - Stubbing
 
-/// Stub mock objects with the same function signature to return a value or perform an operation.
+/// Stub a method, property, or subscript on one or more mock objects to return a value or perform
+/// an operation.
 ///
-/// - Parameter stubbable: A set of stubbable invocations.
+/// - Parameter stubbable: A set of stubbable method, property, or subscript invocations.
 public func given<T, I, R>(_ stubbable: Mockable<T, I, R>...) -> Stub<I, R> {
   return Stub<I, R>(from: stubbable)
+}
+
+/// Stub a method on one or more mock objects to return a value or perform an operation.
+///
+/// Use this function to disambiguate stubbing a method from a property or subscript.
+///
+/// - Parameter stubbable: A set of stubbable method invocations.
+public func givenMethod<I, R>(_ stubbable: Mockable<FunctionDeclaration, I, R>...) -> Stub<I, R> {
+  return Stub<I, R>(from: stubbable)
+}
+
+/// Stub a property on one or more mock objects to return a value or perform an operation.
+///
+/// Use this function to disambiguate stubbing a property from a method or subscript.
+///
+/// - Parameter stubbable: A set of stubbable property getter or setter invocations.
+public func givenProperty<I, R>(_ stubbable: Mockable<VariableDeclaration, I, R>...) -> Stub<I, R> {
+  return Stub<I, R>(from: stubbable)
+}
+
+/// Stub a subscript on one or more mock objects to return a value or perform an operation.
+///
+/// Use this function to disambiguate stubbing a subscript from a method or property.
+///
+/// - Parameter stubbable: A set of stubbable subscript getter or setter invocations.
+public func givenSubscript<I, R>(_ stubbable: Mockable<SubscriptDeclaration, I, R>...)
+  -> Stub<I, R> {
+    return Stub<I, R>(from: stubbable)
 }
 
 /// Stub a sequence of values, returning each value sequentially. The last value will be used if the
@@ -88,13 +117,46 @@ public func useDefaultValues(from valueProvider: ValueProvider, on mock: Mock) {
 
 // MARK: - Verification
 
-/// Verify that a mock recieved a specific invocation some number of times.
+/// Verify that a mock recieved a specific method, property, or subscript invocation some number of
+/// times.
 ///
-/// - Parameters:
-///   - mock: A mockable invocation to verify.
+/// - Parameter mock: A mockable method, property, or subscript invocation to verify.
 public func verify<T, I, R>(file: StaticString = #file, line: UInt = #line,
                             _ mockable: Mockable<T, I, R>) -> Verification<I, R> {
   return Verification(with: mockable, at: SourceLocation(file, line))
+}
+
+/// Verify that a mock received a specific method invocation some number of times.
+///
+/// Use this function to disambiguate verifying a method from a property or subscript.
+///
+/// - Parameter mock: A mockable method invocation to verify.
+public func verifyMethod<I, R>(file: StaticString = #file, line: UInt = #line,
+                               _ mockable: Mockable<FunctionDeclaration, I, R>)
+  -> Verification<I, R> {
+    return Verification(with: mockable, at: SourceLocation(file, line))
+}
+
+/// Verify that a mock received a specific property invocation some number of times.
+///
+/// Use this function to disambiguate verifying a property from a method or subscript.
+///
+/// - Parameter mock: A mockable property getter or setter invocation to verify.
+public func verifyProperty<I, R>(file: StaticString = #file, line: UInt = #line,
+                                 _ mockable: Mockable<VariableDeclaration, I, R>)
+  -> Verification<I, R> {
+    return Verification(with: mockable, at: SourceLocation(file, line))
+}
+
+/// Verify that a mock received a specific subscript invocation some number of times.
+///
+/// Use this function to disambiguate verifying a subscript from a method or property.
+///
+/// - Parameter mock: A mockable subscript getter or setter invocation to verify.
+public func verifySubscript<I, R>(file: StaticString = #file, line: UInt = #line,
+                                  _ mockable: Mockable<SubscriptDeclaration, I, R>)
+  -> Verification<I, R> {
+    return Verification(with: mockable, at: SourceLocation(file, line))
 }
 
 /// Enforce the relative order of invocations verified within the scope of `block`.

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -107,6 +107,201 @@ public func mock<EquatableType: Swift.Equatable>(_ type: AbstractSpecializedGene
   return AbstractSpecializedGenericProtocolMock<EquatableType>(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked AmbiguousSynthesizedMembers
+
+public final class AmbiguousSynthesizedMembersMock: MockingbirdTestsHost.AmbiguousSynthesizedMembers, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      AmbiguousSynthesizedMembersMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked property
+
+  public var `property`: String {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "property.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> String in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> String {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (String).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "property.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (String) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getProperty() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> String, String> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "property.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> String, String>(mock: self, invocation: invocation)
+  }
+
+  public func setProperty(_ newValue: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (String) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "property.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (String) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `getProperty`()
+
+  public func `getProperty`() -> String {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`getProperty`() -> String", arguments: [])
+    return mockingContext.didInvoke(invocation) { () -> String in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? () -> String {
+        return concreteImplementation()
+      } else if let concreteImplementation = implementation as? () -> String {
+        return concreteImplementation()
+      } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (String).self) {
+        return defaultValue
+      } else {
+        fatalError(stubbingContext.failTest(for: invocation))
+      }
+    }
+  }
+
+  public func `getProperty`() -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, () -> String, String> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`getProperty`() -> String", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, () -> String, String>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `getSubscript`(_ `index`: String)
+
+  public func `getSubscript`(_ `index`: String) -> String {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`getSubscript`(_ `index`: String) -> String", arguments: [Mockingbird.ArgumentMatcher(`index`)])
+    return mockingContext.didInvoke(invocation) { () -> String in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (String) -> String {
+        return concreteImplementation(`index`)
+      } else if let concreteImplementation = implementation as? () -> String {
+        return concreteImplementation()
+      } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (String).self) {
+        return defaultValue
+      } else {
+        fatalError(stubbingContext.failTest(for: invocation))
+      }
+    }
+  }
+
+  public func `getSubscript`(_ `index`: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String) -> String, String> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`index`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`getSubscript`(_ `index`: String) -> String", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String) -> String, String>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `setProperty`(_ `newValue`: String)
+
+  public func `setProperty`(_ `newValue`: String) -> Void {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`setProperty`(_ `newValue`: String) -> Void", arguments: [Mockingbird.ArgumentMatcher(`newValue`)])
+    mockingContext.didInvoke(invocation) { () -> Void in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (String) -> Void {
+        concreteImplementation(`newValue`)
+      } else if let concreteImplementation = implementation as? () -> Void {
+        concreteImplementation()
+      }
+    }
+  }
+
+  public func `setProperty`(_ `newValue`: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`newValue`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`setProperty`(_ `newValue`: String) -> Void", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked `setSubscript`(_ `index`: String, `newValue`: String)
+
+  public func `setSubscript`(_ `index`: String, `newValue`: String) -> Void {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`setSubscript`(_ `index`: String, `newValue`: String) -> Void", arguments: [Mockingbird.ArgumentMatcher(`index`), Mockingbird.ArgumentMatcher(`newValue`)])
+    mockingContext.didInvoke(invocation) { () -> Void in
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (String, String) -> Void {
+        concreteImplementation(`index`, `newValue`)
+      } else if let concreteImplementation = implementation as? () -> Void {
+        concreteImplementation()
+      }
+    }
+  }
+
+  public func `setSubscript`(_ `index`: @escaping @autoclosure () -> String, `newValue`: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String, String) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`index`), Mockingbird.resolve(`newValue`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "`setSubscript`(_ `index`: String, `newValue`: String) -> Void", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (String, String) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked subscript(_ `index`: String)
+
+  public subscript(_ `index`: String) -> String {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "get.subscript(_ `index`: String) -> String", arguments: [Mockingbird.ArgumentMatcher(`index`)])
+      return mockingContext.didInvoke(invocation) { () -> String in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? (String) -> String {
+          return concreteImplementation(`index`)
+        } else if let concreteImplementation = implementation as? () -> String {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (String).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "set.subscript(_ `index`: String, `newValue`: String) -> String", arguments: [Mockingbird.ArgumentMatcher(`index`), Mockingbird.ArgumentMatcher(`newValue`)])
+      mockingContext.didInvoke(invocation) { () -> Void in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? (String, String) -> Void {
+          concreteImplementation(`index`, `newValue`)
+        } else if let concreteImplementation = implementation as? () -> Void {
+          concreteImplementation()
+        }
+      }
+    }
+  }
+
+  public func getSubscript(_ `index`: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.SubscriptDeclaration, (String) -> String, String> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`index`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "get.subscript(_ `index`: String) -> String", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.SubscriptDeclaration, (String) -> String, String>(mock: self, invocation: invocation)
+  }
+
+  public func setSubscript(_ `index`: @escaping @autoclosure () -> String, `newValue`: @escaping @autoclosure () -> String) -> Mockingbird.Mockable<Mockingbird.SubscriptDeclaration, (String, String) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(`index`), Mockingbird.resolve(`newValue`)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "set.subscript(_ `index`: String, `newValue`: String) -> String", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.SubscriptDeclaration, (String, String) -> Void, Void>(mock: self, invocation: invocation)
+  }
+}
+
+/// Initialize a protocol mock of `MockingbirdTestsHost.AmbiguousSynthesizedMembers`.
+public func mock(_ type: MockingbirdTestsHost.AmbiguousSynthesizedMembers.Protocol, file: StaticString = #file, line: UInt = #line) -> AmbiguousSynthesizedMembersMock {
+  return AmbiguousSynthesizedMembersMock(sourceLocation: SourceLocation(file, line))
+}
+
 // MARK: - Mocked AnotherTopLevelType
 
 public final class AnotherTopLevelTypeMock: MockingbirdTestsHost.AnotherTopLevelType, Mockingbird.Mock {

--- a/MockingbirdTests/Framework/AmbiguousSynthesizedMembersTests.swift
+++ b/MockingbirdTests/Framework/AmbiguousSynthesizedMembersTests.swift
@@ -1,0 +1,78 @@
+//
+//  AmbiguousSynthesizedMembersTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 4/18/20.
+//
+
+import XCTest
+import Mockingbird
+@testable import MockingbirdTestsHost
+
+class AmbiguousSyntheiszedMembersTests: BaseTestCase {
+  
+  var concreteMock: AmbiguousSynthesizedMembersMock!
+  var concreteInstance: AmbiguousSynthesizedMembers { return concreteMock }
+  
+  override func setUp() {
+    concreteMock = mock(AmbiguousSynthesizedMembers.self)
+  }
+  
+  func testSubscriptGetterConflict_disambiguatesSubscript() {
+    givenSubscript(concreteMock.getSubscript("foo")) ~> "bar"
+    XCTAssertEqual(concreteInstance["foo"], "bar")
+    verifySubscript(concreteMock.getSubscript("foo")).wasCalled()
+  }
+  
+  func testSubscriptGetterConflict_disambiguatesMethod() {
+    givenMethod(concreteMock.getSubscript("foo")) ~> "bar"
+    XCTAssertEqual(concreteInstance.getSubscript("foo"), "bar")
+    verifyMethod(concreteMock.getSubscript("foo")).wasCalled()
+  }
+  
+  func testSubscriptSetterConflict_disambiguatesSubscript() {
+    var concreteInstance: AmbiguousSynthesizedMembers = concreteMock
+    var callCount = 0
+    givenSubscript(concreteMock.setSubscript("foo", newValue: "bar")) ~> { _, _ in callCount += 1 }
+    concreteInstance["foo"] = "bar"
+    verifySubscript(concreteMock.setSubscript("foo", newValue: "bar")).wasCalled()
+    XCTAssertEqual(callCount, 1)
+  }
+  
+  func testSubscriptSetterConflict_disambiguatesMethod() {
+    var callCount = 0
+    givenMethod(concreteMock.setSubscript("foo", newValue: "bar")) ~> { _, _ in callCount += 1 }
+    concreteInstance.setSubscript("foo", newValue: "bar")
+    verifyMethod(concreteMock.setSubscript("foo", newValue: "bar")).wasCalled()
+    XCTAssertEqual(callCount, 1)
+  }
+  
+  func testPropertyGetterConflict_disambiguatesProperty() {
+    givenProperty(concreteMock.getProperty()) ~> "bar"
+    XCTAssertEqual(concreteInstance.property, "bar")
+    verifyProperty(concreteMock.getProperty()).wasCalled()
+  }
+  
+  func testPropertyGetterConflict_disambiguatesMethod() {
+    givenMethod(concreteMock.getProperty()) ~> "bar"
+    XCTAssertEqual(concreteInstance.getProperty(), "bar")
+    verifyMethod(concreteMock.getProperty()).wasCalled()
+  }
+  
+  func testPropertySetterConflict_disambiguatesProperty() {
+    var concreteInstance: AmbiguousSynthesizedMembers = concreteMock
+    var callCount = 0
+    givenProperty(concreteMock.setProperty("bar")) ~> { _ in callCount += 1 }
+    concreteInstance.property = "bar"
+    verifyProperty(concreteMock.setProperty("bar")).wasCalled()
+    XCTAssertEqual(callCount, 1)
+  }
+  
+  func testPropertySetterConflict_disambiguatesMethod() {
+    var callCount = 0
+    givenMethod(concreteMock.setProperty("bar")) ~> { _ in callCount += 1 }
+    concreteInstance.setProperty("bar")
+    verifyMethod(concreteMock.setProperty("bar")).wasCalled()
+    XCTAssertEqual(callCount, 1)
+  }
+}

--- a/MockingbirdTestsHost/AmbiguousSynthesizedMembers.swift
+++ b/MockingbirdTestsHost/AmbiguousSynthesizedMembers.swift
@@ -1,0 +1,20 @@
+//
+//  AmbiguousSynthesizedMembers.swift
+//  MockingbirdTestsHost
+//
+//  Created by Andrew Chang on 4/18/20.
+//
+
+import Foundation
+
+protocol AmbiguousSynthesizedMembers {
+  // MARK: Subscript conflicts
+  subscript(_ index: String) -> String { get set }
+  func getSubscript(_ index: String) -> String
+  func setSubscript(_ index: String, newValue: String)
+  
+  // MARK: Property conflicts
+  var property: String { get set }
+  func getProperty() -> String
+  func setProperty(_ newValue: String)
+}


### PR DESCRIPTION
Although the mock code correctly handles overloads for naming conflicts between synthesized property accessors and mocked methods, it's not actually possible to reference these overloads in tests without helpers.

```swift
protocol AmbiguousSynthesizedMembers {
  // MARK: Subscript conflicts
  subscript(_ index: String) -> String { get set }
  func getSubscript(_ index: String) -> String
  func setSubscript(_ index: String, newValue: String)

  // MARK: Property conflicts
  var property: String { get set }
  func getProperty() -> String
  func setProperty(_ newValue: String)
}
```

The cleanest fix unfortunately requires adding additional `given` and `verify` functions to the API like so:

```swift
verifySubscript(myMock.getSubscript("foo")).wasCalled()
verifyMethod(myMock.getSubscript("foo")).wasCalled()

verifyProperty(myMock.getProperty()).wasCalled()
verifyMethod(myMock.getProperty()).wasCalled()
```

I also considered putting the verbose functions behind a compilation condition to make it opt-in (similar to OCMockito), but this doesn't seem very discoverable.