### PR TITLE
Add support for stubbing a sequence of implementations using closures

### DIFF
--- a/MockingbirdFramework/Mockingbird.swift
+++ b/MockingbirdFramework/Mockingbird.swift
@@ -32,19 +32,19 @@ public func sequence<FunctionType, ReturnType>(of values: ReturnType...)
     return StubImplementation<FunctionType, ReturnType>(handler: implementation, callback: nil)
 }
 
-/// Stub a sequence of lazily computed values, returning each value sequentially. The last value
-/// will be used if the number of invocations is greater than the number of values provided.
+/// Stub a sequence of implementations, calling each implementation sequentially. The last item will
+/// be used if the number of invocations is greater than the number of implementations provided.
 ///
-/// - Parameter lazyValue: A sequence of lazily computed values to stub.
-public func sequence<FunctionType, ReturnType>(of lazyValues: (() -> ReturnType)...)
+/// - Parameter implementations: A sequence of implementations to stub.
+public func sequence<FunctionType, ReturnType>(of implementations: (FunctionType)...)
   -> StubImplementation<FunctionType, ReturnType> {
     var index = 0
-    let implementation: () -> ReturnType = {
-      let value = lazyValues[index]()
-      if index+1 < lazyValues.count { index += 1 }
-      return value
+    let provider: () -> FunctionType = {
+      let implementation = implementations[index]
+      if index+1 < implementations.count { index += 1 }
+      return implementation
     }
-    return StubImplementation<FunctionType, ReturnType>(handler: implementation, callback: nil)
+    return StubImplementation<FunctionType, ReturnType>(provider: provider, callback: nil)
 }
 
 /// Stubs a variable getter to return the last value received by the setter.
@@ -59,7 +59,7 @@ public func lastSetValue<FunctionType, ReturnType>(initial: ReturnType)
       let setterImplementation = { (newValue: ReturnType) -> Void in
         currentValue = newValue
       }
-      _ = context.swizzle(setterInvocation, with: setterImplementation)
+      _ = context.swizzle(setterInvocation, with: { setterImplementation })
     }
     return StubImplementation<FunctionType, ReturnType>(handler: implementation, callback: callback)
 }

--- a/MockingbirdFramework/Stubbing/Stubbing.swift
+++ b/MockingbirdFramework/Stubbing/Stubbing.swift
@@ -26,8 +26,21 @@ public struct Stub<I, R> {
 /// Used for creating wrapped stub implementations that can also add side effects to stubbing, such
 /// as stubbing a setter when stubbing a getter.
 public struct StubImplementation<I, R> {
-  let handler: Any
+  let provider: () -> Any
   let callback: ((StubbingContext.Stub, StubbingContext) -> Void)?
+  
+  /// Create a stub implementation with a handler provider.
+  init(provider: @escaping () -> Any,
+       callback: ((StubbingContext.Stub, StubbingContext) -> Void)? = nil) {
+    self.provider = provider
+    self.callback = callback
+  }
+  
+  /// Create a stub implementation with a single handler.
+  init(handler: Any,
+       callback: ((StubbingContext.Stub, StubbingContext) -> Void)? = nil) {
+    self.init(provider: { handler }, callback: callback)
+  }
 }
 
 /// Convenience method for ignoring all parameters while stubbing.
@@ -37,7 +50,7 @@ public struct StubImplementation<I, R> {
 ///   - implementation: The non-throwing implementation stub.
 public func ~> <I, R>(stub: Stub<I, R>,
                       implementation: @escaping @autoclosure () -> R) {
-  addStub(stub, implementation: implementation)
+  addStub(stub, implementationProvider: { implementation })
 }
 
 /// Stub invocations to a mock taking into account the invocation (and its parameters).
@@ -46,20 +59,20 @@ public func ~> <I, R>(stub: Stub<I, R>,
 ///   - stubbingScope: An internal stubbing scope.
 ///   - implementation: The implementation stub.
 public func ~> <I, R>(stub: Stub<I, R>, implementation: I) {
-  addStub(stub, implementation: implementation)
+  addStub(stub, implementationProvider: { implementation })
 }
 
 /// Internal method for stubbing invocations with side effects.
 public func ~> <I, R>(stub: Stub<I, R>, implementation: StubImplementation<I, R>) {
-  addStub(stub, implementation: implementation.handler, callback: implementation.callback)
+  addStub(stub, implementationProvider: implementation.provider, callback: implementation.callback)
 }
 
 /// Internal helper to swizzle type-erased stub implementations onto stubbing contexts.
 func addStub<I, R>(_ stub: Stub<I, R>,
-                   implementation: Any?,
+                   implementationProvider: (() -> Any)?,
                    callback: ((StubbingContext.Stub, StubbingContext) -> Void)? = nil) {
   stub.requests.forEach({
-    let stub = $0.stubbingContext.swizzle($0.invocation, with: implementation)
+    let stub = $0.stubbingContext.swizzle($0.invocation, with: implementationProvider)
     callback?(stub, $0.stubbingContext)
   })
 }

--- a/MockingbirdFramework/Stubbing/StubbingContext.swift
+++ b/MockingbirdFramework/Stubbing/StubbingContext.swift
@@ -12,14 +12,14 @@ import XCTest
 public class StubbingContext {
   struct Stub {
     let invocation: Invocation
-    let implementation: Any?
+    let implementationProvider: (() -> Any)?
   }
   var stubs = Synchronized<[String: [Stub]]>([:])
   let defaultValueProvider = ValueProvider()
   var sourceLocation: SourceLocation?
   
-  func swizzle(_ invocation: Invocation, with implementation: Any?) -> Stub {
-    let stub = Stub(invocation: invocation, implementation: implementation)
+  func swizzle(_ invocation: Invocation, with implementationProvider: (() -> Any)?) -> Stub {
+    let stub = Stub(invocation: invocation, implementationProvider: implementationProvider)
     stubs.update { $0[invocation.selectorName, default: []].append(stub) }
     return stub
   }
@@ -39,7 +39,7 @@ public class StubbingContext {
   func implementation(for invocation: Invocation) -> Any? {
     return stubs.read({ $0[invocation.selectorName] })?
       .last(where: { $0.invocation == invocation })?
-      .implementation
+      .implementationProvider?()
   }
 
   func clearStubs() {

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ useDefaultValues(from: .standardProvider, on: bird)
 print(bird.name)  // Prints ""
 ```
 
-#### Sequence of Value
+#### Sequence of Values
 
 Methods that return a different value each time can be stubbed with a sequence of values. The last value will be used
 for all subsequent invocations.
@@ -361,6 +361,18 @@ given(bird.getName()) ~> sequence(of: "Ryan", "Sterling")
 print(bird.name)  // Prints "Ryan"
 print(bird.name)  // Prints "Sterling"
 print(bird.name)  // Prints "Sterling"
+```
+
+It’s also possible to stub a sequence of lazily-computed values using closures. 
+
+```swift
+given(bird.getName()) ~> sequence(of: {
+  return "Ryan"
+}, {
+  return "Sterling"
+}, {
+  return Bool.random() ? "Ryan" : "Sterling"
+})
 ```
 
 ### Verification


### PR DESCRIPTION
Closes #111 

Implementation closures follow the same principle as normal closure stubs that use the stubbing operator directly.

```swift
given(bird.getName()) ~> sequence(of: {
  return "Ryan"
}, {
  return "Sterling"
}, {
  return Bool.random() ? "Ryan" : "Sterling"
})
```

This replaces non-parameterized lazy sequential value stubbing in 0.12.