### PR TITLE
Fix uniqueness and equality operators for parsed type models

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		D37503D92460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37503D82460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift */; };
 		D37503DB246120EA003017A7 /* ConflictingProtocolProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */; };
 		D3A854622460D9FC00C5764A /* ImplicitVariableTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */; };
+		D39350D0246619DC00FF52E2 /* DuplicateProtocolMembers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39350CF246619DC00FF52E2 /* DuplicateProtocolMembers.swift */; };
+		D3A854622460D9FC00C5764A /* ImplicitVariableTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */; };
 		OBJ_1001 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_1013 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* Empty.swift */; };
 		OBJ_1019 /* ChildMockMockableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* ChildMockMockableTests.swift */; };
@@ -1147,6 +1149,8 @@
 		D37503D82460FFE1003017A7 /* ImplicitVariableTypesStubbableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypesStubbableTests.swift; sourceTree = "<group>"; };
 		D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictingProtocolProperties.swift; sourceTree = "<group>"; };
 		D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypes.swift; sourceTree = "<group>"; };
+		D39350CF246619DC00FF52E2 /* DuplicateProtocolMembers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateProtocolMembers.swift; sourceTree = "<group>"; };
+		D3A854612460D9FC00C5764A /* ImplicitVariableTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitVariableTypes.swift; sourceTree = "<group>"; };
 		"Mockingbird::MockingbirdCli::Product" /* MockingbirdCli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = MockingbirdCli; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdFramework::Product" /* Mockingbird.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mockingbird.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Mockingbird::MockingbirdGenerator::Product" /* MockingbirdGenerator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockingbirdGenerator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2084,6 +2088,7 @@
 				D37503DA246120EA003017A7 /* ConflictingProtocolProperties.swift */,
 				OBJ_153 /* DeclarationAttributes.swift */,
 				OBJ_154 /* DefaultArgumentValues.swift */,
+				D39350CF246619DC00FF52E2 /* DuplicateProtocolMembers.swift */,
 				OBJ_155 /* EmptyTypes.swift */,
 				OBJ_156 /* Exceptions.swift */,
 				OBJ_157 /* Extensions.swift */,
@@ -4291,6 +4296,7 @@
 				D3A854622460D9FC00C5764A /* ImplicitVariableTypes.swift in Sources */,
 				OBJ_1166 /* TrivialIncludedSource.swift in Sources */,
 				OBJ_1167 /* ModuleImportCases.swift in Sources */,
+				D39350D0246619DC00FF52E2 /* DuplicateProtocolMembers.swift in Sources */,
 				OBJ_1168 /* NestedFields.swift in Sources */,
 				OBJ_1169 /* OpaquelyInheritedTypes.swift in Sources */,
 				OBJ_1170 /* Optionals.swift in Sources */,

--- a/MockingbirdGenerator/Parser/Models/Method.swift
+++ b/MockingbirdGenerator/Parser/Models/Method.swift
@@ -286,13 +286,13 @@ extension Method: Hashable {
     hasher.combine(whereClauses)
     hasher.combine(parameters)
   }
+  
+  static func == (lhs: Method, rhs: Method) -> Bool {
+    return lhs.hashValue == rhs.hashValue
+  }
 }
 
 extension Method: Comparable {
-  static func ==(lhs: Method, rhs: Method) -> Bool {
-    return lhs.hashValue == rhs.hashValue
-  }
-  
   static func < (lhs: Method, rhs: Method) -> Bool {
     return lhs.sortableIdentifier < rhs.sortableIdentifier
   }

--- a/MockingbirdGenerator/Parser/Models/MethodParameter.swift
+++ b/MockingbirdGenerator/Parser/Models/MethodParameter.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct MethodParameter: Hashable {
+struct MethodParameter {
   let name: String
   let argumentLabel: String?
   let typeName: String
@@ -60,6 +60,19 @@ struct MethodParameter: Hashable {
     self.attributes = attributes
     self.hasSelfConstraints = typeName.contains(SerializationRequest.Constants.selfTokenIndicator)
     self.rawType = rawType
+  }
+}
+
+extension MethodParameter: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(argumentLabel)
+    hasher.combine(typeName)
+    hasher.combine(kind.typeScope == .instance)
+    hasher.combine(attributes)
+  }
+  
+  static func == (lhs: MethodParameter, rhs: MethodParameter) -> Bool {
+    return lhs.hashValue == rhs.hashValue
   }
 }
 

--- a/MockingbirdGenerator/Parser/Models/Variable.swift
+++ b/MockingbirdGenerator/Parser/Models/Variable.swift
@@ -37,7 +37,7 @@ struct Variable: Hashable, Comparable {
     hasher.combine(kind.typeScope == .instance)
   }
   
-  static func ==(lhs: Variable, rhs: Variable) -> Bool {
+  static func == (lhs: Variable, rhs: Variable) -> Bool {
     return lhs.hashValue == rhs.hashValue
   }
   

--- a/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
+++ b/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
@@ -111,7 +111,7 @@ class ProcessStructuresOperation: BasicOperation {
     return Set(nameSuffix[whereRange.upperBound..<nameSuffix.endIndex]
       .components(separatedBy: ",", excluding: .allGroups)
       .compactMap({ WhereClause(from: String($0)) })
-      .filter({ $0.operator == .conforms && $0.constrainedTypeName == "Self" })
+      .filter({ $0.requirement == .conforms && $0.constrainedTypeName == "Self" })
       .map({ $0.genericConstraint }))
   }
   

--- a/MockingbirdTestsHost/DuplicateProtocolMembers.swift
+++ b/MockingbirdTestsHost/DuplicateProtocolMembers.swift
@@ -1,0 +1,39 @@
+//
+//  DuplicateProtocolMembers.swift
+//  MockingbirdTestsHost
+//
+//  Created by Andrew Chang on 5/8/20.
+//
+
+import Foundation
+
+// General de-deduplication of inherited methods and properties.
+protocol DuplicateInheritedProtocolMembers: ChildProtocol {
+  // MARK: Instance
+  var childPrivateSetterInstanceVariable: Bool { get }
+  var childInstanceVariable: Bool { get set }
+  func childTrivialInstanceMethod()
+  func childParameterizedInstanceMethod(param1: Bool, _ param2: Int) -> Bool
+  
+  // MARK: Static
+  static var childPrivateSetterStaticVariable: Bool { get }
+  static var childStaticVariable: Bool { get set }
+  static func childTrivialStaticMethod()
+  static func childParameterizedStaticMethod(param1: Bool, _ param2: Int) -> Bool
+}
+
+
+// Method parameter names can differ from inherited (but not the argument label).
+protocol FuzzyDuplicateInheritedProtocolMembers: ChildProtocol {
+  func childParameterizedInstanceMethod(param1 param1Name: Bool, _ param2Name: Int) -> Bool
+  static func childParameterizedStaticMethod(param1 param1Name: Bool, _ param2Name: Int) -> Bool
+}
+
+
+// Same-type generic conformance is commutative and needs to be de-duped.
+protocol GenericSameTypeConformance {
+  func method<T: Sequence, R: Sequence>(param: T) -> R where T.Element == R.Element
+}
+protocol DuplicateGenericSameTypeConformance: GenericSameTypeConformance {
+  func method<T: Sequence, R: Sequence>(param: T) -> R where R.Element == T.Element
+}


### PR DESCRIPTION
Fixes #118 

- Remove `MethodParameter` parameter names and other extraneous parsed info from hashed value
- Add considerations for generic same type requirement which is commutative and can have "swapped" lhs and rhs type identifiers