### PR TITLE
Fix source root derivation for thunk pruning

### DIFF
--- a/.github/workflows/build-framework-cli.yml
+++ b/.github/workflows/build-framework-cli.yml
@@ -57,7 +57,7 @@ jobs:
           --support Sources/MockingbirdSupport \
           --output Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift \
           --disable-cache \
-          --disable-pruning \
+          --disable-thunk-stubs \
           --diagnostics all \
           --loglevel verbose \
           --verbose

--- a/README-0.14.md
+++ b/README-0.14.md
@@ -551,6 +551,13 @@ You can exclude unwanted or problematic sources from being mocked by adding a `.
 
 Supporting source files are used by the generator to resolve inherited types defined outside of your project. Although Mockingbird provides a preset “starter pack” for basic compatibility with common system frameworks, you will occasionally need to add your own definitions for third-party library types. Please see [Supporting Source Files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files) for more information.
 
+#### Thunk Stubs
+
+To reduce compilation time, Mockingbird only generates mocking code (known as thunks) for types referenced in tests with `mock(SomeType.self)`. Types not used in any test files produce minimal generated code in the form of “thunk stubs,” which are simply bodies containing `fatalError`. Projects that indirectly synthesize mocked types, such as through Objective-C based dependency injection, may incorrectly encounter thunk stubs during tests and require special consideration.
+
+- **Option 1:** Explicitly reference each indirectly synthesized type in your tests, e.g. `_ = mock(SomeType.self)`. References can be placed anywhere in the test target sources, such as in the `setUp` method of a test case or in a single file.
+- **Option 2:** Disable thunk stubs entirely by adding the `--disable-thunk-stubs` generator flag.
+
 ## Mockingbird CLI
 
 ### Generate
@@ -576,7 +583,7 @@ Generate mocks for a set of targets in a project.
 | `--disable-swiftlint` | Disable all SwiftLint rules in generated mocks. |
 | `--disable-cache` | Ignore cached mock information stored on disk. |
 | `--disable-relaxed-linking` | Only search explicitly imported modules. |
-| `--disable-pruning` | Generate full mocks for unused types. |
+| `--disable-thunk-stubs` | Generate full mocks for potentially unused types. |
 
 ### Install
 
@@ -604,7 +611,7 @@ Configure a test target to use mocks.
 | `--disable-swiftlint` | Disable all SwiftLint rules in generated mocks. |
 | `--disable-cache` | Ignore cached mock information stored on disk. |
 | `--disable-relaxed-linking` | Only search explicitly imported modules. |
-| `--disable-pruning` | Generate full mocks for unused types. |
+| `--disable-thunk-stubs` | Generate full mocks for potentially unused types. |
 
 ### Uninstall
 

--- a/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -182,10 +182,10 @@ extension ArgumentParser {
                usage: "Only search explicitly imported modules.")
   }
   
-  func addDisablePruning() -> OptionArgument<Bool> {
-    return add(option: "--disable-pruning",
+  func addDisableThunkStubs() -> OptionArgument<Bool> {
+    return add(option: "--disable-thunk-stubs",
                kind: Bool.self,
-               usage: "Generate full mocks for unused types.")
+               usage: "Generate full mocks for potentially unused types.")
   }
   
   // MARK: - Positional
@@ -227,7 +227,8 @@ extension ArgumentParser.Result {
   func getSourceRoot(using argument: OptionArgument<PathArgument>,
                      environment: [String: String],
                      projectPath: Path) -> Path {
-    if let rawSourceRoot = get(argument)?.path.pathString ?? environment["SRCROOT"] {
+    if let rawSourceRoot = get(argument)?.path.pathString ??
+      environment["SRCROOT"] ?? environment["SOURCE_ROOT"] {
       return Path(rawSourceRoot)
     } else {
       return projectPath.parent()

--- a/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
@@ -33,7 +33,7 @@ final class GenerateCommand: BaseCommand {
   private let disableSwiftlintArgument: OptionArgument<Bool>
   private let disableCacheArgument: OptionArgument<Bool>
   private let disableRelaxedLinking: OptionArgument<Bool>
-  private let disablePruning: OptionArgument<Bool>
+  private let disableThunkStubs: OptionArgument<Bool>
   
   required init(parser: ArgumentParser) {
     let subparser = parser.add(subparser: Constants.name, overview: Constants.overview)
@@ -53,7 +53,7 @@ final class GenerateCommand: BaseCommand {
     self.disableSwiftlintArgument = subparser.addDisableSwiftlint()
     self.disableCacheArgument = subparser.addDisableCache()
     self.disableRelaxedLinking = subparser.addDisableRelaxedLinking()
-    self.disablePruning = subparser.addDisablePruning()
+    self.disableThunkStubs = subparser.addDisableThunkStubs()
     
     super.init(parser: subparser)
   }
@@ -84,6 +84,13 @@ final class GenerateCommand: BaseCommand {
       guard path.extension == "xcodeproj" else { return nil }
       return path
     }
+    var environmentSourceRoot: Path? {
+      guard let sourceRoot = environment["SRCROOT"] ?? environment["SOURCE_ROOT"] else {
+        return nil
+      }
+      let path = Path(sourceRoot)
+      return path
+    }
     let environmentTargetName = environment["TARGET_NAME"] ?? environment["TARGETNAME"]
     
     let config = Generator.Configuration(
@@ -91,6 +98,7 @@ final class GenerateCommand: BaseCommand {
       sourceRoot: sourceRoot,
       inputTargetNames: targets,
       environmentProjectFilePath: environmentProjectFilePath,
+      environmentSourceRoot: environmentSourceRoot,
       environmentTargetName: environmentTargetName,
       outputPaths: outputs,
       supportPath: supportPath,
@@ -100,7 +108,7 @@ final class GenerateCommand: BaseCommand {
       disableSwiftlint: arguments.get(disableSwiftlintArgument) == true,
       disableCache: arguments.get(disableCacheArgument) == true,
       disableRelaxedLinking: arguments.get(disableRelaxedLinking) == true,
-      disablePruning: arguments.get(disablePruning) == true
+      disableThunkStubs: arguments.get(disableThunkStubs) == true
     )
     try Generator(config).generate()
   }

--- a/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
@@ -53,7 +53,7 @@ class InstallCommand: BaseCommand, AliasableCommand {
   private let disableSwiftlintArgument: OptionArgument<Bool>
   private let disableCacheArgument: OptionArgument<Bool>
   private let disableRelaxedLinking: OptionArgument<Bool>
-  private let disablePruning: OptionArgument<Bool>
+  private let disableThunkStubs: OptionArgument<Bool>
   
   required convenience init(parser: ArgumentParser) {
     self.init(parser: parser, name: Constants.name, overview: Constants.overview)
@@ -80,7 +80,7 @@ class InstallCommand: BaseCommand, AliasableCommand {
     self.disableSwiftlintArgument = subparser.addDisableSwiftlint()
     self.disableCacheArgument = subparser.addDisableCache()
     self.disableRelaxedLinking = subparser.addDisableRelaxedLinking()
-    self.disablePruning = subparser.addDisablePruning()
+    self.disableThunkStubs = subparser.addDisableThunkStubs()
     
     super.init(parser: subparser)
   }
@@ -122,7 +122,7 @@ class InstallCommand: BaseCommand, AliasableCommand {
       disableSwiftlint: arguments.get(disableSwiftlintArgument) == true,
       disableCache: arguments.get(disableCacheArgument) == true,
       disableRelaxedLinking: arguments.get(disableRelaxedLinking) == true,
-      disablePruning: arguments.get(disablePruning) == true
+      disableThunkStubs: arguments.get(disableThunkStubs) == true
     )
     try Installer.install(using: config)
     print("Installed Mockingbird to \(destinationTarget.singleQuoted) in \(projectPath)")

--- a/Sources/MockingbirdCli/Interface/Generator+PruningPipeline.swift
+++ b/Sources/MockingbirdCli/Interface/Generator+PruningPipeline.swift
@@ -22,6 +22,7 @@ extension Generator {
           getXcodeProj: (Path) throws -> XcodeProj,
           environment: @escaping () -> [String: Any]) {
       guard let environmentProjectFilePath = config.environmentProjectFilePath,
+        let environmentSourceRoot = config.environmentSourceRoot,
         let environmentTargetName = config.environmentTargetName
         else { return nil }
       
@@ -48,7 +49,7 @@ extension Generator {
       switch testTarget {
       case .pbxTarget(let target):
         let operation = ExtractSourcesOperation(target: target,
-                                                sourceRoot: config.sourceRoot,
+                                                sourceRoot: environmentSourceRoot,
                                                 supportPath: config.supportPath,
                                                 options: [],
                                                 environment: environment)
@@ -61,7 +62,7 @@ extension Generator {
       
       case .testTarget(let target):
         let operation = ExtractSourcesOperation(target: target as CodableTarget,
-                                                sourceRoot: config.sourceRoot,
+                                                sourceRoot: environmentSourceRoot,
                                                 supportPath: config.supportPath,
                                                 options: [],
                                                 environment: environment)

--- a/Sources/MockingbirdCli/Interface/Installer.swift
+++ b/Sources/MockingbirdCli/Interface/Installer.swift
@@ -31,7 +31,7 @@ class Installer {
     let disableSwiftlint: Bool
     let disableCache: Bool
     let disableRelaxedLinking: Bool
-    let disablePruning: Bool
+    let disableThunkStubs: Bool
   }
   
   struct UninstallConfiguration {
@@ -330,8 +330,8 @@ class Installer {
       if config.disableRelaxedLinking {
         options.append("--disable-relaxed-linking")
       }
-      if config.disablePruning {
-        options.append("--disable-pruning")
+      if config.disableThunkStubs {
+        options.append("--disable-thunk-stubs")
       }
       if let logLevel = config.logLevel {
         switch logLevel {

--- a/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
@@ -30,7 +30,7 @@ class InitializerMethodTemplate: MethodTemplate {
       }
       """
     } else {
-      body = "{ fatalError() }"
+      body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
     }
     
     return """
@@ -60,7 +60,7 @@ class InitializerMethodTemplate: MethodTemplate {
           }
         """
       } else {
-        body = "{ fatalError() }"
+        body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
       }
       return """
         // MARK: Mocked \(fullNameForMocking)
@@ -81,7 +81,7 @@ class InitializerMethodTemplate: MethodTemplate {
           }
         """
       } else {
-        body = "{ fatalError() }"
+        body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
       }
       
       return """

--- a/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -73,7 +73,7 @@ class MethodTemplate: Template {
         }
       """
     } else {
-      body = "{ fatalError() }"
+      body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
     }
     
     return """
@@ -116,7 +116,7 @@ class MethodTemplate: Template {
         }
       """
     } else {
-      body = "{ fatalError() }"
+      body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
     }
     
     mockableMethods.append("""
@@ -135,7 +135,7 @@ class MethodTemplate: Template {
           }
         """
       } else {
-        variadicBody = "{ fatalError() }"
+        variadicBody = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
       }
       mockableMethods.append("""
       \(attributes)  public \(regularModifiers)func \(fullNameForMatchingVariadics) -> Mockingbird.Mockable<\(mockableGenericTypes)>\(genericConstraints) \(variadicBody)

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -10,10 +10,6 @@
 
 import Foundation
 
-private enum Constants {
-  static let mockProtocolName = "Mockingbird.Mock"
-}
-
 enum Declaration: String, CustomStringConvertible {
   case functionDeclaration = "Mockingbird.FunctionDeclaration"
   case throwingFunctionDeclaration = "Mockingbird.ThrowingFunctionDeclaration"
@@ -39,6 +35,11 @@ extension GenericType {
 class MockableTypeTemplate: Template {
   let mockableType: MockableType
   let mockedTypeNames: Set<String>?
+  
+  enum Constants {
+    static let mockProtocolName = "Mockingbird.Mock"
+    static let thunkStub = #"fatalError("See 'Thunk Stubs' in the README")"#
+  }
   
   private var methodTemplates = [Method: MethodTemplate]()
   init(mockableType: MockableType, mockedTypeNames: Set<String>?) {
@@ -80,7 +81,7 @@ class MockableTypeTemplate: Template {
         }
       """
     } else {
-      sourceLocationBody = "{ get { fatalError() } set { fatalError() } }"
+      sourceLocationBody = "{ get { \(Constants.thunkStub) } set { \(Constants.thunkStub) } }"
     }
     
     let rawBody = renderBody()
@@ -229,7 +230,7 @@ class MockableTypeTemplate: Template {
         }
       """
     } else {
-      body = "{ fatalError() }"
+      body = "{ \(Constants.thunkStub) }"
     }
     
     // Since class-level generic types don't support static variables, we instead use a global

--- a/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -33,7 +33,7 @@ class SubscriptMethodTemplate: MethodTemplate {
         }
       """
     } else {
-      body = "{ get { fatalError() } set { fatalError() } }"
+      body = "{ get { \(MockableTypeTemplate.Constants.thunkStub) } set { \(MockableTypeTemplate.Constants.thunkStub) } }"
     }
     
     return """
@@ -112,7 +112,7 @@ class SubscriptMethodTemplate: MethodTemplate {
         }
       """
     } else {
-      body = "{ fatalError() }"
+      body = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
     }
     
     return """

--- a/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -87,7 +87,7 @@ class VariableTemplate: Template {
         }
       """
     } else {
-      body = "{ get { fatalError() } " + (shouldGenerateSetter ? "set { fatalError() } " : "") + "}"
+      body = "{ get { \(MockableTypeTemplate.Constants.thunkStub) } " + (shouldGenerateSetter ? "set { \(MockableTypeTemplate.Constants.thunkStub) } " : "") + "}"
     }
     
     return """
@@ -120,7 +120,7 @@ class VariableTemplate: Template {
         }
       """
     } else {
-      getterBody = "{ fatalError() }"
+      getterBody = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
     }
     let getter = """
     \(attributes)  public \(modifiers)func get\(capitalizedName)() -> Mockingbird.Mockable<\(mockableGetterGenericTypes)> \(getterBody)
@@ -138,7 +138,7 @@ class VariableTemplate: Template {
           }
         """
       } else {
-        setterBody = "{ fatalError() }"
+        setterBody = "{ \(MockableTypeTemplate.Constants.thunkStub) }"
       }
       
       let setter = """

--- a/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
@@ -72,7 +72,10 @@ public class CodableTarget: Target, Codable {
     self.sourceFilePaths = try target.findSourceFilePaths(sourceRoot: sourceRoot)
       .map({ $0.absolute() })
       .sorted()
-      .map({ try SourceFile(path: $0, hash: $0.read().generateSha1Hash()) })
+      .map({
+        let data = (try? $0.read()) ?? Data()
+        return try SourceFile(path: $0, hash: data.generateSha1Hash())
+      })
     self.sourceRoot = sourceRoot.absolute()
   }
   

--- a/Sources/MockingbirdGenerator/Parser/Project/SourceTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/SourceTarget.swift
@@ -45,7 +45,10 @@ public class SourceTarget: CodableTarget {
     self.supportingFilePaths = try supportPaths
       .map({ $0.absolute() })
       .sorted()
-      .map({ try SourceFile(path: $0, hash: $0.read().generateSha1Hash()) })
+      .map({
+        let data = (try? $0.read()) ?? Data()
+        return try SourceFile(path: $0, hash: data.generateSha1Hash())
+      })
     self.targetPathsHash = targetPathsHash
     self.dependencyPathsHash = dependencyPathsHash
     self.projectHash = projectHash

--- a/Sources/MockingbirdTestsHost/Generics.swift
+++ b/Sources/MockingbirdTestsHost/Generics.swift
@@ -216,15 +216,21 @@ public struct ShadowedType {}
 public class ShadowedGenericType<ShadowedType> {
   func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
   func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
+  func shadowedFunctionScope<ShadowedType>(param: Array<ShadowedType>)
+    -> Array<ShadowedType> { fatalError() }
   
   public class NestedShadowedGenericType {
     func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
     func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
+    func shadowedFunctionScope<ShadowedType>(param: Array<ShadowedType>)
+      -> Array<ShadowedType> { fatalError() }
   }
   
   public class NestedDoublyShadowedGenericType<ShadowedType> {
     func shadowedClassScope(param: ShadowedType) -> ShadowedType { fatalError() }
     func shadowedFunctionScope<ShadowedType>(param: ShadowedType) -> ShadowedType { fatalError() }
+    func shadowedFunctionScope<ShadowedType>(param: Array<ShadowedType>)
+      -> Array<ShadowedType> { fatalError() }
   }
 }
 


### PR DESCRIPTION
- The source root for thunk pruning should be obtained from the build environment during test bundle compilation instead of the argument values passed to the generator.
- Improves documentation and messaging around thunk stubs.