### PR TITLE
Add info logging level for printing to stdout

### DIFF
--- a/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
@@ -85,22 +85,21 @@ final class DownloadCommand: BaseCommand {
     try super.run(with: arguments, environment: environment, workingPath: workingPath)
     guard let type = arguments.get(assetBundleTypeArgument) else { return }
     
-    print("Downloading asset bundle from \(type.url)")
+    logInfo("Downloading asset bundle from \(type.url)")
     guard let fileUrl = downloadAssetBundle(type.url) else {
       log("Unable to download asset bundle \(type.rawValue.singleQuoted)", type: .error)
       exit(1)
     }
     
-    log("Temporary asset bundle data stored at \(fileUrl)")
-    print("Extracting downloaded asset bundle to \(Path().absolute())")
+    logInfo("Temporary asset bundle data stored at \(fileUrl)")
+    logInfo("Extracting downloaded asset bundle to \(Path().absolute())")
     guard let archive = Archive(url: fileUrl, accessMode: .read) else {
       log("The downloaded asset bundle is corrupted", type: .error)
       exit(1)
     }
     
     try self.extractAssetBundle(archive, to: inferredRootPath)
-    flushLogs()
-    print("Successfully loaded asset bundle \(type.rawValue.singleQuoted) into \(inferredRootPath)")
+    logInfo("Successfully loaded asset bundle \(type.rawValue.singleQuoted) into \(inferredRootPath)")
   }
   
   private func downloadAssetBundle(_ url: Foundation.URL) -> Foundation.URL? {

--- a/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
@@ -125,11 +125,11 @@ class InstallCommand: BaseCommand, AliasableCommand {
       disableThunkStubs: arguments.get(disableThunkStubs) == true
     )
     try Installer.install(using: config)
-    print("Installed Mockingbird to \(destinationTarget.singleQuoted) in \(projectPath)")
+    logInfo("Installed Mockingbird to \(destinationTarget.singleQuoted) in \(projectPath)")
     
     // Warn users that haven't added supporting source files.
     guard supportPath == nil else { return }
-    print("""
+    logInfo("""
     Please add starter supporting source files for basic compatibility with system frameworks.
       $ mockingbird download starter-pack
     See https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files for more information.

--- a/Sources/MockingbirdCli/Interface/Commands/TestbedCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/TestbedCommand.swift
@@ -37,7 +37,7 @@ final class TestbedCommand: BaseCommand {
     let count = try arguments.getCount(using: countArgument) ?? 1000
     for i in 0..<count { try generateSourceFile(to: outputDirectory, index: i) }
     
-    print("Generated \(count) source file\(count > 1 ? "s" : "") to \(outputDirectory.absolute())")
+    logInfo("Generated \(count) source file\(count > 1 ? "s" : "") to \(outputDirectory.absolute())")
   }
 
   func generateSourceFile(to directory: Path, index: Int) throws {

--- a/Sources/MockingbirdCli/Interface/Commands/UninstallCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/UninstallCommand.swift
@@ -55,6 +55,6 @@ final class UninstallCommand: BaseCommand {
       targetNames: targets
     )
     try Installer.uninstall(using: config)
-    print("Uninstalled Mockingbird from \(targets.map({ "`\($0)`" }).joined(separator: ", ")) in \(projectPath)")
+    logInfo("Uninstalled Mockingbird from \(targets.map({ "`\($0)`" }).joined(separator: ", ")) in \(projectPath)")
   }
 }

--- a/Sources/MockingbirdCli/Interface/Commands/VersionCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/VersionCommand.swift
@@ -27,6 +27,6 @@ final class VersionCommand: BaseCommand {
                     environment: [String: String],
                     workingPath: Path) throws {
     try super.run(with: arguments, environment: environment, workingPath: workingPath)
-    print(mockingbirdVersion)
+    logInfo("\(mockingbirdVersion)")
   }
 }

--- a/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
@@ -64,6 +64,6 @@ public class GenerateFileOperation: BasicOperation {
       try outputPath.writeUtf8Strings(contents)
     }
     
-    print("Generated file to \(outputPath.absolute())")
+    logInfo("Generated file to \(outputPath.absolute())")
   }
 }

--- a/Sources/MockingbirdGenerator/Utilities/Log.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Log.swift
@@ -47,11 +47,11 @@ private extension String {
 }
 
 public enum LogType: Int, CustomStringConvertible {
-  case debug = 0, warn, error
+  case debug = 0, info, warn, error
   
   public var formattedDescription: String {
     switch self {
-    case .debug: return ""
+    case .debug, .info: return ""
     case .warn: return description.formatted(with: ControlCode.yellow, ControlCode.bold)
     case .error: return description.formatted(with: ControlCode.red, ControlCode.bold)
     }
@@ -59,7 +59,7 @@ public enum LogType: Int, CustomStringConvertible {
   
   public var description: String {
     switch self {
-    case .debug: return ""
+    case .debug, .info: return ""
     case .warn: return "warning:"
     case .error: return "error:"
     }
@@ -67,7 +67,7 @@ public enum LogType: Int, CustomStringConvertible {
   
   var output: UnsafeMutablePointer<FILE> {
     switch self {
-    case .debug: return stdout
+    case .debug, .info: return stdout
     case .warn: return stderr
     case .error: return stderr
     }
@@ -81,7 +81,7 @@ public enum LogLevel: String, RawRepresentable {
   
   func shouldLog(_ type: LogType) -> Bool {
     switch self {
-    case .normal: return type.rawValue >= LogType.warn.rawValue
+    case .normal: return type.rawValue >= LogType.info.rawValue
     case .quiet: return type.rawValue >= LogType.error.rawValue
     case .verbose: return true
     }
@@ -139,7 +139,13 @@ public func log(_ message: @escaping @autoclosure () -> String,
   }
 }
 
-/// Convenience for logging a `.warn` message type
+/// Convenience for logging a `.info` message type.
+public func logInfo(_ message: @escaping @autoclosure () -> String,
+                    output: UnsafeMutablePointer<FILE>? = nil) {
+  log(message(), type: .info, output: output)
+}
+
+/// Convenience for logging a `.warn` message type.
 public func logWarning(_ message: @escaping @autoclosure () -> String,
                        diagnostic: DiagnosticType? = nil,
                        output: UnsafeMutablePointer<FILE>? = nil,


### PR DESCRIPTION
Replaces `print("message")` with `logInfo("message")` which enforces output ordering of printed statements relative to debug logs, errors, and warnings.