### PR TITLE
Unify generic mock init and fix thunk stubs

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		D314ED7F24CE1C10000CC23D /* GenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314ED7E24CE1C10000CC23D /* GenericsTests.swift */; };
 		D3643B6C247B78A5002DF069 /* Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B6B247B78A4002DF069 /* Function.swift */; };
 		D3643B72247C5107002DF069 /* String+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B71247C5107002DF069 /* String+Components.swift */; };
 		D3643B74247C517D002DF069 /* Substring+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B73247C517D002DF069 /* Substring+Components.swift */; };
@@ -1156,6 +1157,7 @@
 /* Begin PBXFileReference section */
 		942B00CDCB48ADC877A01AEE /* MockingbirdTestsHostMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = MockingbirdTestsHostMocks.generated.swift; path = Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D314ED7E24CE1C10000CC23D /* GenericsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericsTests.swift; sourceTree = "<group>"; };
 		D3643B6B247B78A4002DF069 /* Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function.swift; sourceTree = "<group>"; };
 		D3643B71247C5107002DF069 /* String+Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Components.swift"; sourceTree = "<group>"; };
 		D3643B73247C517D002DF069 /* Substring+Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Substring+Components.swift"; sourceTree = "<group>"; };
@@ -2355,6 +2357,7 @@
 				OBJ_257 /* CountMatcherTests.swift */,
 				OBJ_258 /* DefaultValueProviderTests.swift */,
 				OBJ_259 /* FloatingPointMatcherTests.swift */,
+				D314ED7E24CE1C10000CC23D /* GenericsTests.swift */,
 				OBJ_260 /* InitializerTests.swift */,
 				OBJ_261 /* LastSetValueStubTests.swift */,
 				OBJ_262 /* OrderedVerificationTests.swift */,
@@ -4278,6 +4281,7 @@
 				OBJ_1036 /* ExternalModuleTypesMockableTests.swift in Sources */,
 				OBJ_1037 /* ExternalModuleTypesStubbableTests.swift in Sources */,
 				OBJ_1038 /* GenericsMockableTests.swift in Sources */,
+				D314ED7F24CE1C10000CC23D /* GenericsTests.swift in Sources */,
 				OBJ_1039 /* GenericsStubbableTests.swift in Sources */,
 				OBJ_1040 /* IgnoredSourceExclusionTests.swift in Sources */,
 				OBJ_1041 /* IgnoredSourceInclusionTests.swift in Sources */,

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -113,8 +113,8 @@ class MockableTypeTemplate: Template {
   
   lazy var shouldGenerateThunks: Bool = {
     guard let typeNames = mockedTypeNames else { return true }
-    return typeNames.contains(mockableType.fullyQualifiedName) ||
-      typeNames.contains(mockableType.fullyQualifiedModuleName)
+    return typeNames.contains(mockableType.fullyQualifiedName.removingGenericTyping()) ||
+      typeNames.contains(mockableType.fullyQualifiedModuleName.removingGenericTyping())
   }()
   
   lazy var isAvailable: Bool = {

--- a/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
@@ -28,7 +28,8 @@ class TestFileParser: SyntaxVisitor {
     guard expression.lastToken?.withoutTrivia().description == "self" else { return .visitChildren }
     
     // Could be a fully or partially qualified type name.
-    mockedTypeNames.insert(String(expression.withoutTrivia().description.dropLast(5)))
+    let typeName = String(expression.withoutTrivia().description.dropLast(5))
+    mockedTypeNames.insert(typeName.removingGenericTyping())
     
     return .skipChildren
   }

--- a/Sources/MockingbirdTestsHost/Generics.swift
+++ b/Sources/MockingbirdTestsHost/Generics.swift
@@ -33,12 +33,12 @@ where S.Element == EquatableType {
     fatalError()
   }
 
-  public static func methodUsingEquatableTypeWithReturn(equatable: EquatableType) -> EquatableType {
+  public class func methodUsingEquatableTypeWithReturn(equatable: EquatableType) -> EquatableType {
     fatalError()
   }
 
-  public var equatableTypeVariable: EquatableType { return 1 as! EquatableType }
-  public static var equatableTypeVariable: EquatableType { return 1 as! EquatableType }
+  public var equatableTypeVariable: EquatableType { fatalError() }
+  public class var equatableTypeVariable: EquatableType { fatalError() }
 }
 
 public protocol AssociatedTypeImplementerProtocol {
@@ -57,12 +57,12 @@ public class AssociatedTypeImplementer {
     where T.EquatableType == Int, T.HashableType == String {}
 
   func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
-    where T.EquatableType == Int, T.HashableType == String { return 1 }
+    where T.EquatableType == Int, T.HashableType == String { fatalError() }
 
   // Not possible to override overloaded methods where uniqueness is from generic constraints.
   // https://forums.swift.org/t/cannot-override-more-than-one-superclass-declaration/22213
   func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
-    where T.EquatableType == Bool, T.HashableType == String { return true }
+    where T.EquatableType == Bool, T.HashableType == String { fatalError() }
 }
 
 public protocol AssociatedTypeGenericConstraintsProtocol {

--- a/Tests/MockingbirdTests/E2E/GenericsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/GenericsMockableTests.swift
@@ -12,10 +12,10 @@ import MockingbirdTestsHost
 
 // MARK: Mockable declarations
 
-private protocol MockableAssociatedTypeProtocol: AssociatedTypeProtocol, Mock {}
+private protocol MockableAssociatedTypeProtocol: MockingbirdTestsHost.AssociatedTypeProtocol, Mock {}
 extension AssociatedTypeProtocolMock: MockableAssociatedTypeProtocol {}
 
-private protocol MockableAssociatedTypeGenericImplementer: AssociatedTypeProtocol, Mock {
+private protocol MockableAssociatedTypeGenericImplementer: MockingbirdTestsHost.AssociatedTypeProtocol, Mock {
   associatedtype S: Sequence
   
   func methodUsingEquatableType(equatable: EquatableType)
@@ -30,32 +30,32 @@ private protocol MockableAssociatedTypeImplementerProtocol: AssociatedTypeImplem
 extension AssociatedTypeImplementerProtocolMock: MockableAssociatedTypeImplementerProtocol {}
 
 private protocol MockableAssociatedTypeImplementer {
-  func request<T: AssociatedTypeProtocol>(object: T)
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: T)
     where T.EquatableType == Int, T.HashableType == String
   
   #if swift(>=5.2) // This was fixed in Swift 5.2
-  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Int, T.HashableType == String
 
-  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Bool, T.HashableType == String
   #endif
 }
 extension AssociatedTypeImplementerMock: MockableAssociatedTypeImplementer {}
 
-private protocol MockableAssociatedTypeGenericConstraintsProtocol: AssociatedTypeGenericConstraintsProtocol, Mock {}
+private protocol MockableAssociatedTypeGenericConstraintsProtocol: MockingbirdTestsHost.AssociatedTypeGenericConstraintsProtocol, Mock {}
 extension AssociatedTypeGenericConstraintsProtocolMock: MockableAssociatedTypeGenericConstraintsProtocol {}
 
-private protocol MockableAssociatedTypeGenericConformingConstraintsProtocol: AssociatedTypeGenericConformingConstraintsProtocol, Mock {}
+private protocol MockableAssociatedTypeGenericConformingConstraintsProtocol: MockingbirdTestsHost.AssociatedTypeGenericConformingConstraintsProtocol, Mock {}
 extension AssociatedTypeGenericConformingConstraintsProtocolMock: MockableAssociatedTypeGenericConformingConstraintsProtocol {}
 
-private protocol MockableAssociatedTypeSelfReferencingProtocol: AssociatedTypeSelfReferencingProtocol, Mock {}
+private protocol MockableAssociatedTypeSelfReferencingProtocol: MockingbirdTestsHost.AssociatedTypeSelfReferencingProtocol, Mock {}
 extension AssociatedTypeSelfReferencingProtocolMock: MockableAssociatedTypeSelfReferencingProtocol {}
 
-private protocol MockableInheritingAssociatedTypeSelfReferencingProtocol: AssociatedTypeSelfReferencingProtocol, Mock {}
+private protocol MockableInheritingAssociatedTypeSelfReferencingProtocol: MockingbirdTestsHost.AssociatedTypeSelfReferencingProtocol, Mock {}
 extension InheritingAssociatedTypeSelfReferencingProtocolMock: MockableInheritingAssociatedTypeSelfReferencingProtocol {}
 
-private protocol MockableSecondLevelSelfConstrainedAssociatedTypeProtocol: AssociatedTypeSelfReferencingProtocol {}
+private protocol MockableSecondLevelSelfConstrainedAssociatedTypeProtocol: MockingbirdTestsHost.AssociatedTypeSelfReferencingProtocol {}
 extension SecondLevelSelfConstrainedAssociatedTypeProtocolMock: MockableSecondLevelSelfConstrainedAssociatedTypeProtocol {}
 
 private protocol MockableTopLevelSelfConstrainedAssociatedTypeProtocol: MockableSecondLevelSelfConstrainedAssociatedTypeProtocol {}
@@ -68,10 +68,10 @@ extension GenericClassReferencerMock: MockableGenericClassReferencer {}
 
 #if swift(<5.2) // This was fixed in Swift 5.2
 private extension AssociatedTypeImplementerMock {
-  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Int, T.HashableType == String { return 1 }
 
-  func request<T: AssociatedTypeProtocol>(object: T) -> T.EquatableType
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: T) -> T.EquatableType
     where T.EquatableType == Bool, T.HashableType == String { return true }
 }
 #endif

--- a/Tests/MockingbirdTests/E2E/GenericsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/GenericsStubbableTests.swift
@@ -28,7 +28,7 @@ private protocol StubbableAssociatedTypeProtocol {
 }
 extension AssociatedTypeProtocolMock: StubbableAssociatedTypeProtocol {}
 
-private protocol StubbableAssociatedTypeGenericImplementer: AssociatedTypeProtocol {
+private protocol StubbableAssociatedTypeGenericImplementer: MockingbirdTestsHost.AssociatedTypeProtocol {
   associatedtype S: Sequence where S.Element == EquatableType
   
   func methodUsingEquatableType(equatable: @escaping @autoclosure () -> EquatableType)
@@ -44,40 +44,40 @@ private protocol StubbableAssociatedTypeGenericImplementer: AssociatedTypeProtoc
 extension AssociatedTypeGenericImplementerMock: StubbableAssociatedTypeGenericImplementer {}
 
 private protocol StubbableAssociatedTypeImplementerProtocol {
-  func request<T: AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
     -> Mockable<FunctionDeclaration, (T) -> Void, Void>
     where T.EquatableType == Int, T.HashableType == String
   
-  func request<T: AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
     -> Mockable<FunctionDeclaration, (T) -> T.HashableType, T.HashableType>
     where T.EquatableType == Int, T.HashableType == String
   
-  func request<T: AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
     -> Mockable<FunctionDeclaration, (T) -> T.HashableType, T.HashableType>
     where T.EquatableType == Bool, T.HashableType == String
 }
 extension AssociatedTypeImplementerProtocolMock: StubbableAssociatedTypeImplementerProtocol {}
 
 private protocol StubbableAssociatedTypeImplementer {
-  func request<T: AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
+  func request<T: MockingbirdTestsHost.AssociatedTypeProtocol>(object: @escaping @autoclosure () -> T)
     -> Mockable<FunctionDeclaration, (T) -> Void, Void>
     where T.EquatableType == Int, T.HashableType == String
 }
 extension AssociatedTypeImplementerMock: StubbableAssociatedTypeImplementer {}
 
-private protocol StubbableAssociatedTypeGenericConstraintsProtocol: AssociatedTypeGenericConstraintsProtocol {
+private protocol StubbableAssociatedTypeGenericConstraintsProtocol: MockingbirdTestsHost.AssociatedTypeGenericConstraintsProtocol {
   func request(object: @escaping @autoclosure () -> ConstrainedType)
     -> Mockable<FunctionDeclaration, (ConstrainedType) -> Bool, Bool>
 }
 extension AssociatedTypeGenericConstraintsProtocolMock: StubbableAssociatedTypeGenericConstraintsProtocol {}
 
-private protocol StubbableAssociatedTypeGenericConformingConstraintsProtocol: AssociatedTypeGenericConformingConstraintsProtocol {
+private protocol StubbableAssociatedTypeGenericConformingConstraintsProtocol: MockingbirdTestsHost.AssociatedTypeGenericConformingConstraintsProtocol {
   func request(object: @escaping @autoclosure () -> ConformingType)
     -> Mockable<FunctionDeclaration, (ConformingType) -> Bool, Bool>
 }
 extension AssociatedTypeGenericConformingConstraintsProtocolMock: StubbableAssociatedTypeGenericConformingConstraintsProtocol {}
 
-private protocol StubbableAssociatedTypeSelfReferencingProtocol: AssociatedTypeSelfReferencingProtocol {
+private protocol StubbableAssociatedTypeSelfReferencingProtocol: MockingbirdTestsHost.AssociatedTypeSelfReferencingProtocol {
   func request(array: @escaping @autoclosure () -> SequenceType)
     -> Mockable<FunctionDeclaration, (SequenceType) -> Void, Void>
   func request<T: Sequence>(array: @escaping @autoclosure () -> T)

--- a/Tests/MockingbirdTests/E2E/TypealiasingMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/TypealiasingMockableTests.swift
@@ -37,5 +37,5 @@ extension TypealiasedClassMock: MockableTypealiasedClass {}
 private protocol MockableModuleScopedTypealiasedProtocol: ModuleScopedTypealiasedProtocol, Mock {}
 extension ModuleScopedTypealiasedProtocolMock: MockableModuleScopedTypealiasedProtocol {}
 
-private protocol MockableInheritingModuleScopedAssociatedTypeProtocol: ModuleScopedAssociatedTypeProtocol, Mock {}
+private protocol MockableInheritingModuleScopedAssociatedTypeProtocol: MockingbirdTestsHost.ModuleScopedAssociatedTypeProtocol, Mock {}
 extension InheritingModuleScopedAssociatedTypeProtocolMock: MockableInheritingModuleScopedAssociatedTypeProtocol {}

--- a/Tests/MockingbirdTests/Framework/GenericsTests.swift
+++ b/Tests/MockingbirdTests/Framework/GenericsTests.swift
@@ -1,0 +1,166 @@
+//
+//  GenericsTests.swift
+//  MockingbirdTests
+//
+//  Created by Andrew Chang on 7/26/20.
+//
+
+import Mockingbird
+import XCTest
+@testable import MockingbirdTestsHost
+
+class GenericsTests: BaseTestCase {
+  
+  struct EquatableType: Equatable {
+    let value: Int
+  }
+  
+  struct HashableType: Hashable {
+    let value: Int
+  }
+  
+  var protocolMock: AssociatedTypeProtocolMock<EquatableType, HashableType>!
+  func call<T: MockingbirdTestsHost.AssociatedTypeProtocol>(
+    _ collaborator: T,
+    with object: T.EquatableType
+  ) -> T.EquatableType where T.EquatableType == EquatableType {
+    return collaborator.methodUsingEquatableTypeWithReturn(equatable: object)
+  }
+  func call<T: MockingbirdTestsHost.AssociatedTypeProtocol>(
+    _ collaborator: T.Type,
+    with object: T.EquatableType
+  ) -> T.EquatableType where T.EquatableType == EquatableType {
+    return collaborator.methodUsingEquatableTypeWithReturn(equatable: object)
+  }
+  
+  var classMock: AssociatedTypeGenericImplementerMock<EquatableType, [EquatableType]>!
+  var classInstance: AssociatedTypeGenericImplementer<EquatableType, [EquatableType]> {
+    return classMock
+  }
+  
+  let staticTestQueue = DispatchQueue(label: "co.bird.mockingbird.generic-tests")
+  
+  override func setUp() {
+    protocolMock = mock(AssociatedTypeProtocol<EquatableType, HashableType>.self)
+    classMock = mock(AssociatedTypeGenericImplementer<EquatableType, [EquatableType]>.self)
+  }
+  
+  // MARK: - Associated type protocol
+  
+  func testProtocolMock_stubParameterizedReturningInstanceMethod_wildcardMatcher() {
+    given(protocolMock.methodUsingEquatableTypeWithReturn(equatable: any())).will { return $0 }
+    XCTAssertEqual(call(protocolMock, with: EquatableType(value: 1)),
+                   EquatableType(value: 1))
+    verify(protocolMock.methodUsingEquatableTypeWithReturn(equatable: any())).wasCalled()
+  }
+  
+  func testProtocolMock_stubParameterizedReturningInstanceMethod_exactMatcher() {
+    given(protocolMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .will { return $0 }
+    given(protocolMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .willReturn(EquatableType(value: 42))
+    XCTAssertEqual(call(protocolMock, with: EquatableType(value: 2)),
+                   EquatableType(value: 42))
+    verify(protocolMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .wasNeverCalled()
+    verify(protocolMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .wasCalled()
+  }
+  
+  func testProtocolMock_stubParameterizedReturningStaticMethod_wildcardMatcher() {
+    staticTestQueue.sync {
+      reset(type(of: protocolMock).staticMock)
+      
+      given(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+        .will { return $0 }
+      XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 1)),
+                     EquatableType(value: 1))
+      verify(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+        .wasCalled()
+    }
+  }
+  
+  func testProtocolMock_stubParameterizedReturningStaticMethod_exactMatcher() {
+    staticTestQueue.sync {
+      reset(protocolMock)
+      
+      given(type(of: protocolMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+        .will { return $0 }
+      given(type(of: protocolMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+        .willReturn(EquatableType(value: 42))
+      XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 2)),
+                     EquatableType(value: 42))
+      verify(type(of: protocolMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+        .wasNeverCalled()
+      verify(type(of: protocolMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+        .wasCalled()
+    }
+  }
+  
+  // MARK: - Generic class
+  
+  func testClassMock_stubParameterizedReturningInstanceMethod_wildcardMatcher() {
+    given(classMock.methodUsingEquatableTypeWithReturn(equatable: any())).will { return $0 }
+    XCTAssertEqual(
+      classInstance.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)),
+      EquatableType(value: 1)
+    )
+    verify(classMock.methodUsingEquatableTypeWithReturn(equatable: any())).wasCalled()
+  }
+  
+  func testClassMock_stubParameterizedReturningInstanceMethod_exactMatcher() {
+    given(classMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .will { return $0 }
+    given(classMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .willReturn(EquatableType(value: 42))
+    XCTAssertEqual(
+      classInstance.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)),
+      EquatableType(value: 42)
+    )
+    verify(classMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .wasNeverCalled()
+    verify(classMock.methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .wasCalled()
+  }
+  
+  func testClassMock_stubParameterizedReturningClassMethod_wildcardMatcher() {
+    staticTestQueue.sync {
+      reset(type(of: classMock).staticMock)
+      
+      given(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+        .will { return $0 }
+      XCTAssertEqual(
+        type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)),
+        EquatableType(value: 1)
+      )
+      verify(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any())).wasCalled()
+    }
+  }
+  
+  func testClassMock_stubParameterizedReturningClassMethod_exactMatcher() {
+    staticTestQueue.sync {
+      reset(type(of: classMock).staticMock)
+      
+      given(type(of: classMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+        .will { return $0 }
+      given(type(of: classMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+        .willReturn(EquatableType(value: 42))
+      XCTAssertEqual(
+        type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)),
+        EquatableType(value: 42)
+      )
+      verify(type(of: classMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+        .wasNeverCalled()
+      verify(type(of: classMock)
+        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+        .wasCalled()
+    }
+  }
+}

--- a/Tests/MockingbirdTests/Framework/StubbingTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingTests.swift
@@ -417,7 +417,12 @@ class StubbingTests: BaseTestCase {
     XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod() as Bool)
     verify(throwingProtocol.throwingMethod()).returning(Bool.self).wasCalled()
   }
-  func testStubThrowingMethod_implicitlyRethrowsError() {
+  func testStubParameterizedThrowingMethod_throwsError() {
+    given(throwingProtocol.throwingMethod(block: any())) ~> { _ in throw FakeError() }
+    XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod(block: { true }))
+    verify(throwingProtocol.throwingMethod(block: any())).wasCalled()
+  }
+  func testStubParameterizedThrowingMethod_implicitlyRethrowsError() {
     given(throwingProtocol.throwingMethod(block: any())) ~> { _ = try $0() }
     XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod(block: { throw FakeError() }))
     verify(throwingProtocol.throwingMethod(block: any())).wasCalled()
@@ -433,7 +438,12 @@ class StubbingTests: BaseTestCase {
     XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod() as Bool)
     verify(throwingProtocol.throwingMethod()).returning(Bool.self).wasCalled()
   }
-  func testStubThrowingMethod_implicitlyRethrowsError_explicitSyntax() {
+  func testStubParameterizedThrowingMethod_throwsError_explicitSyntax() {
+    given(throwingProtocol.throwingMethod(block: any())).willThrow(FakeError())
+    XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod(block: { true }))
+    verify(throwingProtocol.throwingMethod(block: any())).wasCalled()
+  }
+  func testStubParameterizedThrowingMethod_implicitlyRethrowsError_explicitSyntax() {
     given(throwingProtocol.throwingMethod(block: any())).will { _ = try $0() }
     XCTAssertThrowsError(try throwingProtocolInstance.throwingMethod(block: { throw FakeError() }))
     verify(throwingProtocol.throwingMethod(block: any())).wasCalled()


### PR DESCRIPTION
⚠️ Stacked on #156 ⚠️ 

Previously, generic classes and protocols required passing the generated mock metatype for initialization which was differed from non-generic mock initialization. This is now unified such that initialization always takes in the original metatype.

```swift
// Old
mock(MyGenericTypeMock<SomeType>.self)

// New
mock(MyGenericType<SomeType>.self)
```

For protocols, this requires shadowing the original type with an uninhabited enum. Although this could introduce ambiguity in test cases that reference the original type in a generic type constraint, the incidence should be quite low and users can resolve it by simply prefixing the type name with its module qualification.

Closes #154 