### PR TITLE
Improve ValueProvider value semantics

### DIFF
--- a/Sources/MockingbirdFramework/Stubbing/DefaultValues.swift
+++ b/Sources/MockingbirdFramework/Stubbing/DefaultValues.swift
@@ -135,7 +135,7 @@ public extension Mock {
   ///   - valueProvider: A value provider to add.
   @discardableResult
   func useDefaultValues(from valueProvider: ValueProvider) -> Self {
-    stubbingContext.defaultValueProvider.addSubprovider(valueProvider)
+    stubbingContext.defaultValueProvider.add(valueProvider)
     return self
   }
 }

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Collections.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Collections.swift
@@ -20,7 +20,8 @@ extension Dictionary: Providable {
 }
 
 public extension ValueProvider {  
-  /// Provides default-initialized collections.
+  /// A value provider with default-initialized collections.
+  ///
   /// https://developer.apple.com/documentation/foundation/collections
   static let collectionsProvider = ValueProvider(values: [
     ObjectIdentifier(NSCountedSet.self): NSCountedSet(),

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Foundation.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Foundation.swift
@@ -9,7 +9,8 @@ import Foundation
 import CoreGraphics
 
 public extension ValueProvider {
-  /// Provides default values for primitive Swift types.
+  /// A value provider with primitive Swift types.
+  ///
   /// https://developer.apple.com/documentation/foundation/numbers_data_and_basic_values
   static let primitivesProvider = ValueProvider(values: [
     ObjectIdentifier(Bool.self): Bool(),
@@ -40,31 +41,26 @@ extension Optional: Providable {
 }
 
 public extension ValueProvider {
-  /// Provides default values for basic types that are not primitives.
+  /// A value provider with basic number and data types that are not primitives.
+  ///
   /// https://developer.apple.com/documentation/foundation/numbers_data_and_basic_values
   static let basicsProvider = ValueProvider(values: [
     ObjectIdentifier(Data.self): Data(),
     ObjectIdentifier(UUID.self): UUID(),
     ObjectIdentifier(IndexPath.self): IndexPath(),
     ObjectIdentifier(IndexSet.self): IndexSet(),
+    ObjectIdentifier(CGFloat.self): CGFloat(),
+    ObjectIdentifier(CGPoint.self): CGPoint(),
+    ObjectIdentifier(CGSize.self): CGSize(),
+    ObjectIdentifier(CGRect.self): CGRect(),
   ], identifiers: [
     Optional<Any>.providableIdentifier,
   ])
 }
 
 public extension ValueProvider {
-  /// Provides default values for graphics and geometry types.
-  /// https://developer.apple.com/documentation/foundation/numbers_data_and_basic_values
-  static let geometryProvider = ValueProvider(values: [
-    ObjectIdentifier(CGFloat.self): CGFloat(),
-    ObjectIdentifier(CGPoint.self): CGPoint(),
-    ObjectIdentifier(CGSize.self): CGSize(),
-    ObjectIdentifier(CGRect.self): CGRect(),
-  ])
-}
-
-public extension ValueProvider {
-  /// Provides default values for string and text types.
+  /// A value provider with string and text types.
+  ///
   /// https://developer.apple.com/documentation/foundation/strings_and_text
   static let stringsProvider = ValueProvider(values: [
     ObjectIdentifier(String.self): String(),
@@ -76,7 +72,8 @@ public extension ValueProvider {
 }
 
 public extension ValueProvider {
-  /// Provides default values for date and time types.
+  ///A value provider with date and time types.
+  /// 
   /// https://developer.apple.com/documentation/foundation/dates_and_times
   static let datesProvider = ValueProvider(values: [
     ObjectIdentifier(Date.self): Date(),

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Tuples.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Tuples.swift
@@ -9,12 +9,8 @@ import Foundation
 
 // Tuples only work for non-generic types, since generic parameters cannot be inferred here.
 extension ValueProvider {
-  
   func provideValue<T1, T2>(for type: (T1, T2).Type) -> (T1, T2)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1, T2) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1, T2) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -26,10 +22,7 @@ extension ValueProvider {
   }
   
   func provideValue<T1, T2, T3>(for type: (T1, T2, T3).Type) -> (T1, T2, T3)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1, T2, T3) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1, T2, T3) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -42,10 +35,7 @@ extension ValueProvider {
   }
   
   func provideValue<T1, T2, T3, T4>(for type: (T1, T2, T3, T4).Type) -> (T1, T2, T3, T4)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1, T2, T3, T4) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1, T2, T3, T4) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -60,10 +50,7 @@ extension ValueProvider {
   
   func provideValue<T1, T2, T3, T4, T5>(for type: (T1, T2, T3, T4, T5).Type)
     -> (T1, T2, T3, T4, T5)? {
-      for provider in subproviders.value {
-        if let value = provider.provideValue(for: type) { return value }
-      }
-      if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1, T2, T3, T4, T5) {
+      if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1, T2, T3, T4, T5) {
         return tupleValue
       } else if
         let t1 = provideValue(for: T1.self),
@@ -79,10 +66,7 @@ extension ValueProvider {
   
   func provideValue<T1, T2, T3, T4, T5, T6>(for type: (T1, T2, T3, T4, T5, T6).Type)
     -> (T1, T2, T3, T4, T5, T6)? {
-      for provider in subproviders.value {
-        if let value = provider.provideValue(for: type) { return value }
-      }
-      if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1, T2, T3, T4, T5, T6) {
+      if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1, T2, T3, T4, T5, T6) {
         return tupleValue
       } else if
         let t1 = provideValue(for: T1.self),
@@ -100,10 +84,7 @@ extension ValueProvider {
   // MARK: - Optionals
   
   func provideValue<T1, T2>(for type: (T1?, T2?).Type) -> (T1?, T2?)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1?, T2?) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1?, T2?) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -115,10 +96,7 @@ extension ValueProvider {
   }
   
   func provideValue<T1, T2, T3>(for type: (T1?, T2?, T3?).Type) -> (T1?, T2?, T3?)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1?, T2?, T3?) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1?, T2?, T3?) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -131,10 +109,7 @@ extension ValueProvider {
   }
   
   func provideValue<T1, T2, T3, T4>(for type: (T1?, T2?, T3?, T4?).Type) -> (T1?, T2?, T3?, T4?)? {
-    for provider in subproviders.value {
-      if let value = provider.provideValue(for: type) { return value }
-    }
-    if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?) {
+    if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?) {
       return tupleValue
     } else if
       let t1 = provideValue(for: T1.self),
@@ -149,10 +124,7 @@ extension ValueProvider {
   
   func provideValue<T1, T2, T3, T4, T5>(for type: (T1?, T2?, T3?, T4?, T5?).Type)
     -> (T1?, T2?, T3?, T4?, T5?)? {
-      for provider in subproviders.value {
-        if let value = provider.provideValue(for: type) { return value }
-      }
-      if let tupleValue = storedValues.value[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?, T5?) {
+      if let tupleValue = storedValues[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?, T5?) {
         return tupleValue
       } else if
         let t1 = provideValue(for: T1.self),
@@ -168,11 +140,8 @@ extension ValueProvider {
   
   func provideValue<T1, T2, T3, T4, T5, T6>(for type: (T1?, T2?, T3?, T4?, T5?, T6?).Type)
     -> (T1?, T2?, T3?, T4?, T5?, T6?)? {
-      for provider in subproviders.value {
-        if let value = provider.provideValue(for: type) { return value }
-      }
       if let tupleValue =
-        storedValues.value[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?, T5?, T6?) {
+        storedValues[ObjectIdentifier(type)] as? (T1?, T2?, T3?, T4?, T5?, T6?) {
         return tupleValue
       } else if
         let t1 = provideValue(for: T1.self),

--- a/Sources/MockingbirdFramework/Verification/Invocation.swift
+++ b/Sources/MockingbirdFramework/Verification/Invocation.swift
@@ -38,7 +38,8 @@ struct Invocation: CustomStringConvertible {
       .components(separatedBy: ".")
       .dropLast()
       .joined(separator: ".")
-    return (isGetter ? Constants.getterPrefix : Constants.setterPrefix) + propertyName.capitalized
+    return (isGetter ? Constants.getterPrefix : Constants.setterPrefix) +
+      propertyName.prefix(1).uppercased() + propertyName.dropFirst()
   }
 
   var description: String {


### PR DESCRIPTION
Simplifies `ValueProvider` by removing the previous ability to hierarchically compose providers. This change better aligns `ValueProvider` with the Swift collection APIs.

```swift
// Old
var provider = ValueProvider()
provider.addSubprovider(.standardProvider)
provider.removeSubprovider(.standardProvider)

// New (mutating)
var provider = ValueProvider()
provider.add(.standardProvider)

// New (non-mutating)
let provider = ValueProvider.collectionsProvider
  .adding(.primitivesProvider)

// New (non-mutating w/ sugar)
let provider = .collectionsProvider + .primitivesProvider
```