### PR TITLE
Refactor automatic conformance and improve Self constraint handling

### DIFF
--- a/MockingbirdGenerator/Parser/Models/Specializable.swift
+++ b/MockingbirdGenerator/Parser/Models/Specializable.swift
@@ -8,6 +8,28 @@
 import Foundation
 
 struct SpecializationContext {
+  init?(typeName: String, baseRawType: RawType) {
+    let declaredType = DeclaredType(from: typeName)
+    var parsedGenericTypes: [DeclaredType]? {
+      switch declaredType {
+      case .single(let single, _): return single.genericTypes
+      case .tuple: return nil
+      }
+    }
+    guard let remappedGenericTypes = parsedGenericTypes else { return nil }
+    
+    var specializations = [String: DeclaredType]()
+    var typeList = [DeclaredType]()
+    for (i, genericType) in baseRawType.genericTypes.enumerated() {
+      guard let remappedGenericType = remappedGenericTypes.get(i) else { break }
+      specializations[genericType] = remappedGenericType
+      typeList.append(remappedGenericType)
+    }
+    
+    self.specializations = specializations
+    self.typeList = typeList
+  }
+  
   /// Mapping from generic type name to a serializable `DeclaredType`
   let specializations: [String: DeclaredType]
   

--- a/MockingbirdTests/Framework/InitializerTests.swift
+++ b/MockingbirdTests/Framework/InitializerTests.swift
@@ -68,7 +68,7 @@ class InitializerTests: XCTestCase {
     classOnlyProtocolWithInheritance = mock(ClassOnlyProtocolWithInheritance.self)
     openClassConstrainedProtocol =
       mock(ConformingInitializableOpenClassConstrainedProtocol.self).initialize()
-    nsObjectProtocolConformingProtocol = mock(NSObjectProtocolConformingProtocol.self)
+    nsObjectProtocolConformingProtocol = mock(NSObjectProtocolConformingProtocol.self).initialize()
     initializableClassOnlyProtocol =
       mock(InitializableClassOnlyProtocol.self).initialize(param1: true, param2: 42)
     initializableClassOnlyProtocolWithInheritedInitializer =

--- a/MockingbirdTestsHost/Generics.swift
+++ b/MockingbirdTestsHost/Generics.swift
@@ -91,7 +91,12 @@ public protocol AssociatedTypeSelfReferencingProtocol {
   func request(object: Self)
 }
 
-public protocol InheritingAssociatedTypeSelfReferencingProtocol: AssociatedTypeSelfReferencingProtocol {}
+// MARK: Inheritance
+
+public protocol InheritingAssociatedTypeSelfReferencingProtocol:
+AssociatedTypeSelfReferencingProtocol {}
+public protocol IndirectlyInheritingAssociatedTypeSelfReferencingProtocol:
+InheritingAssociatedTypeSelfReferencingProtocol {}
 
 public protocol SecondLevelSelfConstrainedAssociatedTypeProtocol
 where Self: AssociatedTypeSelfReferencingProtocol {}
@@ -101,11 +106,42 @@ where Self: SecondLevelSelfConstrainedAssociatedTypeProtocol, Self.Element: Hash
   associatedtype Element
 }
 
-public protocol OpaqueClassSelfConstrainedAssociatedTypeProtocol
-where Self: NSViewController {}
+// NOTE: Constraint syntax is sugar for `where Self: <Type>`, but SourceKit treats them differently.
 
-public protocol OpaqueProtocolSelfConstrainedAssociatedTypeProtocol
-where Self: Hashable {}
+public protocol ExplicitSelfConstrainedToClassProtocol where Self: NSViewController {}
+public protocol InheritingExplicitSelfConstrainedToClassProtocol
+where Self: ExplicitSelfConstrainedToClassProtocol {}
+public protocol IndirectlyInheritingExplicitSelfConstrainedToClassProtocol
+where Self: InheritingExplicitSelfConstrainedToClassProtocol {}
+
+public protocol ConstrainedToClassProtocol: NSViewController {}
+public protocol InheritingConstrainedToClassProtocol: ConstrainedToClassProtocol {}
+public protocol IndirectlyInheritingConstrainedToClassProtocol:
+InheritingConstrainedToClassProtocol {}
+
+public protocol ExplicitSelfConstrainedToProtocolProtocol where Self: Hashable {}
+public protocol InheritingExplicitSelfConstrainedToProtocolProtocol
+where Self: ExplicitSelfConstrainedToProtocolProtocol {}
+public protocol IndirectlyInheritingExplicitSelfConstrainedToProtocolProtocol
+where Self: InheritingExplicitSelfConstrainedToProtocolProtocol {}
+
+public protocol ConstrainedToProtocolProtocol: Hashable {}
+public protocol InheritingConstrainedToProtocolProtocol: ConstrainedToProtocolProtocol {}
+public protocol IndirectlyInheritingConstrainedToProtocolProtocol:
+InheritingConstrainedToProtocolProtocol {}
+
+public protocol AutomaticallyConformedExplicitSelfConstrainedProtocol
+where Self: Foundation.NSObjectProtocol {}
+public protocol InheritingAutomaticallyConformedExplicitSelfConstrainedProtocol
+where Self: AutomaticallyConformedExplicitSelfConstrainedProtocol {}
+public protocol IndirectlyInheritingAutomaticallyConformedExplicitSelfConstrainedProtocol
+where Self: InheritingAutomaticallyConformedExplicitSelfConstrainedProtocol {}
+
+public protocol AutomaticallyConformedConstrainedProtocol: Foundation.NSObjectProtocol {}
+public protocol InheritingAutomaticallyConformedConstrainedProtocol:
+AutomaticallyConformedConstrainedProtocol {}
+public protocol IndirectlyInheritingAutomaticallyConformedConstrainedProtocol:
+InheritingAutomaticallyConformedConstrainedProtocol {}
 
 public class ReferencedGenericClass<T> {}
 public class ReferencedGenericClassWithConstraints<S: Sequence> where S.Element: Hashable {}
@@ -132,6 +168,8 @@ public class GenericBaseClass<T> {
   func baseMethod(param: T) -> T { fatalError() }
 }
 
+// MARK: Shadowing
+
 public struct ShadowedType {}
 
 public class ShadowedGenericType<ShadowedType> {
@@ -149,17 +187,40 @@ public class ShadowedGenericType<ShadowedType> {
   }
 }
 
+// MARK: Specialization
+
 class SpecializedGenericSubclass: GenericBaseClass<Bool> {}
+class InheritingSpecializedGenericSubclass: SpecializedGenericSubclass {}
+class IndirectlyInheritingSpecializedGenericSubclass: InheritingSpecializedGenericSubclass {}
+
 protocol SpecializedGenericProtocol: GenericBaseClass<Bool> {}
+protocol InheritingSpecializedGenericProtocol: SpecializedGenericProtocol {}
+protocol IndirectlyInheritingSpecializedGenericProtocol: InheritingSpecializedGenericProtocol {}
+
+protocol SpecializedExplicitSelfConstrainedGenericProtocol
+where Self: GenericBaseClass<Bool> {}
+protocol InheritingSpecializedExplicitSelfConstrainedGenericProtocol
+where Self: SpecializedExplicitSelfConstrainedGenericProtocol {}
+protocol IndirectlyInheritingSpecializedExplicitSelfConstrainedGenericProtocol
+where Self: InheritingSpecializedExplicitSelfConstrainedGenericProtocol {}
+
 protocol AbstractSpecializedGenericProtocol: GenericBaseClass<Bool> {
   associatedtype EquatableType: Equatable
 }
+protocol InheritingAbstractSpecializedGenericProtocol: AbstractSpecializedGenericProtocol {}
+protocol IndirectlyInheritingAbstractSpecializedGenericProtocol:
+InheritingAbstractSpecializedGenericProtocol {}
 
 class SpecializedShadowedGenericSubclass: ShadowedGenericType<NSObject> {}
 protocol SpecializedShadowedGenericProtocol: ShadowedGenericType<NSObject> {}
 
 class UnspecializedGenericSubclass<T>: GenericBaseClass<T> {}
+class InheritingUnspecializedGenericSubclass<T>: UnspecializedGenericSubclass<T> {}
 
 class ConstrainedUnspecializedGenericSubclass<T: Equatable>: GenericBaseClass<T> {}
+class InheritingConstrainedUnspecializedGenericSubclass<T: Equatable>:
+ConstrainedUnspecializedGenericSubclass<T> {}
 
 class UnspecializedMultipleGenericSubclass<T, R>: GenericBaseClass<T> {}
+class InheritingUnspecializedMultipleGenericSubclass<T, R>:
+UnspecializedMultipleGenericSubclass<T, R> {}


### PR DESCRIPTION
Automatic conformance of unmockable protocols like `NSObjectProtocol` to
`NSObject` were previously handled by the rendering pipeline instead of
the parsing pipeline as a kind of post-processing step.

```swift
protocol MyProtocol: NSObjectProtocol {}
protocol InheritingMyProtocol: MyProtocol {}

// Would previously fail to auto-conform to `NSObject`
protocol IndirectlyInheritingMyProtocol: InheritingMyProtocol {}
```

This resulted in incorrect behavior for indirect inheritance and also
didn't play nicely with specialization contexts for Self constraints and
class constrained protocols.

```swift
class MyClass<T> {}
protocol MyProtocol: MyClass<Int> {}

// Would previously try to incorrectly conform to `MyClass<T>`
protocol InheritingMyProtocol: SpecializedProtocol {}
```