### PR TITLE
Improve documentation for mocking types

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 		OBJ_875 /* ArgumentMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* ArgumentMatcher.swift */; };
 		OBJ_876 /* CountMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* CountMatcher.swift */; };
 		OBJ_877 /* TypeFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* TypeFacade.swift */; };
-		OBJ_878 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* Mock.swift */; };
+		OBJ_878 /* Mocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* Mocking.swift */; };
 		OBJ_879 /* MockingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* MockingContext.swift */; };
 		OBJ_881 /* Stubbing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Stubbing.swift */; };
 		OBJ_882 /* StubbingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* StubbingContext.swift */; };
@@ -1449,7 +1449,7 @@
 		OBJ_367 /* XCScheme+BuildAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildAction.swift"; sourceTree = "<group>"; };
 		OBJ_368 /* XCScheme+BuildableProductRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildableProductRunnable.swift"; sourceTree = "<group>"; };
 		OBJ_369 /* XCScheme+BuildableReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildableReference.swift"; sourceTree = "<group>"; };
-		OBJ_37 /* Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
+		OBJ_37 /* Mocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocking.swift; sourceTree = "<group>"; };
 		OBJ_370 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
 		OBJ_371 /* XCScheme+EnvironmentVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+EnvironmentVariable.swift"; sourceTree = "<group>"; };
 		OBJ_372 /* XCScheme+ExecutionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ExecutionAction.swift"; sourceTree = "<group>"; };
@@ -2637,7 +2637,7 @@
 		OBJ_36 /* Mocking */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_37 /* Mock.swift */,
+				OBJ_37 /* Mocking.swift */,
 				OBJ_38 /* MockingContext.swift */,
 				D3E6F67F24845131000D1971 /* ResetMock.swift */,
 			);
@@ -4905,7 +4905,7 @@
 				D3E6F67C24844C5B000D1971 /* SourceLocation.swift in Sources */,
 				OBJ_876 /* CountMatcher.swift in Sources */,
 				OBJ_877 /* TypeFacade.swift in Sources */,
-				OBJ_878 /* Mock.swift in Sources */,
+				OBJ_878 /* Mocking.swift in Sources */,
 				OBJ_879 /* MockingContext.swift in Sources */,
 				D3E6F67E24844CEA000D1971 /* ExpectationGroup.swift in Sources */,
 				D3E6F67A24844A37000D1971 /* DefaultValues.swift in Sources */,

--- a/README-0.14.md
+++ b/README-0.14.md
@@ -201,27 +201,26 @@ Mockingbird provides a comprehensive [API reference](https://birdrides.github.io
 
 ### 1. Mocking
 
-Mock types can be passed in place of the original type and are suffixed with `Mock`. Avoid explicitly coercing mock types into their supertype, as this breaks stubbing and verification.
+Initialized mocks can be passed in place of the original type. Protocol mocks do not require explicit initialization while class mocks should be created using `initialize(…)`.
 
-#### Mock Protocols
+```swift
+protocol Bird {
+  init(name: String)
+}
+class Tree {
+  init(with bird: Bird) {}
+}
 
-Note that the initialized mock type is `BirdMock` instead of `Bird`.
+let bird = mock(Bird.self)  // Protocol mock
+let tree = mock(Tree.self).initialize(with: bird)  // Class mock
+```
+
+Generated mock types are suffixed with `Mock` and should not be coerced into their supertype.
 
 ```swift
 let bird: BirdMock = mock(Bird.self)  // The concrete type is `BirdMock`
-let inferredBird = mock(Bird.self)    // but type inference also works
-```
-
-#### Mock Classes
-
-Initialize concrete class mocks using the `initialize` method. Keep in mind that class mocks rely on subclassing which has certain limitations, so consider using protocol mocks whenever possible.
-
-```swift
-class Bird {
-  let name: String
-  init(named name: String) { self.name = name }
-}
-let bird = mock(Bird.self).initialize(named: "Ryan")
+let inferredBird = mock(Bird.self)    // Type inference also works
+let coerced: Bird = mock(Bird.self)   // Avoid upcasting mocks
 ```
 
 #### Reset Mocks

--- a/README.md
+++ b/README.md
@@ -199,27 +199,26 @@ Have questions or issues?
 
 ### 1. Mocking
 
-Mock types can be passed in place of the original type and are suffixed with `Mock`. Avoid explicitly coercing mock types into their supertype, as this breaks stubbing and verification.
+Initialized mocks can be passed in place of the original type. Protocol mocks do not require explicit initialization while class mocks should be created using `initialize(…)`.
 
-#### Mock Protocols
+```swift
+protocol Bird {
+  init(name: String)
+}
+class Tree {
+  init(with bird: Bird) {}
+}
 
-Note that the initialized mock type is `BirdMock` instead of `Bird`.
+let bird = mock(Bird.self)  // Protocol mock
+let tree = mock(Tree.self).initialize(with: bird)  // Class mock
+```
+
+Generated mock types are suffixed with `Mock` and should not be coerced into their supertype.
 
 ```swift
 let bird: BirdMock = mock(Bird.self)  // The concrete type is `BirdMock`
-let inferredBird = mock(Bird.self)    // but type inference also works
-```
-
-#### Mock Classes
-
-Initialize concrete class mocks using the `initialize` method. Keep in mind that class mocks rely on subclassing which has certain limitations, so consider using protocol mocks whenever possible.
-
-```swift
-class Bird {
-  let name: String
-  init(named name: String) { self.name = name }
-}
-let bird = mock(Bird.self).initialize(named: "Ryan")
+let inferredBird = mock(Bird.self)    // Type inference also works
+let coerced: Bird = mock(Bird.self)   // Avoid upcasting mocks
 ```
 
 #### Reset Mocks

--- a/Sources/MockingbirdFramework/Mocking/Mocking.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mocking.swift
@@ -1,11 +1,36 @@
 //
-//  Mock.swift
+//  Mocking.swift
 //  Mockingbird
 //
 //  Created by Andrew Chang on 7/29/19.
 //
 
 import Foundation
+
+/// Returns a mock of a given type.
+///
+/// Initialized mocks can be passed in place of the original type. Protocol mocks do not require
+/// explicit initialization while class mocks should be created using `initialize(…)`.
+///
+///     protocol Bird {
+///       init(name: String)
+///     }
+///     class Tree {
+///       init(with bird: Bird) {}
+///     }
+///
+///     let bird = mock(Bird.self)  // Protocol mock
+///     let tree = mock(Tree.self).initialize(with: bird)  // Class mock
+///
+/// Generated mock types are suffixed with `Mock` and should not be coerced into their supertype.
+///
+///     let bird: BirdMock = mock(Bird.self)  // The concrete type is `BirdMock`
+///     let inferredBird = mock(Bird.self)    // Type inference also works
+///     let coerced: Bird = mock(Bird.self)   // Avoid upcasting mocks
+///
+/// - Parameter type: The type to mock.
+@available(*, unavailable, message: "No generated mock for this type which might be resolved by building the test target (⇧⌘U)")
+public func mock<T>(_ type: T.Type) -> T { fatalError() }
 
 /// All generated mocks conform to this protocol.
 public protocol Mock {

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
@@ -103,12 +103,12 @@ struct MockableTypeInitializerTemplate: Template {
       // Requires an initializer proxy to create the partial class mock.
       returnType = "\(mockTypeScopedName).InitializerProxy.Type"
       returnStatement = "return \(mockTypeScopedName).InitializerProxy.self"
-      returnTypeDescription = "/// Initialize an initializable class mock of `\(mockableTypeTemplate.fullyQualifiedName)`."
+      returnTypeDescription = "/// Returns an abstract mock which should be initialized using `mock(\(mockableTypeTemplate.mockableType.name).self).initialize(…)`."
     } else {
       // Does not require an initializer proxy.
       returnType = mockTypeScopedName
       returnStatement = "return \(mockTypeScopedName)(sourceLocation: Mockingbird.SourceLocation(file, line))"
-      returnTypeDescription = "/// Initialize a " + (kind == .class ? "class" : "protocol") + " mock of `\(mockableTypeTemplate.fullyQualifiedName)`."
+      returnTypeDescription = "/// Returns a concrete mock of `\(mockableTypeTemplate.mockableType.name)`."
     }
     
     let allGenericTypes = genericTypeConstraints.isEmpty ? "" :


### PR DESCRIPTION
- Disambiguates concrete vs abstract return types from `mock(…)`
- Adds fallback with descriptive error message for unmocked types