### PR TITLE
Improve type inference for enums

### DIFF
--- a/Sources/MockingbirdGenerator/Parser/Models/InferType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/InferType.swift
@@ -130,15 +130,16 @@ private func parseInitializer(from string: String) -> String? {
 
 /// Try to parse qualified enums, e.g. `MyEnum.someCase(...)` => `MyEnum`.
 private func parseEnum(from string: String) -> String? {
-  let lastCharacter = string.last
-  guard lastCharacter?.isLetter == true
-    || lastCharacter?.isNumber == true
-    || lastCharacter == "_"
-    else { return nil }
-  
   // This can incorrectly infer uncapitalized qualified non-enum types e.g. `MyModule.fooClass`.
   let components = string.components(separatedBy: ".", excluding: .allGroups)
   guard components.count > 1, components.last?.first?.isLowercase ?? false else { return nil }
+  
+  // All components must be valid. This can incorrectly infer static methods and properties.
+  var validCharacterSet = CharacterSet.alphanumerics
+  validCharacterSet.insert("_")
+  guard components.reduce(into: true, { (result, component) in
+    result = result && component.rangeOfCharacter(from: validCharacterSet.inverted) == nil
+  }) else { return nil }
   
   // All identifier components must be capitalized.
   let identifierComponents = components.dropLast()

--- a/Sources/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
@@ -165,7 +165,6 @@ extension SerializationRequest {
     
     // Don't qualify generic types which could be shadowing types defined at the module level.
     guard !context.genericTypeContext.contains(where: { $0.contains(typeName) }) else {
-      print("wtfwtf shadowed module \(typeName)")
       return serializeGenericTypes(typeName)
     }
     
@@ -262,7 +261,6 @@ extension SerializationRequest {
       let specialization = context.specializationContext?.specializations[typeName],
       !context.excludedGenericTypeNames.contains(typeName)
       else {
-        print("wtfwtf not specialized \(typeName)")
         return nil
     }
     

--- a/Sources/MockingbirdTestsHost/ImplicitVariableTypes.swift
+++ b/Sources/MockingbirdTestsHost/ImplicitVariableTypes.swift
@@ -14,6 +14,19 @@ enum EnumWithCapitalizedCases {
   case Failure
 }
 
+enum EnumWithAssociatedValues {
+  case success(message: String)
+  case failure(message: String)
+}
+
+class ClassWithProperty {
+  var property: String { fatalError() }
+}
+
+class ClassWithStaticProperty {
+  static var property: String { fatalError() }
+}
+
 class ImplicitVariableTypes {
   // MARK: Inferrable
   var boolType = true
@@ -34,6 +47,11 @@ class ImplicitVariableTypes {
   // MARK: Not inferrable
   var complexFunctionalType = "foo".map({ $0.uppercased() })
   var qualifiedCapitalizedEnumType = EnumWithCapitalizedCases.Success
+  var qualifiedAssociatedValueEnumType = EnumWithAssociatedValues.success(message: "foo")
+  var classWithProperty = ClassWithProperty().property
   lazy var lazyComplexFunctionalType = self.stringType.map({ $0.uppercased() })
-  // var actuallyAFunction = NotAType() // TODO: This is an edge case we don't handle yet.
+  
+  // TODO: Edge cases the type inference system doesn't handle yet.
+  // var classWithStaticProperty = ClassWithStaticProperty.property
+  // var actuallyAFunction = NotAType()
 }

--- a/Tests/E2E/ImplicitVariableTypesMockableTests.swift
+++ b/Tests/E2E/ImplicitVariableTypesMockableTests.swift
@@ -20,7 +20,6 @@ private protocol MockableImplicitVariableTypes {
   var dictionaryType: [String: Bool] { get set }
   var dictionaryArrayType: [String: [Bool]] { get set }
   var dictionaryDictionaryType: [String: [String: Bool]] { get set }
-  var qualifiedEnumType: EnumType { get set }
   var explicitInitializedType: String { get set }
   var implicitInitializedType: Bool { get set }
   var implicitGenericInitializedType: Array<(String, Int)> { get set }

--- a/Tests/Generator/InferTypeTests.swift
+++ b/Tests/Generator/InferTypeTests.swift
@@ -10,6 +10,9 @@ import XCTest
 @testable import MockingbirdGenerator
 
 class InferTypeTests: XCTestCase {
+  
+  // MARK: - Literals
+  
   func testBooleanLiteralType() {
     XCTAssertEqual(inferType(from: "true"), "Bool")
     XCTAssertEqual(inferType(from: "false"), "Bool")
@@ -34,9 +37,31 @@ class InferTypeTests: XCTestCase {
     XCTAssertEqual(inferType(from: "##\"foo bar\"##"), "String")
   }
   
+  // MARK: - Initialized
+  
   func testImplicitInitializedType() {
     let input = "Bool(booleanLiteral: true)"
     XCTAssertEqual(inferType(from: input), "Bool")
+  }
+  
+  func testImplicitInitializedType_method() {
+    let input = "Bool(booleanLiteral: true).map({ true })"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testImplicitInitializedType_capitalizedMethod() {
+    let input = "Bool(booleanLiteral: true).Method(param: true)"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testImplicitInitializedType_trailingClosureMethod() {
+    let input = "Bool(booleanLiteral: true).map { true }"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testImplicitInitializedType_property() {
+    let input = "Bool(booleanLiteral: true).property"
+    XCTAssertNil(inferType(from: input))
   }
   
   func testExplicitInitializedType() {
@@ -44,15 +69,69 @@ class InferTypeTests: XCTestCase {
     XCTAssertEqual(inferType(from: input), "Bool")
   }
   
+  func testExplicitInitializedType_method() {
+    let input = "Bool.init(booleanLiteral: true).map({ true })"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testExplicitInitializedType_capitalizedMethod() {
+    let input = "Bool.init(booleanLiteral: true).Method(param: true)"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testExplicitInitializedType_trailingClosureMethod() {
+    let input = "Bool.init(booleanLiteral: true).map { true }"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testExplicitInitializedType_property() {
+    let input = "Bool.init(booleanLiteral: true).property"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  // MARK: - Qualified
+  
   func testImplicitQualifiedInitializedType() {
     let input = "Swift.Bool(booleanLiteral: true)"
     XCTAssertEqual(inferType(from: input), "Swift.Bool")
+  }
+  
+  func testImplicitQualifiedInitializedType_method() {
+    let input = "Swift.Bool(booleanLiteral: true).map({ true })"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testImplicitQualifiedInitializedType_trailingClosureMethod() {
+    let input = "Swift.Bool(booleanLiteral: true).map { true }"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testImplicitQualifiedInitializedType_property() {
+    let input = "Swift.Bool(booleanLiteral: true).property"
+    XCTAssertNil(inferType(from: input))
   }
   
   func testExplicitQualifiedInitializedType() {
     let input = "Swift.Bool.init(booleanLiteral: true)"
     XCTAssertEqual(inferType(from: input), "Swift.Bool")
   }
+  
+  func testExplicitQualifiedInitializedType_method() {
+    let input = "Swift.Bool.init(booleanLiteral: true).map({ true })"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testExplicitQualifiedInitializedType_trailingClosureMethod() {
+    let input = "Swift.Bool.init(booleanLiteral: true).map { true }"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  func testExplicitQualifiedInitializedType_property() {
+    let input = "Swift.Bool.init(booleanLiteral: true).property"
+    XCTAssertNil(inferType(from: input))
+  }
+  
+  // MARK: - Generics
 
   func testImplicitInitializedGenericType() {
     let input = #"Array<(String, Int)>(arrayLiteral: ("foo", 1))"#
@@ -74,15 +153,29 @@ class InferTypeTests: XCTestCase {
     XCTAssertEqual(inferType(from: input), "Foundation.Array<(String, Int)>")
   }
   
-  func testMappedInitializedType() {
-    let input = "Bool(booleanLiteral: true).map({ $0 })"
+  // MARK: - Enums
+  
+  func testEnumCase() {
+    let input = "MyEnum.someCase"
+    XCTAssertEqual(inferType(from: input), "MyEnum")
+  }
+  
+  func testQualifiedEnumCase() {
+    let input = "MyModule.MyEnum.someCase"
+    XCTAssertEqual(inferType(from: input), "MyModule.MyEnum")
+  }
+  
+  func testAssociatedTypeEnumCase() {
+    let input = "MyEnum.someCase(success: true)"
     XCTAssertNil(inferType(from: input))
   }
   
-  func testCalledInitializedType() {
-    let input = "Bool(booleanLiteral: true).SomeFunction()"
+  func testQualifiedAssociatedTypeEnumCase() {
+    let input = "MyModule.MyEnum.someCase(success: true)"
     XCTAssertNil(inferType(from: input))
   }
+
+  // MARK: - Tuples
   
   func testUniformTupleType() {
     let input = "(true, false)"
@@ -176,11 +269,6 @@ class InferTypeTests: XCTestCase {
   
   func testMappedVariableWithParentheses() {
     let input = #"self.foo.map({ $0 })"#
-    XCTAssertNil(inferType(from: input))
-  }
-  
-  func testMappedCapitalizedVariableWithParentheses() {
-    let input = #"Foo.map({ $0 })"#
     XCTAssertNil(inferType(from: input))
   }
 }


### PR DESCRIPTION
Previously `MyType().property` would be incorrectly inferred as an enum.

Note that enum cases are syntactically the same as static properties (or methods in the case of enums with associated types). It's not 100% safe to infer the type without additional semantic info.