### PR TITLE
Fix verification for methods overloaded via generic return type

### DIFF
--- a/MockingbirdFramework/Verification/Invocation.swift
+++ b/MockingbirdFramework/Verification/Invocation.swift
@@ -11,12 +11,14 @@ import Foundation
 struct Invocation: CustomStringConvertible {
   let selectorName: String
   let arguments: [ArgumentMatcher]
+  let returnType: ObjectIdentifier
   let timestamp = Date()
   let identifier = UUID()
 
-  init(selectorName: String, arguments: [ArgumentMatcher]) {
+  init(selectorName: String, arguments: [ArgumentMatcher], returnType: ObjectIdentifier) {
     self.selectorName = selectorName
     self.arguments = arguments
+    self.returnType = returnType
   }
   
   /// Selector name without tickmark escaping.
@@ -47,13 +49,16 @@ struct Invocation: CustomStringConvertible {
     guard isGetter else { return nil }
     let setterSelectorName = String(selectorName.dropLast(4) + Constants.setterSuffix)
     let matcher = ArgumentMatcher(description: "any()", priority: .high) { return true }
-    return Invocation(selectorName: setterSelectorName, arguments: [matcher])
+    return Invocation(selectorName: setterSelectorName,
+                      arguments: [matcher],
+                      returnType: ObjectIdentifier(Void.self))
   }
 }
 
 extension Invocation: Equatable {
   static func == (lhs: Invocation, rhs: Invocation) -> Bool {
     guard lhs.arguments.count == rhs.arguments.count else { return false }
+    guard lhs.returnType == rhs.returnType else { return false }
     for (index, argument) in lhs.arguments.enumerated() {
       if argument != rhs.arguments[index] { return false }
     }

--- a/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
@@ -44,7 +44,7 @@ class InitializerMethodTemplate: MethodTemplate {
         \(functionDeclaration){
           \(trySuper)super.init(\(superCallParameters))
           Mockingbird.checkVersion(for: self)
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)], returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
           \(contextPrefix)mockingContext.didInvoke(invocation)
         }
       """
@@ -56,7 +56,7 @@ class InitializerMethodTemplate: MethodTemplate {
       \(attributes)
         \(functionDeclaration){\(superCall)
           Mockingbird.checkVersion(for: self)
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)], returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
           \(contextPrefix)mockingContext.didInvoke(invocation)
         }
       """

--- a/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -70,7 +70,7 @@ class MethodTemplate: Template {
       // MARK: Mocked \(fullNameForMocking)
     \(attributes)
       public \(overridableModifiers)func \(uniqueDeclaration) {
-        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)])
+        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [\(mockArgumentMatchers)], returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
     \(stubbedImplementationCall())
       }
     """
@@ -111,7 +111,7 @@ class MethodTemplate: Template {
       mockableMethods.append("""
       \(attributes)  public \(regularModifiers)func \(fullNameForMatchingVariadics) -> Mockingbird.Mockable<\(mockableGenericTypes)>\(genericConstraints) {
       \(resolvedVariadicArgumentMatchers)
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: arguments)
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: arguments, returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
           return Mockingbird.Mockable<\(mockableGenericTypes)>(mock: \(mockObject), invocation: invocation)
         }
       """)
@@ -312,12 +312,12 @@ class MethodTemplate: Template {
   lazy var matchableInvocation: String = {
     guard !method.parameters.isEmpty else {
       return """
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: [], returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
       """
     }
     return """
     \(resolvedArgumentMatchers)
-        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: arguments)
+        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclaration)", arguments: arguments, returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
     """
   }()
   

--- a/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -20,11 +20,11 @@ class SubscriptMethodTemplate: MethodTemplate {
     \(attributes)
       public \(overridableModifiers)\(uniqueDeclaration) {
         get {
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclarationForSubscriptGetter)", arguments: [\(mockArgumentMatchers)])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclarationForSubscriptGetter)", arguments: [\(mockArgumentMatchers)], returnType: Swift.ObjectIdentifier((\(unwrappedReturnTypeName)).self))
     \(stubbedImplementationCall().indent())
         }
         set {
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclarationForSubscriptSetter)", arguments: [\(mockArgumentMatchersForSubscriptSetter)])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(uniqueDeclarationForSubscriptSetter)", arguments: [\(mockArgumentMatchersForSubscriptSetter)], returnType: Swift.ObjectIdentifier(Void.self))
     \(stubbedSetterImplementationCall.indent())
         }
       }
@@ -77,6 +77,7 @@ class SubscriptMethodTemplate: MethodTemplate {
     let variant: FunctionVariant = isGetter ? .subscriptGetter : .subscriptSetter
     let fullName = self.fullName(for: .matching(useVariadics: isVariadic, variant: variant))
     let namePrefix = isGetter ? "get" : "set"
+    let escapedReturnType = isGetter ? "(" + unwrappedReturnTypeName + ")" : "Void"
     
     let selectorName = isGetter ?
       uniqueDeclarationForSubscriptGetter : uniqueDeclarationForSubscriptSetter
@@ -92,7 +93,7 @@ class SubscriptMethodTemplate: MethodTemplate {
     return """
     \(attributes)  public \(regularModifiers)func \(namePrefix)\(fullName.capitalizedFirst) -> Mockingbird.Mockable<\(mockableGenericTypes)>\(genericConstraints) {
     \(argumentMatchers)
-        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(selectorName)", arguments: arguments)
+        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(selectorName)", arguments: arguments, returnType: Swift.ObjectIdentifier(\(escapedReturnType).self))
         return Mockingbird.Mockable<\(mockableGenericTypes)>(mock: \(mockObject), invocation: invocation)
       }
     """

--- a/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -46,7 +46,7 @@ class VariableTemplate: Template {
     let setter = shouldGenerateSetter ? """
 
         set {
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(setterName)", arguments: [ArgumentMatcher(newValue)])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(setterName)", arguments: [ArgumentMatcher(newValue)], returnType: Swift.ObjectIdentifier(Void.self))
           \(contextPrefix)mockingContext.didInvoke(invocation)
           let implementation = \(contextPrefix)stubbingContext.implementation(for: invocation)
           if let concreteImplementation = implementation as? (\(unwrappedSpecializedTypeName)) -> Void {
@@ -61,7 +61,7 @@ class VariableTemplate: Template {
     \(attributes)
       \(override)public \(modifiers)var `\(variable.name)`: \(specializedTypeName) {
         get {
-          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(getterName)", arguments: [])
+          let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(getterName)", arguments: [], returnType: Swift.ObjectIdentifier((\(unwrappedSpecializedTypeName)).self))
           return \(contextPrefix)mockingContext.didInvoke(invocation) { () -> \(unwrappedSpecializedTypeName) in
             let implementation = \(contextPrefix)stubbingContext.implementation(for: invocation)
             if let concreteImplementation = implementation as? () -> \(unwrappedSpecializedTypeName) {
@@ -94,13 +94,13 @@ class VariableTemplate: Template {
     
     \(attributes)  public \(modifiers)func set\(capitalizedName)(_ newValue: @escaping @autoclosure () -> \(typeName)) -> Mockingbird.Mockable<\(mockableSetterGenericTypes)> {
         let arguments: [Mockingbird.ArgumentMatcher] = [Mockingbird.resolve(newValue)]
-        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(setterName)", arguments: arguments)
+        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(setterName)", arguments: arguments, returnType: Swift.ObjectIdentifier(Void.self))
         return Mockingbird.Mockable<\(mockableSetterGenericTypes)>(mock: \(mockObject), invocation: invocation)
       }
     """ : ""
     return """
     \(attributes)  public \(modifiers)func get\(capitalizedName)() -> Mockingbird.Mockable<\(mockableGetterGenericTypes)> {
-        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(getterName)", arguments: [])
+        let invocation: Mockingbird.Invocation = Mockingbird.Invocation(selectorName: "\(getterName)", arguments: [], returnType: Swift.ObjectIdentifier((\(unwrappedSpecializedTypeName)).self))
         return Mockingbird.Mockable<\(mockableGetterGenericTypes)>(mock: \(mockObject), invocation: invocation)
       }\(setter)
     """

--- a/MockingbirdTests/Framework/OverloadedMethodTests.swift
+++ b/MockingbirdTests/Framework/OverloadedMethodTests.swift
@@ -12,62 +12,28 @@ import Mockingbird
 class OverloadedMethodTests: XCTestCase {
   
   var classMock: OverloadedMethodsClassMock!
+  var classInstance: OverloadedMethodsClass { return classMock }
   var protocolMock: OverloadedMethodsProtocolMock!
+  var protocolInstance: OverloadedMethodsProtocol { return protocolMock }
   
   override func setUp() {
     classMock = mock(OverloadedMethodsClass.self)
     protocolMock = mock(OverloadedMethodsProtocol.self)
   }
   
-  func callOverloadedParametersMethod(on classMock: OverloadedMethodsClass,
-                                      param1: Bool = true,
-                                      param2: Bool = true) -> Bool {
-    return classMock.overloadedParameters(param1: param1, param2: param2)
-  }
-  func callOverloadedParametersMethod(on protocolMock: OverloadedMethodsProtocol,
-                                      param1: Bool = true,
-                                      param2: Bool = true) -> Bool {
-    return protocolMock.overloadedParameters(param1: param1, param2: param2)
-  }
-  
-  func callOverloadedParametersMethod(on classMock: OverloadedMethodsClass,
-                                      param1: Int = 1,
-                                      param2: Int = 1) -> Bool {
-    return classMock.overloadedParameters(param1: param1, param2: param2)
-  }
-  func callOverloadedParametersMethod(on protocolMock: OverloadedMethodsProtocol,
-                                      param1: Int = 1,
-                                      param2: Int = 1) -> Bool {
-    return protocolMock.overloadedParameters(param1: param1, param2: param2)
-  }
-  
-  func callOverloadedReturnTypeMethod(on classMock: OverloadedMethodsClass) -> Bool {
-    return classMock.overloadedReturnType()
-  }
-  func callOverloadedReturnTypeMethod(on protocolMock: OverloadedMethodsProtocol) -> Bool {
-    return protocolMock.overloadedReturnType()
-  }
-  
-  func callOverloadedReturnTypeMethod(on classMock: OverloadedMethodsClass) -> Int {
-    return classMock.overloadedReturnType()
-  }
-  func callOverloadedReturnTypeMethod(on protocolMock: OverloadedMethodsProtocol) -> Int {
-    return protocolMock.overloadedReturnType()
-  }
-  
   func testOverloadedMethod_classMock_overloadedParameters() {
     given(classMock.overloadedParameters(param1: any(Bool.self), param2: any())) ~> true
     given(classMock.overloadedParameters(param1: any(Int.self), param2: any())) ~> false
-    XCTAssertTrue(callOverloadedParametersMethod(on: classMock, param1: true, param2: false))
-    XCTAssertFalse(callOverloadedParametersMethod(on: classMock, param1: 1, param2: 2))
+    XCTAssertTrue(classInstance.overloadedParameters(param1: true, param2: false))
+    XCTAssertFalse(classInstance.overloadedParameters(param1: 1, param2: 2))
     verify(classMock.overloadedParameters(param1: any(Bool.self), param2: any())).wasCalled()
     verify(classMock.overloadedParameters(param1: any(Int.self), param2: any())).wasCalled()
   }
   func testOverloadedMethod_protocolMock_overloadedParameters() {
     given(protocolMock.overloadedParameters(param1: any(Bool.self), param2: any())) ~> true
     given(protocolMock.overloadedParameters(param1: any(Int.self), param2: any())) ~> false
-    XCTAssertTrue(callOverloadedParametersMethod(on: protocolMock, param1: true, param2: false))
-    XCTAssertFalse(callOverloadedParametersMethod(on: protocolMock, param1: 1, param2: 2))
+    XCTAssertTrue(protocolInstance.overloadedParameters(param1: true, param2: false))
+    XCTAssertFalse(protocolInstance.overloadedParameters(param1: 1, param2: 2))
     verify(protocolMock.overloadedParameters(param1: any(Bool.self), param2: any())).wasCalled()
     verify(protocolMock.overloadedParameters(param1: any(Int.self), param2: any())).wasCalled()
   }
@@ -75,16 +41,16 @@ class OverloadedMethodTests: XCTestCase {
   func testOverloadedMethod_classMock_overloadedReturnType() {
     given(classMock.overloadedReturnType()) ~> true
     given(classMock.overloadedReturnType()) ~> 1
-    XCTAssert(callOverloadedReturnTypeMethod(on: classMock) == true)
-    XCTAssert(callOverloadedReturnTypeMethod(on: classMock) == 1)
+    XCTAssert(classInstance.overloadedReturnType() == true)
+    XCTAssert(classInstance.overloadedReturnType() == 1)
     verify(classMock.overloadedReturnType()).returning(Bool.self).wasCalled()
     verify(classMock.overloadedReturnType()).returning(Int.self).wasCalled()
   }
   func testOverloadedMethod_protocolMock_overloadedReturnType() {
     given(protocolMock.overloadedReturnType()) ~> true
     given(protocolMock.overloadedReturnType()) ~> 1
-    XCTAssert(callOverloadedReturnTypeMethod(on: protocolMock) == true)
-    XCTAssert(callOverloadedReturnTypeMethod(on: protocolMock) == 1)
+    XCTAssert(protocolInstance.overloadedReturnType() == true)
+    XCTAssert(protocolInstance.overloadedReturnType() == 1)
     verify(protocolMock.overloadedReturnType()).returning(Bool.self).wasCalled()
     verify(protocolMock.overloadedReturnType()).returning(Int.self).wasCalled()
   }
@@ -92,14 +58,14 @@ class OverloadedMethodTests: XCTestCase {
   func testOverloadedMethod_classMock_overloadedParameters_separateInvocationCounts() {
     given(classMock.overloadedParameters(param1: any(Bool.self), param2: any())) ~> true
     given(classMock.overloadedParameters(param1: any(Int.self), param2: any())) ~> false
-    XCTAssertTrue(callOverloadedParametersMethod(on: classMock, param1: true, param2: false))
+    XCTAssertTrue(classInstance.overloadedParameters(param1: true, param2: false))
     verify(classMock.overloadedParameters(param1: any(Bool.self), param2: any())).wasCalled()
     verify(classMock.overloadedParameters(param1: any(Int.self), param2: any())).wasNeverCalled()
   }
   func testOverloadedMethod_protocolMock_overloadedParameters_separateInvocationCounts() {
     given(protocolMock.overloadedParameters(param1: any(Bool.self), param2: any())) ~> true
     given(protocolMock.overloadedParameters(param1: any(Int.self), param2: any())) ~> false
-    XCTAssertTrue(callOverloadedParametersMethod(on: protocolMock, param1: true, param2: false))
+    XCTAssertTrue(protocolInstance.overloadedParameters(param1: true, param2: false))
     verify(protocolMock.overloadedParameters(param1: any(Bool.self), param2: any())).wasCalled()
     verify(protocolMock.overloadedParameters(param1: any(Int.self), param2: any())).wasNeverCalled()
   }
@@ -107,15 +73,30 @@ class OverloadedMethodTests: XCTestCase {
   func testOverloadedMethod_classMock_overloadedReturnType_separateInvocationCounts() {
     given(classMock.overloadedReturnType()) ~> true
     given(classMock.overloadedReturnType()) ~> 1
-    XCTAssert(callOverloadedReturnTypeMethod(on: classMock) == true)
+    XCTAssert(classInstance.overloadedReturnType() == true)
     verify(classMock.overloadedReturnType()).returning(Bool.self).wasCalled()
     verify(classMock.overloadedReturnType()).returning(Int.self).wasNeverCalled()
   }
   func testOverloadedMethod_protocolMock_overloadedReturnType_separateInvocationCounts() {
     given(protocolMock.overloadedReturnType()) ~> true
     given(protocolMock.overloadedReturnType()) ~> 1
-    XCTAssert(callOverloadedReturnTypeMethod(on: protocolMock) == true)
+    XCTAssert(protocolInstance.overloadedReturnType() == true)
     verify(protocolMock.overloadedReturnType()).returning(Bool.self).wasCalled()
     verify(protocolMock.overloadedReturnType()).returning(Int.self).wasNeverCalled()
+  }
+  
+  func testOverloadedMethod_classMock_overloadedGenericReturnType_separateInvocationCounts() {
+    given(classMock.overloadedGenericReturnType()) ~> true
+    given(classMock.overloadedGenericReturnType()) ~> 1
+    XCTAssert(classInstance.overloadedGenericReturnType() == true)
+    verify(classMock.overloadedGenericReturnType()).returning(Bool.self).wasCalled()
+    verify(classMock.overloadedReturnType()).returning(Int.self).wasNeverCalled()
+  }
+  func testOverloadedMethod_protocolMock_overloadedGenericReturnType_separateInvocationCounts() {
+    given(protocolMock.overloadedGenericReturnType()) ~> true
+    given(protocolMock.overloadedGenericReturnType()) ~> 1
+    XCTAssert(protocolInstance.overloadedGenericReturnType() == true)
+    verify(protocolMock.overloadedGenericReturnType()).returning(Bool.self).wasCalled()
+    verify(protocolMock.overloadedGenericReturnType()).returning(Int.self).wasNeverCalled()
   }
 }

--- a/MockingbirdTestsHost/OverloadedMethods.swift
+++ b/MockingbirdTestsHost/OverloadedMethods.swift
@@ -14,7 +14,7 @@ protocol OverloadedMethodsProtocol {
   
   func overloadedReturnType() -> Bool
   func overloadedReturnType() -> Int
-  func overloadedReturnType<T>() -> T
+  func overloadedGenericReturnType<T>() -> T
 }
 
 class OverloadedMethodsClass {
@@ -24,5 +24,5 @@ class OverloadedMethodsClass {
   
   func overloadedReturnType() -> Bool { return true }
   func overloadedReturnType() -> Int { return 1 }
-  func overloadedReturnType<T>() -> T { fatalError() }
+  func overloadedGenericReturnType<T>() -> T { fatalError() }
 }


### PR DESCRIPTION
Fix verification for methods overloaded via generic return type

This was causing all invocations to methods with generic return types to be treated as returning the same type.

```swift
protocol MyProtocol {
  func genericMethod<T>() -> T
}

let myMock = mock(MyProtocol.self)
given(myMock.genericMethod()) ~> "Foo"
given(myMock.genericMethod()) ~> true

let foo: String = (myMock as MyProtocol).genericMethod()
let bar: Bool = (myMock as MyProtocol).genericMethod()

// Invocation counts for both were incorrectly 2 instead of 1
verify(myMock.genericMethod()).returning(String.self).wasCalled()
verify(myMock.genericMethod()).returning(Bool.self).wasCalled()
```

Fix is to also store the actual type returned at runtime in order to differentiate invocations to the same generic method.