### PR TITLE
Fix collection types not being properly synchronized

### DIFF
--- a/MockingbirdFramework/Stubbing/StubbingContext.swift
+++ b/MockingbirdFramework/Stubbing/StubbingContext.swift
@@ -37,7 +37,7 @@ public class StubbingContext {
   }
 
   func implementation(for invocation: Invocation) -> Any? {
-    return stubs.value[invocation.selectorName]?
+    return stubs.read({ $0[invocation.selectorName] })?
       .last(where: { $0.invocation == invocation })?
       .implementation
   }

--- a/MockingbirdFramework/Stubbing/ValueProvider.swift
+++ b/MockingbirdFramework/Stubbing/ValueProvider.swift
@@ -68,7 +68,7 @@ public class ValueProvider {
   /// - Parameter provider: The value provider to remove.
   @discardableResult
   public func removeSubprovider(_ provider: ValueProvider) -> Self {
-    subproviders.value.removeAll(where: { $0 === provider })
+    subproviders.update { $0.removeAll(where: { $0 === provider }) }
     return self
   }
   
@@ -83,7 +83,7 @@ public class ValueProvider {
   @discardableResult
   public func register<K, V>(_ value: V, for type: K.Type = K.self) -> Self {
     precondition(value is K)
-    storedValues.value[ObjectIdentifier(type)] = value
+    storedValues.update { $0[ObjectIdentifier(type)] = value }
     return self
   }
   
@@ -92,13 +92,13 @@ public class ValueProvider {
   /// - Parameter type: The type to remove a previously registered value for.
   @discardableResult
   public func removeValue<T>(for type: T.Type) -> Self {
-    storedValues.value.removeValue(forKey: ObjectIdentifier(type))
+    storedValues.update { $0.removeValue(forKey: ObjectIdentifier(type)) }
     return self
   }
   
   func reset() {
-    storedValues.value.removeAll()
-    subproviders.value.removeAll()
+    storedValues.update { $0.removeAll() }
+    subproviders.update { $0.removeAll() }
   }
   
   
@@ -118,62 +118,62 @@ public class ValueProvider {
   // type, so making helper functions doesn't work here.
   
   func provideValue<T>(for type: T.Type = T.self) -> T? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? T
+    return storedValues.read { $0[ObjectIdentifier(type)] as? T }
   }
   
   // MARK: Collections
   
   func provideValue<T>(for type: Array<T>.Type) -> Array<T>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? Array<T>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? Array<T> }
   }
   
   func provideValue<T>(for type: Set<T>.Type) -> Set<T>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? Set<T>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? Set<T> }
   }
   
   func provideValue<K, V>(for type: Dictionary<K, V>.Type) -> Dictionary<K, V>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? Dictionary<K, V>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? Dictionary<K, V> }
   }
   
   func provideValue<K, V>(for type: NSCache<K, V>.Type) -> NSCache<K, V>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? NSCache<K, V>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? NSCache<K, V> }
   }
   
   func provideValue<K, V>(for type: NSMapTable<K, V>.Type) -> NSMapTable<K, V>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? NSMapTable<K, V>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? NSMapTable<K, V> }
   }
   
   func provideValue<T>(for type: NSHashTable<T>.Type) -> NSHashTable<T>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? NSHashTable<T>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? NSHashTable<T> }
   }
   
   // MARK: Foundation
   
   func provideValue<T>(for type: Optional<T>.Type) -> Optional<T>? {
-    for provider in subproviders.value {
+    for provider in subproviders.read({ Array($0) }) {
       if let value = provider.provideValue(for: type) { return value }
     }
-    return storedValues.value[ObjectIdentifier(type)] as? Optional<T>
+    return storedValues.read { $0[ObjectIdentifier(type)] as? Optional<T> }
   }
 }

--- a/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -124,7 +124,7 @@ class MockableTypeTemplate: Template {
       static var staticMock: Mockingbird.StaticMock {
         let runtimeGenericTypeNames = \(runtimeGenericTypeNames)
         let staticMockIdentifier = "\(mockableType.name)Mock\(allSpecializedGenericTypes)," + runtimeGenericTypeNames
-        if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+        if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
         let staticMock = Mockingbird.StaticMock()
         genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
         return staticMock

--- a/MockingbirdGenerator/Parser/Models/Typealias.swift
+++ b/MockingbirdGenerator/Parser/Models/Typealias.swift
@@ -70,10 +70,10 @@ class TypealiasRepository {
                        moduleNames: [String],
                        referencingModuleName: String,
                        containingTypeNames: ArraySlice<String>) -> [String] {
-    let unwrappedTypealiases = self.unwrappedTypealiases.value
-    
     // This typealias is already resolved.
-    if let actualTypeNames = unwrappedTypealiases[typeAlias.rawType.fullyQualifiedModuleName] {
+    if let actualTypeNames = unwrappedTypealiases.read({
+      $0[typeAlias.rawType.fullyQualifiedModuleName]
+    }) {
       return actualTypeNames
     }
     
@@ -100,7 +100,7 @@ class TypealiasRepository {
                              referencingModuleName: aliasedTypealias.rawType.parsedFile.moduleName,
                              containingTypeNames: aliasedTypealias.rawType.containingTypeNames[...])
     })
-    self.unwrappedTypealiases.update {
+    unwrappedTypealiases.update {
       $0[typeAlias.rawType.fullyQualifiedModuleName] = unwrappedNames
     }
     return unwrappedNames

--- a/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
@@ -71,7 +71,8 @@ class FlattenInheritanceOperation: BasicOperation {
     }
 
     // Create a copy of `memoizedMockableTypes` to reduce lock contention.
-    let memoizedMockableTypes = FlattenInheritanceOperation.memoizedMockbleTypes.value
+    let memoizedMockableTypes = FlattenInheritanceOperation.memoizedMockbleTypes
+      .read({ $0.mapValues({ $0 }) })
     guard let baseRawType = rawType.findBaseRawType() else { return nil }
     
     let fullyQualifiedName = baseRawType.fullyQualifiedModuleName

--- a/MockingbirdGenerator/Parser/Operations/ParseSingleFileOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ParseSingleFileOperation.swift
@@ -37,7 +37,7 @@ class ParseSingleFileOperation: BasicOperation {
   
   override func run() throws {
     let sourcePath = self.sourcePath
-    if let memoized = ParseSingleFileOperation.memoizedParsedFiles.value[sourcePath] {
+    if let memoized = ParseSingleFileOperation.memoizedParsedFiles.read({ $0[sourcePath] }) {
       result.parsedFile = ParsedFile(from: memoized, shouldMock: shouldMock)
       return
     }

--- a/MockingbirdGenerator/Utilities/Deallocation.swift
+++ b/MockingbirdGenerator/Utilities/Deallocation.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-private let objectReferences = Synchronized<[Any]>([])
+private var objectReferences = [AnyObject]()
 private let queue = DispatchQueue(label: "co.bird.mockingbird.retain", qos: .background)
 
 /// Retain an object for the lifetime of the application.
@@ -19,6 +19,6 @@ private let queue = DispatchQueue(label: "co.bird.mockingbird.retain", qos: .bac
 func retainForever<T: AnyObject>(_ object: T?) {
   guard let object = object else { return }
   #if !(DEBUG)
-  queue.async { objectReferences.value.append(object) }
+  queue.async { objectReferences.append(object) }
   #endif
 }

--- a/MockingbirdGenerator/Utilities/Synchronized.swift
+++ b/MockingbirdGenerator/Utilities/Synchronized.swift
@@ -12,26 +12,27 @@ public class Synchronized<T> {
   private(set) public var unsafeValue: T
   public var value: T {
     get {
-      lock.lock()
-      defer { lock.unlock() }
-      return unsafeValue
+      var value: T!
+      queue.sync { value = unsafeValue }
+      return value
     }
-    
     set {
-      lock.lock()
-      defer { lock.unlock() }
-      unsafeValue = newValue
+      queue.sync { unsafeValue = newValue }
     }
   }
-  private let lock = NSLock()
+  private let queue = DispatchQueue(label: "co.bird.mockingbird.synchronized")
   
   public init(_ value: T) {
     self.unsafeValue = value
   }
   
   public func update(_ block: (inout T) throws -> Void) rethrows {
-    lock.lock()
-    defer { lock.unlock() }
-    try block(&unsafeValue)
+    try queue.sync { try block(&unsafeValue) }
+  }
+  
+  public func read<R>(_ block: (T) throws -> R) rethrows -> R {
+    var value: R!
+    try queue.sync { value = try block(unsafeValue) }
+    return value
   }
 }

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -32,7 +32,7 @@ public final class AbstractSpecializedGenericProtocolMock<EquatableType: Swift.E
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(EquatableType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AbstractSpecializedGenericProtocolMock<EquatableType: Swift.Equatable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -1217,7 +1217,7 @@ public final class AssociatedTypeGenericConformingConstraintsProtocolMock<Confor
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(ConformingType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AssociatedTypeGenericConformingConstraintsProtocolMock<ConformingType: MockingbirdTestsHost.AssociatedTypeProtocol>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -1274,7 +1274,7 @@ public final class AssociatedTypeGenericConstraintsProtocolMock<ConstrainedType:
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(ConstrainedType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AssociatedTypeGenericConstraintsProtocolMock<ConstrainedType: MockingbirdTestsHost.AssociatedTypeProtocol>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -1331,7 +1331,7 @@ public final class AssociatedTypeGenericImplementerMock<EquatableType: Swift.Equ
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(EquatableType.self).debugDescription, ObjectIdentifier(S.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AssociatedTypeGenericImplementerMock<EquatableType: Swift.Equatable, S: Sequence>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -1649,7 +1649,7 @@ public final class AssociatedTypeProtocolMock<EquatableType: Swift.Equatable, Ha
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(EquatableType.self).debugDescription, ObjectIdentifier(HashableType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AssociatedTypeProtocolMock<EquatableType: Swift.Equatable, HashableType: Swift.Hashable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -1816,7 +1816,7 @@ public final class AssociatedTypeSelfReferencingProtocolMock<SequenceType: Seque
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(SequenceType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "AssociatedTypeSelfReferencingProtocolMock<SequenceType: Sequence & Swift.Hashable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -5599,7 +5599,7 @@ public final class ConstrainedUnspecializedGenericSubclassMock<T: Swift.Equatabl
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "ConstrainedUnspecializedGenericSubclassMock<T: Swift.Equatable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -9630,7 +9630,7 @@ public final class FakeableGenericClassMock<T>: MockingbirdTestsHost.FakeableGen
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "FakeableGenericClassMock<T>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -10325,7 +10325,7 @@ public final class GenericBaseClassMock<T>: MockingbirdTestsHost.GenericBaseClas
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "GenericBaseClassMock<T>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -11669,7 +11669,7 @@ public final class InheritedTypeQualificationProtocolGenericImplementerMock<T>: 
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "InheritedTypeQualificationProtocolGenericImplementerMock<T>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -11751,7 +11751,7 @@ public final class InheritedTypeQualificationProtocolMock<ScopedType>: Mockingbi
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(ScopedType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "InheritedTypeQualificationProtocolMock<ScopedType>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -11832,7 +11832,7 @@ public final class InheritingAssociatedTypeSelfReferencingProtocolMock<SequenceT
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(SequenceType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "InheritingAssociatedTypeSelfReferencingProtocolMock<SequenceType: Sequence & Swift.Hashable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -11925,7 +11925,7 @@ public final class InheritingExternalModuleScopedAssociatedTypeProtocolMock<Elem
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(Data.self).debugDescription, ObjectIdentifier(Element.self).debugDescription, ObjectIdentifier(Subelement.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "InheritingExternalModuleScopedAssociatedTypeProtocolMock<Element, Subelement, Data: MockingbirdModuleTestsHost.ExternalModuleScopedAssociatedTypeProtocol>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -12128,7 +12128,7 @@ public final class InheritingModuleScopedAssociatedTypeProtocolMock<Element, Sub
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(Data.self).debugDescription, ObjectIdentifier(Element.self).debugDescription, ObjectIdentifier(Subelement.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "InheritingModuleScopedAssociatedTypeProtocolMock<Element, Subelement, Data: MockingbirdTestsHost.ModuleScopedAssociatedTypeProtocol>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -13501,7 +13501,7 @@ public final class ModuleScopedAssociatedTypeProtocolMock<Element, Subelement, D
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(Data.self).debugDescription, ObjectIdentifier(Element.self).debugDescription, ObjectIdentifier(Subelement.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "ModuleScopedAssociatedTypeProtocolMock<Element, Subelement, Data: MockingbirdTestsHost.ModuleScopedAssociatedTypeProtocol>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -16784,7 +16784,7 @@ public final class ReferencedGenericClassWithConstraintsMock<S: Sequence>: Mocki
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(S.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "ReferencedGenericClassWithConstraintsMock<S: Sequence>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -16818,7 +16818,7 @@ public final class ReferencedGenericClassMock<T>: MockingbirdTestsHost.Reference
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "ReferencedGenericClassMock<T>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -17047,7 +17047,7 @@ public final class SecondLevelSelfConstrainedAssociatedTypeProtocolMock<Sequence
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(SequenceType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "SecondLevelSelfConstrainedAssociatedTypeProtocolMock<SequenceType: Sequence & Swift.Hashable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -17189,7 +17189,7 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(ShadowedType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "ShadowedGenericTypeMock<ShadowedType>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -17265,7 +17265,7 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
     static var staticMock: Mockingbird.StaticMock {
       let runtimeGenericTypeNames = [].joined(separator: ",")
       let staticMockIdentifier = "NestedShadowedGenericTypeMock," + runtimeGenericTypeNames
-      if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+      if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
       let staticMock = Mockingbird.StaticMock()
       genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
       return staticMock
@@ -17342,7 +17342,7 @@ public final class ShadowedGenericTypeMock<ShadowedType>: MockingbirdTestsHost.S
     static var staticMock: Mockingbird.StaticMock {
       let runtimeGenericTypeNames = [ObjectIdentifier(ShadowedType.self).debugDescription].joined(separator: ",")
       let staticMockIdentifier = "NestedDoublyShadowedGenericTypeMock<ShadowedType>," + runtimeGenericTypeNames
-      if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+      if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
       let staticMock = Mockingbird.StaticMock()
       genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
       return staticMock
@@ -19557,7 +19557,7 @@ public final class TopLevelSelfConstrainedAssociatedTypeProtocolMock<Element, Se
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(Element.self).debugDescription, ObjectIdentifier(SequenceType.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "TopLevelSelfConstrainedAssociatedTypeProtocolMock<Element, SequenceType: Sequence & Swift.Hashable>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -20840,7 +20840,7 @@ public final class UnalphabetizedGenericClassMock<C, B, A>: MockingbirdTestsHost
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(A.self).debugDescription, ObjectIdentifier(B.self).debugDescription, ObjectIdentifier(C.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "UnalphabetizedGenericClassMock<C, B, A>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -20972,7 +20972,7 @@ public final class UnspecializedGenericSubclassMock<T>: MockingbirdTestsHost.Uns
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "UnspecializedGenericSubclassMock<T>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock
@@ -21053,7 +21053,7 @@ public final class UnspecializedMultipleGenericSubclassMock<T, R>: MockingbirdTe
   static var staticMock: Mockingbird.StaticMock {
     let runtimeGenericTypeNames = [ObjectIdentifier(R.self).debugDescription, ObjectIdentifier(T.self).debugDescription].joined(separator: ",")
     let staticMockIdentifier = "UnspecializedMultipleGenericSubclassMock<T, R>," + runtimeGenericTypeNames
-    if let staticMock = genericTypesStaticMocks.value[staticMockIdentifier] { return staticMock }
+    if let staticMock = genericTypesStaticMocks.read({ $0[staticMockIdentifier] }) { return staticMock }
     let staticMock = Mockingbird.StaticMock()
     genericTypesStaticMocks.update { $0[staticMockIdentifier] = staticMock }
     return staticMock


### PR DESCRIPTION
This was leading to very rare and hard to reproduce crashes in release builds. Adds a `read` method on the `Synchronized` class for thread-safe reading of synchronized collection types.