### PR TITLE
Fix thread-safety issues with opaque inherited type names

### DIFF
--- a/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -71,6 +71,7 @@ class MockableType: Hashable, Comparable {
         mockableTypes: [String: MockableType],
         moduleNames: [String],
         specializationContexts: [String: SpecializationContext],
+        opaqueInheritedTypeNames: Set<String>,
         rawTypeRepository: RawTypeRepository,
         typealiasRepository: TypealiasRepository) {
     guard let baseRawType = rawTypes.findBaseRawType(),
@@ -97,7 +98,6 @@ class MockableType: Hashable, Comparable {
     self.kind = baseRawType.kind
     self.accessLevel = accessLevel
     self.isContainedType = !baseRawType.containingTypeNames.isEmpty
-    self.opaqueInheritedTypeNames = Set(rawTypes.flatMap({ $0.opaqueInheritedTypeNames }))
     self.shouldMock = baseRawType.parsedFile.shouldMock
     self.genericTypeContext = baseRawType.genericTypeContext
     self.isInGenericContainingType = baseRawType.genericTypeContext.contains(where: { !$0.isEmpty })
@@ -178,6 +178,8 @@ class MockableType: Hashable, Comparable {
       )
       return nil
     }
+    self.opaqueInheritedTypeNames = opaqueInheritedTypeNames
+      .union(Set(inheritedTypes.flatMap({ $0.opaqueInheritedTypeNames })))
     
     // Parse protocol `Self` conformance.
     let rawConformanceTypeNames = baseRawType.kind == .protocol ?

--- a/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -25,8 +25,6 @@ class RawType {
   let kind: SwiftDeclarationKind
   let parsedFile: ParsedFile
   
-  var opaqueInheritedTypeNames = Set<String>()
-  
   var isContainedType: Bool { return !containingTypeNames.isEmpty }
   
   /// Fully qualified with respect to other modules.

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -12155,6 +12155,27 @@ public func mock<Element, Subelement, Data: MockingbirdTestsHost.ModuleScopedAss
   return InheritingModuleScopedAssociatedTypeProtocolMock<Element, Subelement, Data>(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked InheritingOpaqueFileManagerDelegate
+
+public final class InheritingOpaqueFileManagerDelegateMock: Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      InheritingOpaqueFileManagerDelegateMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+}
+
+@available(*, unavailable, message: "'InheritingOpaqueFileManagerDelegate' inherits from the externally-defined type 'FileManagerDelegate' which needs to be declared in a supporting source file")
+public func mock(_ type: MockingbirdTestsHost.InheritingOpaqueFileManagerDelegate.Protocol, file: StaticString = #file, line: UInt = #line) -> InheritingOpaqueFileManagerDelegateMock {
+  fatalError()
+}
+
 // MARK: - Mocked InheritsExtendableProtocol
 
 public final class InheritsExtendableProtocolMock: MockingbirdTestsHost.InheritsExtendableProtocol, Mockingbird.Mock {

--- a/MockingbirdTestsHost/OpaquelyInheritedTypes.swift
+++ b/MockingbirdTestsHost/OpaquelyInheritedTypes.swift
@@ -36,3 +36,4 @@ public class SynthesizedRequiredInitializer: Decodable {
 
 /// Inherits an opaque type not defined in a supporting source file. Should generate a `#warning`.
 public protocol OpaqueFileManagerDelegate: FileManagerDelegate {}
+public protocol InheritingOpaqueFileManagerDelegate: OpaqueFileManagerDelegate {}


### PR DESCRIPTION
Remove mutable opaque inherited type names from `RawType` and move into `MockableType` initialization instead.