### PR TITLE
Simplify installation instructions in README

### DIFF
--- a/Examples/iOSMockingbirdExample-Carthage/README.md
+++ b/Examples/iOSMockingbirdExample-Carthage/README.md
@@ -8,11 +8,6 @@ Having issues setting up Mockingbird? Join the [Slack channel](https://slofile.c
 
 ## Tutorial
 
-### Create the Xcode Project
-
-Open Xcode and create an iOS Single View App with the name `iOSMockingbirdExample-Carthage`. Make sure
-that the checkbox labeled “Include Unit Tests” is selected.
-
 ### Configure Carthage
 
 Create the Cartfile in the Xcode project root directory.
@@ -30,16 +25,15 @@ $ echo 'github "birdrides/mockingbird" ~> 0.12' >> Cartfile
 
 ### Install Mockingbird
 
-Build the framework using Carthage.
+Build the framework and link the built `Mockingbird.framework` to the test target, making sure to add the
+framework to
+[a new Copy Files build phase](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets) with the
+destination set to `Frameworks`.
 
 ```bash
 $ carthage update --platform ios
 $ open Carthage/Build/iOS
 ```
-
-Link the built `Mockingbird.framework` to the test target, making sure to add the framework to 
-[a new Copy Files build phase](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets) with the
-destination set to `Frameworks`.
 
 Then install the CLI.
 
@@ -47,7 +41,7 @@ Then install the CLI.
 $ (cd Carthage/Checkouts/mockingbird && make install-prebuilt)
 ```
 
-Configure the test target by using the CLI.
+Configure the test target.
 
 ```bash
 $ mockingbird install \

--- a/Examples/iOSMockingbirdExample-CocoaPods/README.md
+++ b/Examples/iOSMockingbirdExample-CocoaPods/README.md
@@ -8,11 +8,6 @@ Having issues setting up Mockingbird? Join the [Slack channel](https://slofile.c
 
 ## Tutorial
 
-### Create the Xcode Project
-
-Open Xcode and create an iOS Single View App with the name `iOSMockingbirdExample-CocoaPods`. Make sure
-that the checkbox labeled “Include Unit Tests” is selected.
-
 ### Configure CocoaPods
 
 Create the Podfile in the Xcode project root directory.
@@ -33,14 +28,14 @@ end
 
 ### Install Mockingbird
 
-Install the framework and CLI.
+Initialize the pod and install the CLI.
 
 ```bash
 $ pod install
 $ (cd Pods/MockingbirdFramework && make install-prebuilt)
 ```
 
-Then configure the test target by using the CLI.
+Then configure the test target.
 
 ```bash
 $ mockingbird install \

--- a/Examples/iOSMockingbirdExample-SPM/README.md
+++ b/Examples/iOSMockingbirdExample-SPM/README.md
@@ -8,11 +8,6 @@ Having issues setting up Mockingbird? Join the [Slack channel](https://slofile.c
 
 ## Tutorial
 
-### Create the Xcode Project
-
-Open Xcode and create an iOS Single View App with the name `iOSMockingbirdExample-SPM`. Make sure that the
-checkbox labeled “Include Unit Tests” is selected.
-
 ### Configure Dependencies
 
 1. File > Swift Packages > Add Package Dependency…
@@ -22,17 +17,17 @@ checkbox labeled “Include Unit Tests” is selected.
 
 ### Install Mockingbird
 
-Install the CLI from the checked out Mockingbird repository in derived data. 
+Initialize the package dependency and install the CLI.
 
 ```bash
 $ xcodebuild -resolvePackageDependencies
-$ DERIVED_DATA=$(xcodebuild -showBuildSettings | grep -m1 'BUILD_DIR' | grep -o '\/.*' | dirname $(xargs dirname))
+$ DERIVED_DATA=$(xcodebuild -showBuildSettings | pcregrep -o1 'OBJROOT = (/.*)/Build')
 $ (cd "${DERIVED_DATA}/SourcePackages/checkouts/mockingbird" && make install-prebuilt)
 ```
 
 ### Configure Test Target
 
-Configure the test target by using the CLI.
+Configure the test target.
 
 ```bash
 $ mockingbird install \

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ setup-carthage:
 
 setup-spm:
 	(cd Examples/iOSMockingbirdExample-SPM && xcodebuild -resolvePackageDependencies)
-	$(eval DERIVED_DATA = $(shell xcodebuild -project Examples/iOSMockingbirdExample-SPM/iOSMockingbirdExample-SPM.xcodeproj -showBuildSettings | grep -m1 'BUILD_DIR' | grep -o '\/.*' | xargs dirname | xargs dirname))
+	$(eval DERIVED_DATA = $(shell xcodebuild -project Examples/iOSMockingbirdExample-SPM/iOSMockingbirdExample-SPM.xcodeproj -showBuildSettings | pcregrep -o1 'OBJROOT = (/.*)/Build'))
 	(cd $(DERIVED_DATA)/SourcePackages/checkouts/mockingbird && make install-prebuilt)
 
 test-cocoapods: setup-cocoapods

--- a/MockingbirdCli/Interface/Commands/InstallCommand.swift
+++ b/MockingbirdCli/Interface/Commands/InstallCommand.swift
@@ -10,7 +10,24 @@ import MockingbirdGenerator
 import PathKit
 import SPMUtility
 
-final class InstallCommand: BaseCommand {
+class ConfigureCommand: InstallCommand {
+  private enum Constants {
+    static let name = "configure"
+    static let overview = "Configure a test target to use mocks (alias of 'install')."
+  }
+  override var name: String { return Constants.name }
+  override var overview: String { return Constants.overview }
+  
+  required init(parser: ArgumentParser) {
+    super.init(parser: parser, name: Constants.name, overview: Constants.overview)
+  }
+  
+  required init(parser: ArgumentParser, name: String, overview: String) {
+    super.init(parser: parser, name: name, overview: overview)
+  }
+}
+
+class InstallCommand: BaseCommand, AliasableCommand {
   private enum Constants {
     static let name = "install"
     static let overview = "Configure a test target to use mocks."
@@ -37,8 +54,12 @@ final class InstallCommand: BaseCommand {
   private let disableCacheArgument: OptionArgument<Bool>
   private let disableRelaxedLinking: OptionArgument<Bool>
   
-  required init(parser: ArgumentParser) {
-    let subparser = parser.add(subparser: Constants.name, overview: Constants.overview)
+  required convenience init(parser: ArgumentParser) {
+    self.init(parser: parser, name: Constants.name, overview: Constants.overview)
+  }
+  
+  required init(parser: ArgumentParser, name: String, overview: String) {
+    let subparser = parser.add(subparser: name, overview: overview)
     
     self.projectPathArgument = subparser.addProjectPath()
     self.sourceTargetsArgument = subparser.addSourceTargets()
@@ -108,6 +129,7 @@ final class InstallCommand: BaseCommand {
     print("""
     Please add starter supporting source files for basic compatibility with system frameworks.
       $ mockingbird download starter-pack
+    See https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files for more information.
     """)
   }
 }

--- a/MockingbirdCli/Interface/Program.swift
+++ b/MockingbirdCli/Interface/Program.swift
@@ -22,6 +22,10 @@ protocol Command {
            workingPath: Path) throws
 }
 
+protocol AliasableCommand: BaseCommand {
+  init(parser subparser: ArgumentParser, name: String, overview: String)
+}
+
 class BaseCommand: Command {
   var name: String { fatalError() }
   var overview: String { fatalError() }

--- a/MockingbirdCli/main.swift
+++ b/MockingbirdCli/main.swift
@@ -12,6 +12,7 @@ func main(arguments: [String]) -> Int32 {
   let program = Program(usage: "<method>",
                         overview: "Mockingbird mock generator",
                         commands: [GenerateCommand.self,
+                                   ConfigureCommand.self,
                                    InstallCommand.self,
                                    UninstallCommand.self,
                                    DownloadCommand.self,

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ readable tests.
 
 ### Under the Hood
 
-Mockingbird consists of two main components: the _generator_ and the _testing framework_. Before each test bundle
-compilation, configurable mock objects are created by implementing protocols and subclassing classes. The testing
+Mockingbird consists of two main components: the _generator_ and the _testing framework_. The generator creates
+mocks before each test bundle compilation by implementing protocols and subclassing classes, while the testing
 framework hooks into the generated code and provides APIs for mocking, stubbing, and verification.
+
+A key design consideration was performance. Mockingbird runs an optimized parser built on SwiftSyntax and
+SourceKit that is [~30-40x faster](https://github.com/birdrides/mockingbird/wiki/Performance) than existing
+frameworks and supports a
+[broad range](https://github.com/birdrides/mockingbird/wiki/Elephant-in-the-Room#other-third-party-mocking-frameworks)
+of complex Swift features like generics and type qualification.
 
 ### A Simple Example
 
@@ -77,30 +83,41 @@ func testShakingTreeCausesBirdToFly() {
 
 ## Installation
 
-### CocoaPods
+<details><summary><b>CocoaPods</b></summary>
 
 Add the framework to a test target in your `Podfile`, making sure to include the `use_frameworks!` option.
 
 ```ruby
-target 'MyTestTarget' do
+target 'MyAppTests' do
   use_frameworks!
   pod 'MockingbirdFramework', '~> 0.12'
 end
 ```
 
-Initialize the pod.
+Initialize the pod and install the CLI.
 
 ```bash
 $ pod install
-```
-
-Then install the CLI.
-
-```bash
 $ (cd Pods/MockingbirdFramework && make install-prebuilt)
 ```
 
-### Carthage
+Finally, configure your test target to start generating mocks before each test bundle compilation. List all source targets
+that should be mocked. You can also
+[set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
+
+```bash
+$ mockingbird install --target MyAppTests --sources MyApp MyLibrary1 MyLibrary2
+```
+
+Have questions or issues?
+
+- Join the [Slack channel](https://slofile.com/slack/birdopensource)
+- Search the [troubleshooting guide](https://github.com/birdrides/mockingbird/wiki/Troubleshooting)
+- Check out the [CocoaPods tutorial + example project](/Examples/iOSMockingbirdExample-CocoaPods)
+
+</details>
+
+<details><summary><b>Carthage</b></summary>
 
 Add the framework to your `Cartfile`.
 
@@ -108,25 +125,33 @@ Add the framework to your `Cartfile`.
 github "birdrides/mockingbird" ~> 0.12
 ```
 
-Build the framework using Carthage and [link it to your test target](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets), making
-sure to add the framework to a Copy Files build phase with the destination set to `Frameworks`.
+Build the framework with Carthage,
+[link it to your test target](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets), and install the CLI.
 
 ```bash
 $ carthage update
-```
-
-Then install the CLI.
-
-```bash
 $ (cd Carthage/Checkouts/mockingbird && make install-prebuilt)
 ```
 
-### Swift Package Manager
+Finally, configure your test target to start generating mocks before each test bundle compilation. List all source targets
+that should be mocked. You can also
+[set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
 
-<details><summary>Using a Package Manifest</summary>
+```bash
+$ mockingbird install --target MyAppTests --sources MyApp MyLibrary1 MyLibrary2
+```
 
-Add Mockingbird as a package dependency in `Package.swift`, making sure to include it as a dependency to your
-test target.
+Have questions or issues?
+
+- Join the [Slack channel](https://slofile.com/slack/birdopensource)
+- Search the [troubleshooting guide](https://github.com/birdrides/mockingbird/wiki/Troubleshooting)
+- Check out the [Carthage tutorial + example project](/Examples/iOSMockingbirdExample-Carthage)
+
+</details>
+
+<details><summary><b>Swift Package Manager</b></summary>
+
+Add the framework as a package and test target dependency in your project’s `Package.swift` manifest file.
 
 ```swift
 let package = Package(
@@ -134,96 +159,37 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/birdrides/mockingbird.git", from: "0.12.0"),
   ],
-  .testTarget(
-    name: "MyPackageTests",
-    dependencies: [
-      "Mockingbird",
-    ],
-    path: "MyPackageTests"
-  )
+  targets: [
+    .testTarget(name: "MyPackageTests", dependencies: ["Mockingbird"]),
+  ]
 )
 ```
 
-</details>
-
-<details><summary>Using Xcode’s GUI</summary>
-
-Add a new package dependency with `https://github.com/birdrides/mockingbird.git` as the repository
-URL, making sure to select your test target for the Mockingbird library product.
-
-</details>
-
-Initialize the package dependency.
+Initialize the package dependency and install the CLI.
 
 ```bash
 $ xcodebuild -resolvePackageDependencies
-```
-
-Then install the CLI.
-
-```bash
-$ DERIVED_DATA=$(xcodebuild -showBuildSettings | grep -m1 'BUILD_DIR' | grep -o '\/.*' | dirname $(xargs dirname))
+$ DERIVED_DATA=$(xcodebuild -showBuildSettings | pcregrep -o1 'OBJROOT = (/.*)/Build')
 $ (cd "${DERIVED_DATA}/SourcePackages/checkouts/mockingbird" && make install-prebuilt)
 ```
 
-### From Source
-
-Clone the repository.
-
-```bash
-$ git clone https://github.com/birdrides/mockingbird.git
-$ cd mockingbird
-```
-
-Build the release artifacts and add the framework to your project, making sure to 
-[link it to your test target](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets).
+Finally, configure your test target to start generating mocks before each test bundle compilation. List all source targets
+that should be mocked. You can also
+[set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
 
 ```bash
-$ make release
-$ unzip Mockingbird.zip -d bin
+$ mockingbird install --target MyPackageTests --sources MyPackage MyLibrary1 MyLibrary2
 ```
 
-Then build and install the CLI, or use the `Mockingbird.pkg` installer.
+Have questions or issues?
 
-```bash
-$ make install
-```
+- Join the [Slack channel](https://slofile.com/slack/birdopensource)
+- Search the [troubleshooting guide](https://github.com/birdrides/mockingbird/wiki/Troubleshooting)
+- Check out the [Swift Package Manager tutorial + example project](/Examples/iOSMockingbirdExample-SPM)
 
-## Setup
-
-Use the CLI to configure a test target, listing all source targets that should be mocked.
-
-```bash
-$ mockingbird install \
-  --target BirdTests \
-  --sources Bird BirdManagers
-```
-
-Need to [set up your project manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup)?
-
-### System Framework Compatibility
-
-For basic compatibility with system frameworks and types defined outside of your project, download the latest starter
-supporting source files. Note that supporting source files should not be imported into Xcode or added to any targets.
-See [Supporting Source Files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files) for more information.
-
-```bash
-$ mockingbird download starter-pack
-```
-
-### Excluding Files
-
-You can exclude unwanted or problematic sources from being mocked by adding a `.mockingbird-ignore` file. 
-Mockingbird follows the same pattern format as [`.gitignore`](https://git-scm.com/docs/gitignore#_pattern_format) 
-and scopes ignore files to their enclosing directory.
+</details>
 
 ## Usage
-
-Example projects demonstrating basic usage of Mockingbird:
-
-- [CocoaPods tutorial + example project](/Examples/iOSMockingbirdExample-CocoaPods)
-- [Carthage tutorial + example project](/Examples/iOSMockingbirdExample-Carthage)
-- [Swift Package Manager tutorial + example project](/Examples/iOSMockingbirdExample-SPM)
 
 ### Mocking
 
@@ -324,7 +290,7 @@ provides preset value providers which are guaranteed to be backwards compatible,
 
 ```swift
 useDefaultValues(from: .standardProvider, on: bird)
-print(bird.name)    // Prints ""
+print(bird.name)  // Prints ""
 ```
 
 Values from concrete stubs always have a higher precedence than default values.
@@ -571,6 +537,12 @@ fuzzily match floating point arguments with some tolerance.
 around(10.0, tolerance: 0.01)
 ```
 
+### Excluding Files
+
+You can exclude unwanted or problematic sources from being mocked by adding a `.mockingbird-ignore` file. 
+Mockingbird follows the same pattern format as [`.gitignore`](https://git-scm.com/docs/gitignore#_pattern_format) 
+and scopes ignore files to their enclosing directory.
+
 ## Mockingbird CLI
 
 ### Generate
@@ -674,6 +646,14 @@ Mockingbird will recursively look for [supporting source files](https://github.c
 
 ## Additional Resources
 
-- [Troubleshooting](https://github.com/birdrides/mockingbird/wiki/Troubleshooting)
+### Examples and Tutorials
+
+- [CocoaPods tutorial + example project](/Examples/iOSMockingbirdExample-CocoaPods)
+- [Carthage tutorial + example project](/Examples/iOSMockingbirdExample-Carthage)
+- [Swift Package Manager tutorial + example project](/Examples/iOSMockingbirdExample-SPM)
+
+### Help and Documentation
+
 - [Slack channel](https://slofile.com/slack/birdopensource)
+- [Troubleshooting guide](https://github.com/birdrides/mockingbird/wiki/Troubleshooting)
 - [Mockingbird wiki](https://github.com/birdrides/mockingbird/wiki/)


### PR DESCRIPTION
Also removes building framework from source in README. Will be moved to wiki along with best practices for Module Stability and CI integration.