### PR TITLE
Fix missing return type in ordering logic

### DIFF
--- a/.github/workflows/build-framework-cli.yml
+++ b/.github/workflows/build-framework-cli.yml
@@ -22,54 +22,33 @@ jobs:
         make print-debug-info | grep "Mockingbird rpath: /var/tmp/mockingbird/$(make get-version)/libs"
         PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make print-debug-info
         PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make install
-    - name: Set Up Target
+    - name: Set Up Caching Target
       run: |
         ./bin/mockingbird install \
           --target MockingbirdTests \
           --source MockingbirdTestsHost \
           --support Sources/MockingbirdSupport \
-          --diagnostics all not-mockable \
+          --output Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
+          --diagnostics all \
           --loglevel verbose \
           --verbose
     - name: Test
       run: make clean-test
     - name: Cached Test
       run: make test
-
-  build-xcode-11_4_0:
-    name: Xcode 11.4.0 toolchain
-    runs-on: macOS-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set Up Environment
-      run: sudo xcode-select -s /Applications/Xcode_11.4.app/Contents/Developer
-    - name: Print Debug Info
-      run: make print-debug-info
-    - name: Set Up Project
-      run: make setup-project
-    - name: Clean
-      run: make clean
-    - name: Build Framework
-      run: make build-framework
-    - name: Build and Install CLI
-      run: |
-        make print-debug-info | grep "Mockingbird rpath: /var/tmp/mockingbird/$(make get-version)/libs"
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make print-debug-info
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make install
-    - name: Set Up Target
+    - name: Set Up Non-Caching Target
       run: |
         ./bin/mockingbird install \
           --target MockingbirdTests \
           --source MockingbirdTestsHost \
           --support Sources/MockingbirdSupport \
-          --diagnostics all not-mockable \
+          --output Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
+          --disable-cache \
+          --diagnostics all \
           --loglevel verbose \
           --verbose
-    - name: Test
-      run: make clean-test
-    - name: Cached Test
-      run: make test
+    - name: Test Flakiness
+      run: make test-flaky
 
   build-xcode-11_3_1:
     name: Xcode 11.3.1 toolchain
@@ -98,7 +77,8 @@ jobs:
           --target MockingbirdTests \
           --source MockingbirdTestsHost \
           --support Sources/MockingbirdSupport \
-          --diagnostics all not-mockable \
+          --output Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
+          --diagnostics all \
           --loglevel verbose \
           --verbose
     - name: Test

--- a/.github/workflows/test-example-projects.yml
+++ b/.github/workflows/test-example-projects.yml
@@ -21,8 +21,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clean
       run: make clean-cocoapods
-    - name: Set Up
-      run: 'PREFIX=$(pwd) make setup-cocoapods'
     - name: Test
       run: 'PATH=$(pwd)/bin:$PATH make test-cocoapods'
     - name: Cached Test
@@ -36,8 +34,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clean
       run: make clean-carthage
-    - name: Set Up
-      run: 'PREFIX=$(pwd) make setup-carthage'
     - name: Test
       run: 'PATH=$(pwd)/bin:$PATH make test-carthage'
     - name: Cached Test
@@ -51,8 +47,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clean
       run: make clean-spm
-    - name: Set Up
-      run: 'PREFIX=$(pwd) make setup-spm'
     - name: Test
       run: 'PATH=$(pwd)/bin:$PATH make test-spm'
     - name: Cached Test

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ all: build
 
 .PHONY: clean-mocks
 clean-mocks:
-	rm -f Sources/MockingbirdMocks/*.generated.swift
+	rm -f Tests/MockingbirdTests/Mocks/*.generated.swift
 	rm -f Mockingbird.xcodeproj/MockingbirdCache/*.lock
 
 .PHONY: clean-temporary-files
@@ -258,6 +258,20 @@ test:
 
 .PHONY: clean-test
 clean-test: clean test
+
+.PHONY: test-flaky
+test-flaky:
+	$(BUILD_TOOL) -scheme 'MockingbirdTests' $(XCODEBUILD_MACOS_FLAGS) test
+	mv -f Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
+		Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.tmp.generated.swift
+
+	set -e
+	for i in {1..4}; do \
+		$(BUILD_TOOL) -scheme 'MockingbirdTests' $(XCODEBUILD_MACOS_FLAGS) test; \
+		diff Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
+			Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.tmp.generated.swift; \
+		[[ $$? == 0 ]] && echo "[Test $$i completed]" || exit 1; \
+	done
 
 .PHONY: setup-swiftdoc
 setup-swiftdoc:

--- a/Sources/MockingbirdGenerator/Parser/Models/GenericType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/GenericType.swift
@@ -24,8 +24,8 @@ struct WhereClause: Hashable, Comparable, CustomStringConvertible {
   
   var description: String {
     switch requirement {
-    case .conforms: return "\(constrainedTypeName)\(self.requirement.rawValue) \(genericConstraint)"
-    case .equals: return "\(constrainedTypeName) \(self.requirement.rawValue) \(genericConstraint)"
+    case .conforms: return "\(constrainedTypeName)\(requirement.rawValue) \(genericConstraint)"
+    case .equals: return "\(constrainedTypeName) \(requirement.rawValue) \(genericConstraint)"
     }
   }
   

--- a/Sources/MockingbirdGenerator/Parser/Models/Method.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Method.swift
@@ -269,12 +269,14 @@ extension Method: Comparable {
   static func < (lhs: Method, rhs: Method) -> Bool {
     return (
       lhs.whereClauses,
+      lhs.returnTypeName,
       lhs.kind.typeScope,
       lhs.parameters,
       lhs.genericTypes,
       lhs.name
     ) < (
       rhs.whereClauses,
+      rhs.returnTypeName,
       rhs.kind.typeScope,
       rhs.parameters,
       rhs.genericTypes,


### PR DESCRIPTION
⚠️ Stacked on #141 and #142 ⚠️ 

Inconsistent generated mock files are generally benign as mocks aren't checked in and caching logic only depends on on input / source file consistency.

However, in an effort to make builds 100% reproducible, we now test for output (and test) flakiness in the CI.