### PR TITLE
Fix thunk stub generation for generic types

### DIFF
--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -113,8 +113,8 @@ class MockableTypeTemplate: Template {
   
   lazy var shouldGenerateThunks: Bool = {
     guard let typeNames = mockedTypeNames else { return true }
-    return typeNames.contains(mockableType.fullyQualifiedName) ||
-      typeNames.contains(mockableType.fullyQualifiedModuleName)
+    return typeNames.contains(mockableType.fullyQualifiedName.removingGenericTyping()) ||
+      typeNames.contains(mockableType.fullyQualifiedModuleName.removingGenericTyping())
   }()
   
   lazy var isAvailable: Bool = {

--- a/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
@@ -28,7 +28,8 @@ class TestFileParser: SyntaxVisitor {
     guard expression.lastToken?.withoutTrivia().description == "self" else { return .visitChildren }
     
     // Could be a fully or partially qualified type name.
-    mockedTypeNames.insert(String(expression.withoutTrivia().description.dropLast(5)))
+    let typeName = String(expression.withoutTrivia().description.dropLast(5))
+    mockedTypeNames.insert(typeName.removingGenericTyping())
     
     return .skipChildren
   }


### PR DESCRIPTION
Mock type references are now stripped of generic types during parsing and before comparison.

Fixes #155