### PR TITLE
Generate availability attributes for unmockable top-level types

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D37503D72460FE7E003017A7 /* ImplicitVariableTypesMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37503D52460FE78003017A7 /* ImplicitVariableTypesMockableTests.swift */; };
 		D37503D92460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37503D82460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift */; };
 		D3A854622460D9FC00C5764A /* ImplicitVariableTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */; };
+		D37503DB246120EA003017A7 /* ConflictingProtocolProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */; };
 		OBJ_1001 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_1013 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* Empty.swift */; };
 		OBJ_1019 /* ChildMockMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* ChildMockMockableTests.swift */; };
@@ -1145,6 +1146,7 @@
 		D37503D52460FE78003017A7 /* ImplicitVariableTypesMockableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypesMockableTests.swift; sourceTree = "<group>"; };
 		D37503D82460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypesStubbableTests.swift; sourceTree = "<group>"; };
 		D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypes.swift; sourceTree = "<group>"; };
+		D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictingProtocolProperties.swift; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdGenerator::Product" /* MockingbirdGenerator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockingbirdGenerator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2079,6 +2081,7 @@
 				OBJ_150 /* Collections.swift */,
 				OBJ_151 /* CompilationDirectives.swift */,
 				OBJ_152 /* CompoundTypes.swift */,
+				D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */,
 				OBJ_153 /* DeclarationAttributes.swift */,
 				OBJ_154 /* DefaultArgumentValues.swift */,
 				OBJ_155 /* EmptyTypes.swift */,
@@ -4278,6 +4281,7 @@
 				OBJ_1158 /* EnclosingDirectoryOverriddenIncludedSource.swift in Sources */,
 				OBJ_1159 /* WildcardDirectoryIgnoredSource.swift in Sources */,
 				OBJ_1160 /* DirectoryNonRelativeIgnoredSource.swift in Sources */,
+				D37503DB246120EA003017A7 /* ConflictingProtocolProperties.swift in Sources */,
 				OBJ_1161 /* WildcardFileNonRelativeIgnoredSource.swift in Sources */,
 				OBJ_1162 /* NonRelativeSecondLevelFileIgnoredSource.swift in Sources */,
 				OBJ_1163 /* RelativeSecondLevelFileIncludedSource.swift in Sources */,

--- a/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -164,23 +164,9 @@ class MockableType: Hashable, Comparable {
                              typealiasRepository: typealiasRepository)
     self.inheritedTypes = inheritedTypes
     self.allInheritedTypeNames = allInheritedTypeNames
-    if baseRawType.parsedFile.shouldMock,
-      let nonInheritableType = inheritedTypes.first(where: {
-        $0.kind == .class && !$0.accessLevel.isInheritableType(withinSameModule: $0.shouldMock)
-      }) {
-      logWarning(
-        "\(baseRawType.name.singleQuoted) inherits from the non-inheritable type \(nonInheritableType.name.singleQuoted) and is not mockable",
-        diagnostic: .notMockable,
-        filePath: baseRawType.parsedFile.path,
-        line: SourceSubstring.key
-          .extractLinesNumbers(from: baseRawType.dictionary,
-                               contents: baseRawType.parsedFile.file.contents)?.start
-      )
-      return nil
-    }
     self.opaqueInheritedTypeNames = opaqueInheritedTypeNames
       .union(Set(inheritedTypes.flatMap({ $0.opaqueInheritedTypeNames })))
-    
+
     // Parse protocol `Self` conformance.
     let rawConformanceTypeNames = baseRawType.kind == .protocol ?
       baseRawType.selfConformanceTypeNames.union(
@@ -211,20 +197,6 @@ class MockableType: Hashable, Comparable {
                                            baseRawType: baseRawType,
                                            rawTypeRepository: rawTypeRepository,
                                            typealiasRepository: typealiasRepository)
-    if baseRawType.parsedFile.shouldMock,
-      let nonInheritableType = selfConformanceTypes.first(where: {
-        $0.kind == .class && !$0.accessLevel.isInheritableType(withinSameModule: $0.shouldMock)
-      }) {
-      logWarning(
-        "\(baseRawType.name.singleQuoted) inherits from the non-open class \(nonInheritableType.name.singleQuoted) and cannot be mocked",
-        diagnostic: .notMockable,
-        filePath: baseRawType.parsedFile.path,
-        line: SourceSubstring.key
-          .extractLinesNumbers(from: baseRawType.dictionary,
-                               contents: baseRawType.parsedFile.file.contents)?.start
-      )
-      return nil
-    }
     
     self.subclassesExternalType = subclassesExternalType || conformsToExternalType
     self.methods = methods

--- a/MockingbirdGenerator/Parser/Models/Variable.swift
+++ b/MockingbirdGenerator/Parser/Models/Variable.swift
@@ -22,9 +22,18 @@ struct Variable: Hashable, Comparable {
   
   private let rawType: RawType
   
+  struct Reduced: Hashable {
+    let name: String
+    let isInstance: Bool
+    init(from variable: Variable) {
+      self.name = variable.name
+      self.isInstance = variable.kind.typeScope == .instance
+    }
+  }
+  
   func hash(into hasher: inout Hasher) {
     hasher.combine(name)
-    hasher.combine(typeName)
+    hasher.combine(typeName) // This is used to generate availability attributes on conflicts.
     hasher.combine(kind.typeScope == .instance)
   }
   

--- a/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
@@ -76,20 +76,6 @@ public class ProcessTypesOperation: BasicOperation {
       result.mockableTypes = flattenInheritanceOperations
         .compactMap({ $0.result.mockableType })
         .filter({ !$0.isContainedType })
-        .filter({ mockableType -> Bool in
-          guard mockableType.kind == .class, mockableType.subclassesExternalType else { return true }
-          // Ignore any types that simply cannot be initialized.
-          guard mockableType.methods.contains(where: { $0.isInitializer }) else {
-            logWarning(
-              "\(mockableType.name.singleQuoted) subclasses a type from a different module but does not declare any accessible initializers and cannot be mocked",
-              diagnostic: .notMockable,
-              filePath: mockableType.filePath,
-              line: mockableType.lineNumber
-            )
-            return false
-          }
-          return true
-        })
       result.imports = parseFilesResult.imports
       log("Created \(result.mockableTypes.count) mockable type\(result.mockableTypes.count != 1 ? "s" : "")")
     }

--- a/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
+++ b/MockingbirdMocks/MockingbirdTestsHostMocks.generated.swift
@@ -5593,6 +5593,27 @@ public func mock(_ type: MockingbirdTestsHost.ConformingUninitializableOpenClass
   return ConformingUninitializableOpenClassConstrainedProtocolMock.InitializerProxy.self
 }
 
+// MARK: - Mocked ConformingUnmockablePublicClassConstrainedProtocol
+
+public final class ConformingUnmockablePublicClassConstrainedProtocolMock: Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      ConformingUnmockablePublicClassConstrainedProtocolMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+}
+
+@available(*, unavailable, message: "'ConformingUnmockablePublicClassConstrainedProtocol' inherits from the non-open class 'PublicClass' and cannot be mocked")
+public func mock(_ type: MockingbirdTestsHost.ConformingUnmockablePublicClassConstrainedProtocol.Protocol, file: StaticString = #file, line: UInt = #line) -> ConformingUnmockablePublicClassConstrainedProtocolMock {
+  fatalError()
+}
+
 // MARK: - Mocked ConstrainedUnspecializedGenericSubclass
 
 public final class ConstrainedUnspecializedGenericSubclassMock<T: Swift.Equatable>: MockingbirdTestsHost.ConstrainedUnspecializedGenericSubclass<T>, Mockingbird.Mock {
@@ -12236,6 +12257,110 @@ public func mock(_ type: MockingbirdTestsHost.ImplicitlyImportedExternalObjectiv
   return ImplicitlyImportedExternalObjectiveCTypeMock(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked InheritedConflictingProtocolProperties
+
+public final class InheritedConflictingProtocolPropertiesMock: MockingbirdTestsHost.InheritedConflictingProtocolProperties, Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      InheritedConflictingProtocolPropertiesMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+
+  // MARK: Mocked bar
+
+  public var `bar`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "bar.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> Bool in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> Bool {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (Bool).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "bar.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getBar() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "bar.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setBar(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "bar.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  // MARK: Mocked foo
+
+  public var `foo`: Bool {
+    get {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "foo.get", arguments: [])
+      return mockingContext.didInvoke(invocation) { () -> Bool in
+        let implementation = stubbingContext.implementation(for: invocation)
+        if let concreteImplementation = implementation as? () -> Bool {
+          return concreteImplementation()
+        } else if let defaultValue = stubbingContext.defaultValueProvider.provideValue(for: (Bool).self) {
+          return defaultValue
+        } else {
+          fatalError(stubbingContext.failTest(for: invocation))
+        }
+      }
+    }
+    set {
+      let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "foo.set", arguments: [ArgumentMatcher(newValue)])
+      mockingContext.didInvoke(invocation)
+      let implementation = stubbingContext.implementation(for: invocation)
+      if let concreteImplementation = implementation as? (Bool) -> Void {
+        concreteImplementation(newValue)
+      } else {
+        (implementation as? () -> Void)?()
+      }
+    }
+  }
+
+  public func getFoo() -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool> {
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "foo.get", arguments: [])
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, () -> Bool, Bool>(mock: self, invocation: invocation)
+  }
+
+  public func setFoo(_ newValue: @escaping @autoclosure () -> Bool) -> Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void> {
+    let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
+    let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "foo.set", arguments: arguments)
+    return Mockingbird.Mockable<Mockingbird.VariableDeclaration, (Bool) -> Void, Void>(mock: self, invocation: invocation)
+  }
+
+  fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
+    Mockingbird.checkVersion(for: self)
+    self.sourceLocation = sourceLocation
+  }
+}
+
+/// Initialize a protocol mock of `MockingbirdTestsHost.InheritedConflictingProtocolProperties`.
+public func mock(_ type: MockingbirdTestsHost.InheritedConflictingProtocolProperties.Protocol, file: StaticString = #file, line: UInt = #line) -> InheritedConflictingProtocolPropertiesMock {
+  return InheritedConflictingProtocolPropertiesMock(sourceLocation: SourceLocation(file, line))
+}
+
 // MARK: - Mocked InheritedTypeQualificationProtocolGenericImplementer
 
 public final class InheritedTypeQualificationProtocolGenericImplementerMock<T>: MockingbirdTestsHost.InheritedTypeQualificationProtocolGenericImplementer<T>, Mockingbird.Mock {
@@ -14290,6 +14415,27 @@ public final class ModuleScopedTypealiasedProtocolMock: MockingbirdTestsHost.Mod
 /// Initialize a protocol mock of `MockingbirdTestsHost.ModuleScopedTypealiasedProtocol`.
 public func mock(_ type: MockingbirdTestsHost.ModuleScopedTypealiasedProtocol.Protocol, file: StaticString = #file, line: UInt = #line) -> ModuleScopedTypealiasedProtocolMock {
   return ModuleScopedTypealiasedProtocolMock(sourceLocation: SourceLocation(file, line))
+}
+
+// MARK: - Mocked MultipleConflictingProtocolProperties
+
+public final class MultipleConflictingProtocolPropertiesMock: Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      MultipleConflictingProtocolPropertiesMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+}
+
+@available(*, unavailable, message: "'MultipleConflictingProtocolProperties' contains the properties 'bar' and 'foo' that each conflict with inherited declarations and cannot be mocked")
+public func mock(_ type: MockingbirdTestsHost.MultipleConflictingProtocolProperties.Protocol, file: StaticString = #file, line: UInt = #line) -> MultipleConflictingProtocolPropertiesMock {
+  fatalError()
 }
 
 // MARK: - Mocked NSObjectProtocolConformingProtocol
@@ -18023,6 +18169,27 @@ public func mock<ShadowedGenericType_ShadowedType, ShadowedType>(_ type: Shadowe
   return ShadowedGenericTypeMock<ShadowedGenericType_ShadowedType>.NestedDoublyShadowedGenericTypeMock<ShadowedType>(sourceLocation: SourceLocation(file, line))
 }
 
+// MARK: - Mocked SingleConflictingProtocolProperties
+
+public final class SingleConflictingProtocolPropertiesMock: Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SingleConflictingProtocolPropertiesMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+}
+
+@available(*, unavailable, message: "'SingleConflictingProtocolProperties' contains the property 'foo' that conflicts with an inherited declaration and cannot be mocked")
+public func mock(_ type: MockingbirdTestsHost.SingleConflictingProtocolProperties.Protocol, file: StaticString = #file, line: UInt = #line) -> SingleConflictingProtocolPropertiesMock {
+  fatalError()
+}
+
 // MARK: - Mocked SpecializedGenericProtocol
 
 public final class SpecializedGenericProtocolMock: MockingbirdTestsHost.GenericBaseClass<Bool>, MockingbirdTestsHost.SpecializedGenericProtocol, Mockingbird.Mock {
@@ -18627,6 +18794,27 @@ public final class SubclassingExternalClassWithInheritedIntializerMock: Mockingb
 /// Initialize an initializable class mock of `MockingbirdTestsHost.SubclassingExternalClassWithInheritedIntializer`.
 public func mock(_ type: MockingbirdTestsHost.SubclassingExternalClassWithInheritedIntializer.Type, file: StaticString = #file, line: UInt = #line) -> SubclassingExternalClassWithInheritedIntializerMock.InitializerProxy.Type {
   return SubclassingExternalClassWithInheritedIntializerMock.InitializerProxy.self
+}
+
+// MARK: - Mocked SubclassingExternalClass
+
+public final class SubclassingExternalClassMock: Mockingbird.Mock {
+  static let staticMock = Mockingbird.StaticMock()
+  public let mockingContext = Mockingbird.MockingContext()
+  public let stubbingContext = Mockingbird.StubbingContext()
+  public let mockMetadata = Mockingbird.MockMetadata(["generator_version": "0.11.0", "module_name": "MockingbirdTestsHost"])
+  public var sourceLocation: Mockingbird.SourceLocation? {
+    get { return stubbingContext.sourceLocation }
+    set {
+      stubbingContext.sourceLocation = newValue
+      SubclassingExternalClassMock.staticMock.stubbingContext.sourceLocation = newValue
+    }
+  }
+}
+
+@available(*, unavailable, message: "'SubclassingExternalClass' subclasses a type from a different module but does not declare any accessible initializers and cannot be mocked")
+public func mock(_ type: MockingbirdTestsHost.SubclassingExternalClass.Type, file: StaticString = #file, line: UInt = #line) -> SubclassingExternalClassMock {
+  fatalError()
 }
 
 // MARK: - Mocked SubclassingExternalSubclassWithDesignatedInitializer

--- a/MockingbirdTestsHost/ConflictingProtocolProperties.swift
+++ b/MockingbirdTestsHost/ConflictingProtocolProperties.swift
@@ -1,0 +1,24 @@
+//
+//  ConflictingProtocolProperties.swift
+//  MockingbirdTestsHost
+//
+//  Created by Andrew Chang on 5/4/20.
+//
+
+import Foundation
+
+protocol InheritedConflictingProtocolProperties {
+  var foo: Bool { get set }
+  var bar: Bool { get set }
+}
+
+// Not possible to create a class conforming to any of the protocols below.
+
+protocol SingleConflictingProtocolProperties: InheritedConflictingProtocolProperties {
+  var foo: String { get set }
+}
+
+protocol MultipleConflictingProtocolProperties: SingleConflictingProtocolProperties {
+  var foo: Int { get set }
+  var bar: Int { get set }
+}


### PR DESCRIPTION
Adds check for inherited property names that conflict with other declarations, specifically for protocols.

```swift
protocol InheritedConflictingProtocolProperties {
  var foo: Bool { get set }
  var bar: Bool { get set }
}

// Not possible to create a class conforming to any of the protocols below.

protocol SingleConflictingProtocolProperties: InheritedConflictingProtocolProperties {
  var foo: String { get set }
}

protocol MultipleConflictingProtocolProperties: SingleConflictingProtocolProperties {
  var foo: Int { get set }
  var bar: Int { get set }
}
```

Consolidates `.notMockable` diagnostic warnings into the rendering step.