### PR TITLE
[1/n] Add support for reading JSON project descriptions

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		287F852825194F2A007D135D /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 287F852725194F2A007D135D /* ZIPFoundation */; };
 		287F852E25195011007D135D /* XcodeProj in Frameworks */ = {isa = PBXBuildFile; productRef = 287F852D25195011007D135D /* XcodeProj */; };
 		287F85322519659B007D135D /* MockingbirdGenerator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Mockingbird::MockingbirdGenerator::Product" /* MockingbirdGenerator.framework */; };
+		28950E2D251C4C82008EEE29 /* ProjectDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28950E2C251C4C82008EEE29 /* ProjectDescription.swift */; };
+		28DAD96E251BDD66001A0B3F /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DAD96D251BDD66001A0B3F /* Project.swift */; };
 		D314ED7F24CE1C10000CC23D /* GenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314ED7E24CE1C10000CC23D /* GenericsTests.swift */; };
 		D3643B6C247B78A5002DF069 /* Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B6B247B78A4002DF069 /* Function.swift */; };
 		D3643B72247C5107002DF069 /* String+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B71247C5107002DF069 /* String+Components.swift */; };
@@ -355,6 +357,8 @@
 
 /* Begin PBXFileReference section */
 		287F853D25196ACE007D135D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = Sources/Package.swift; sourceTree = "<group>"; };
+		28950E2C251C4C82008EEE29 /* ProjectDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDescription.swift; sourceTree = "<group>"; };
+		28DAD96D251BDD66001A0B3F /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		942B00CDCB48ADC877A01AEE /* MockingbirdTestsHostMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = MockingbirdTestsHostMocks.generated.swift; path = Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift; sourceTree = "<group>"; };
 		D314ED7E24CE1C10000CC23D /* GenericsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericsTests.swift; sourceTree = "<group>"; };
 		D3643B6B247B78A4002DF069 /* Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function.swift; sourceTree = "<group>"; };
@@ -769,6 +773,8 @@
 				D3643B75247C76EA002DF069 /* BuildSetting.swift */,
 				OBJ_108 /* CodableTarget.swift */,
 				OBJ_109 /* PBXTarget+Target.swift */,
+				28DAD96D251BDD66001A0B3F /* Project.swift */,
+				28950E2C251C4C82008EEE29 /* ProjectDescription.swift */,
 				D3EC1C0A2490BB92004E555F /* SourceTarget.swift */,
 				OBJ_110 /* SubstitutionStyle.swift */,
 				OBJ_111 /* Target.swift */,
@@ -1857,9 +1863,11 @@
 				OBJ_923 /* Tuple.swift in Sources */,
 				OBJ_924 /* Primitives.swift in Sources */,
 				OBJ_925 /* RawType.swift in Sources */,
+				28950E2D251C4C82008EEE29 /* ProjectDescription.swift in Sources */,
 				OBJ_926 /* SerializationRequest.swift in Sources */,
 				OBJ_927 /* Specializable.swift in Sources */,
 				OBJ_928 /* TypeAttributes.swift in Sources */,
+				28DAD96E251BDD66001A0B3F /* Project.swift in Sources */,
 				OBJ_929 /* Typealias.swift in Sources */,
 				OBJ_930 /* Variable.swift in Sources */,
 				OBJ_931 /* BasicOperation.swift in Sources */,

--- a/README-0.16.md
+++ b/README-0.16.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="#installation"><img src="https://img.shields.io/badge/package-cocoapods%20%7C%20carthage%20%7C%20spm-4BC51D.svg" alt="Package managers"></a>
-  <a href="/andrewchang-bird/mockingbird/blob/add-readme-logo/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+  <a href="/birdrides/mockingbird/blob/add-readme-logo/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://slofile.com/slack/birdopensource" rel="nofollow"><img src="https://img.shields.io/badge/slack-join%20channel-A417A6.svg" alt="Slack"></a>
 </p>
 
@@ -570,11 +570,12 @@ Generate mocks for a set of targets in a project.
 
 | Option | Default Value | Description | 
 | --- | --- | --- |
-| `--project` | [`(inferred)`](#--project) | Path to your project’s `.xcodeproj` file. |
-| `--targets` | `$TARGET_NAME` | List of target names to generate mocks for. |
-| `--srcroot` | `$SRCROOT` | The folder containing your project’s source files. |
+| `--targets` | *(required)* | List of target names to generate mocks for. |
+| `--project` | [`(inferred)`](#--project) | Path to an `.xcodeproj` file or a [JSON project description](https://github.com/birdrides/mockingbird/wiki/Manual-Setup#generating-mocks-for-non-xcode-projects). |
+| `--srcroot` | [`(inferred)`](#--srcroot) | The directory containing your project’s source files. |
 | `--outputs` | [`(inferred)`](#--outputs) | List of mock output file paths for each target. |
-| `--support` | [`(inferred)`](#--support) | The folder containing [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
+| `--support` | [`(inferred)`](#--support) | The directory containing [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
+| `--testbundle` | [`(inferred)`](#--testbundle) | The name of the test bundle using the mocks. |
 | `--header` |  `(none)` | Content to add at the beginning of each generated mock file. |
 | `--condition` | `(none)` | [Compilation condition](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID538) to wrap all generated mocks in, e.g. `DEBUG`. |
 | `--diagnostics` | `(none)` | List of [diagnostic generator warnings](https://github.com/birdrides/mockingbird/wiki/Diagnostic-Warnings-and-Errors) to enable. |
@@ -598,10 +599,10 @@ Configure a test target to use mocks.
 | --- | --- | --- |
 | `--target` | *(required)* | The name of a test target to configure. |
 | `--sources` | *(required)* | List of target names to generate mocks for. |
-| `--project` | [`(inferred)`](#--project) | Your project’s `.xcodeproj` file. |
-| `--srcroot` |  `<project>/../` | The folder containing your project’s source files. |
+| `--project` | [`(inferred)`](#--project) | Path to an `.xcodeproj` file or a [JSON project description](https://github.com/birdrides/mockingbird/wiki/Manual-Setup#generating-mocks-for-non-xcode-projects). |
+| `--srcroot` | [`(inferred)`](#--srcroot) | The directory containing your project’s source files. |
 | `--outputs` | [`(inferred)`](#--outputs) | List of mock output file paths for each target. |
-| `--support` | [`(inferred)`](#--support) | The folder containing [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
+| `--support` | [`(inferred)`](#--support) | The directory containing [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
 | `--header` |  `(none)` | Content to add at the beginning of each generated mock file. |
 | `--condition` | `(none)` | [Compilation condition](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID538) to wrap all generated mocks in, e.g. `DEBUG`. |
 | `--diagnostics` | `(none)` | List of [diagnostic generator warnings](https://github.com/birdrides/mockingbird/wiki/Diagnostic-Warnings-and-Errors) to enable. |
@@ -627,7 +628,7 @@ Remove Mockingbird from a test target.
 | --- | --- | --- |
 | `--targets` | *(required)* | List of target names to uninstall the Run Script Phase. |
 | `--project` | [`(inferred)`](#--project) | Your project’s `.xcodeproj` file. |
-| `--srcroot` |  `<project>/../` | The folder containing your project’s source files. |
+| `--srcroot` | [`(inferred)`](#--srcroot) | The directory containing your project’s source files. |
 
 ### Download
 
@@ -650,15 +651,23 @@ Download and unpack a compatible asset bundle. Bundles will never overwrite exis
 
 #### `--project`
 
-Mockingbird will first check if the environment variable `$PROJECT_FILE_PATH` was set (usually by an Xcode build context). It will then perform a shallow search of the current working directory for an `.xcodeproj` file. If multiple `.xcodeproj` files exist then you must explicitly provide a project file path.
+Mockingbird first checks the environment variable `PROJECT_FILE_PATH` set by the Xcode build context and then performs a shallow search of the current working directory for an `.xcodeproj` file. If multiple `.xcodeproj` files exist then you must explicitly provide a project file path.
+
+#### `--srcroot`
+
+Mockingbird checks the environment variables `SRCROOT` and `SOURCE_ROOT` set by the Xcode build context and then falls back to the directory containing the `.xcodeproj` project file. Note that source root is ignored when using JSON project descriptions. 
 
 #### `--outputs`
 
-By default Mockingbird will generate mocks into the `$(SRCROOT)/MockingbirdMocks` directory with the file name `$(PRODUCT_MODULE_NAME)Mocks.generated.swift`.
+By Mockingbird generates mocks into the directory `$(SRCROOT)/MockingbirdMocks` with the file name `$(PRODUCT_MODULE_NAME)Mocks.generated.swift`.
 
 #### `--support`
 
-Mockingbird will recursively look for [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files) in the `$(SRCROOT)/MockingbirdSupport` directory.
+Mockingbird recursively looks for [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files) in the directory `$(SRCROOT)/MockingbirdSupport`.
+
+#### `--testbundle`
+
+Mockingbird checks the environment variables `TARGET_NAME` and `TARGETNAME` set by the Xcode build context and verifies that it refers to a valid Swift unit test target. The test bundle option must be set when using [JSON project descriptions](https://github.com/birdrides/mockingbird/wiki/Manual-Setup#generating-mocks-for-non-xcode-projects) in order to enable thunk stubs.
 
 ## Additional Resources
 

--- a/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -16,14 +16,14 @@ extension ArgumentParser {
   func addProjectPath() -> OptionArgument<PathArgument> {
     return add(option: "--project",
                kind: PathArgument.self,
-               usage: "Path to your project’s '.xcodeproj' file.",
+               usage: "Path to an '.xcodeproj' file or a JSON project description.",
                completion: .filename)
   }
   
   func addSourceRoot() -> OptionArgument<PathArgument> {
     return add(option: "--srcroot",
                kind: PathArgument.self,
-               usage: "The folder containing your project's source files.",
+               usage: "The directory containing your project's source files.",
                completion: .filename)
   }
   
@@ -85,8 +85,14 @@ extension ArgumentParser {
   func addSupportPath() -> OptionArgument<PathArgument> {
     return add(option: "--support",
                kind: PathArgument.self,
-               usage: "The folder containing supporting source files.",
+               usage: "The directory containing supporting source files.",
                completion: .filename)
+  }
+  
+  func addTestBundle() -> OptionArgument<String> {
+    return add(option: "--testbundle",
+               kind: String.self,
+               usage: "The name of the test bundle using the mocks.")
   }
   
   func addHeader() -> OptionArgument<[String]> {
@@ -222,10 +228,6 @@ extension ArgumentParser.Result {
         }
         throw ArgumentParserError.expectedValue(option: "--project <xcodeproj file path>")
       }
-    }
-    guard projectPath.isDirectory, projectPath.extension == "xcodeproj" else {
-      throw ArgumentParserError.invalidValue(argument: "--project \(projectPath.absolute())",
-                                             error: .custom("Not a valid '.xcodeproj' path"))
     }
     return projectPath
   }

--- a/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
@@ -25,6 +25,7 @@ final class GenerateCommand: BaseCommand {
   private let outputsArgument: OptionArgument<[PathArgument]>
   private let outputArgument: OptionArgument<[PathArgument]>
   private let supportPathArgument: OptionArgument<PathArgument>
+  private let testBundleArgument: OptionArgument<String>
   private let diagnosticsArgument: OptionArgument<[DiagnosticType]>
   private let headerArgument: OptionArgument<[String]>
   private let compilationConditionArgument: OptionArgument<String>
@@ -46,6 +47,7 @@ final class GenerateCommand: BaseCommand {
     self.outputsArgument = subparser.addOutputs()
     self.outputArgument = subparser.addOutput()
     self.supportPathArgument = subparser.addSupportPath()
+    self.testBundleArgument = subparser.addTestBundle()
     self.diagnosticsArgument = subparser.addDiagnostics()
     self.headerArgument = subparser.addHeader()
     self.compilationConditionArgument = subparser.addCompilationCondition()
@@ -81,19 +83,22 @@ final class GenerateCommand: BaseCommand {
                                                    sourceRoot: sourceRoot)
     
     var environmentProjectFilePath: Path? {
+      guard projectPath.extension == "xcodeproj" else { return projectPath }
       guard let filePath = environment["PROJECT_FILE_PATH"] else { return nil }
       let path = Path(filePath)
       guard path.extension == "xcodeproj" else { return nil }
       return path
     }
     var environmentSourceRoot: Path? {
+      guard projectPath.extension == "xcodeproj" else { return projectPath.parent() }
       guard let sourceRoot = environment["SRCROOT"] ?? environment["SOURCE_ROOT"] else {
         return nil
       }
       let path = Path(sourceRoot)
       return path
     }
-    let environmentTargetName = environment["TARGET_NAME"] ?? environment["TARGETNAME"]
+    let environmentTargetName = arguments.get(testBundleArgument)
+      ?? environment["TARGET_NAME"] ?? environment["TARGETNAME"]
     
     let config = Generator.Configuration(
       projectPath: projectPath,

--- a/Sources/MockingbirdCli/Interface/Generator+Pipeline.swift
+++ b/Sources/MockingbirdCli/Interface/Generator+Pipeline.swift
@@ -43,6 +43,14 @@ extension Generator {
                                                  options: .all,
                                                  environment: environment)
         checkCache = nil
+        
+      case .describedTarget(let target):
+        extractSources = ExtractSourcesOperation(target: target,
+                                                 sourceRoot: config.sourceRoot,
+                                                 supportPath: config.supportPath,
+                                                 options: .all,
+                                                 environment: environment)
+        checkCache = nil
       
       case .sourceTarget(let target):
         extractSources = ExtractSourcesOperation(target: target as CodableTarget,
@@ -116,6 +124,20 @@ extension Generator {
       let target: SourceTarget
       switch inputTarget {
       case .pbxTarget(let pipelineTarget):
+        target = try SourceTarget(from: pipelineTarget,
+                                  sourceRoot: sourceRoot,
+                                  supportPaths: result.supportPaths.map({ $0.path }),
+                                  projectHash: projectHash,
+                                  outputHash: outputPath.read().generateSha1Hash(),
+                                  mockedTypesHash: mockedTypesResult?.generateMockedTypeNamesHash(),
+                                  targetPathsHash: result.generateTargetPathsHash(),
+                                  dependencyPathsHash: result.generateDependencyPathsHash(),
+                                  cliVersion: cliVersion,
+                                  configHash: configHash,
+                                  ignoredDependencies: &ignoredDependencies,
+                                  environment: environment)
+        
+      case .describedTarget(let pipelineTarget):
         target = try SourceTarget(from: pipelineTarget,
                                   sourceRoot: sourceRoot,
                                   supportPaths: result.supportPaths.map({ $0.path }),

--- a/Sources/MockingbirdCli/Interface/Generator.swift
+++ b/Sources/MockingbirdCli/Interface/Generator.swift
@@ -39,7 +39,8 @@ class Generator {
   
   enum Constants {
     static let generatedFileNameSuffix = "Mocks.generated.swift"
-    static let cacheSubdirectory = "MockingbirdCache"
+    static let xcodeCacheSubdirectory = "MockingbirdCache"
+    static let jsonCacheSubdirectory = ".mockingbird"
   }
   
   let config: Configuration
@@ -54,37 +55,53 @@ class Generator {
     self.configHash = try config.toSha1Hash()
     
     // Set up directories for target metadata caching.
-    self.sourceTargetCacheDirectory = config.projectPath + Constants.cacheSubdirectory
-    if let environmentProjectFilePath = config.environmentProjectFilePath {
-      let cacheDirectory = environmentProjectFilePath + Constants.cacheSubdirectory
-      self.testTargetCacheDirectory = cacheDirectory
+    if config.projectPath.extension == "xcodeproj" {
+      self.sourceTargetCacheDirectory = config.projectPath + Constants.xcodeCacheSubdirectory
+      if let environmentProjectFilePath = config.environmentProjectFilePath {
+        let cacheDirectory = environmentProjectFilePath + Constants.xcodeCacheSubdirectory
+        self.testTargetCacheDirectory = cacheDirectory
+      } else {
+        self.testTargetCacheDirectory = nil
+      }
     } else {
-      self.testTargetCacheDirectory = nil
+      self.sourceTargetCacheDirectory = config.projectPath.parent()
+        + Constants.jsonCacheSubdirectory
+      self.testTargetCacheDirectory = self.sourceTargetCacheDirectory
     }
   }
   
-  var parsedProjects = [Path: XcodeProj]()
-  func getXcodeProj(_ projectPath: Path) throws -> XcodeProj {
+  var parsedProjects = [Path: Project]()
+  func getProject(_ projectPath: Path) throws -> Project {
     if let xcodeproj = parsedProjects[projectPath] { return xcodeproj }
-    var xcodeproj: XcodeProj!
+    var project: Project!
     try time(.parseXcodeProject) {
-      xcodeproj = try XcodeProj(path: projectPath)
+      if projectPath.extension == "xcodeproj" {
+        project = .xcode(try XcodeProj(path: projectPath))
+      } else {
+        logInfo("Inferring JSON project description from extension \((projectPath.extension ?? "").singleQuoted)")
+        project = .json(try JSONProject(path: projectPath))
+      }
     }
-    parsedProjects[projectPath] = xcodeproj
-    return xcodeproj
+    parsedProjects[projectPath] = project
+    return project
   }
   
   // Parsing Xcode projects can be slow, so lazily get implicit build environments.
   func getBuildEnvironment() -> [String: Any] {
-    let xcodeproj = try? getXcodeProj(config.projectPath)
-    return xcodeproj?.implicitBuildEnvironment ?? [:]
+    let project = try? getProject(config.projectPath)
+    switch project {
+    case .xcode(let xcodeproj): return xcodeproj.implicitBuildEnvironment
+    case .json, .none: return [:]
+    }
   }
   
   var projectHash: String?
   func getProjectHash(_ projectPath: Path) -> String? {
     if let projectHash = projectHash { return projectHash }
-    let pbxprojPath = projectPath.glob("*.pbxproj").first
-    let projectHash = try? pbxprojPath?.read().generateSha1Hash()
+    let filePath = projectPath.extension == "xcodeproj"
+      ? projectPath.glob("*.pbxproj").first
+      : projectPath
+    let projectHash = try? filePath?.read().generateSha1Hash()
     self.projectHash = projectHash
     return projectHash
   }
@@ -130,19 +147,29 @@ class Generator {
     }
     
     // Resolve target names to concrete Xcode project targets.
-    let isSourceTarget: (PBXTarget) -> Bool = { target in
-      guard target.productType?.isTestBundle != true else {
-        logWarning("Excluding \(target.name.singleQuoted) from mock generation because it is a test bundle target")
-        return false
+    let isSourceTarget: (TargetType) -> Bool = { target in
+      switch target {
+      case .pbxTarget(let target):
+        guard target.productType?.isTestBundle != true else {
+          logWarning("Excluding \(target.name.singleQuoted) from mock generation because it is a test bundle target")
+          return false
+        }
+        return true
+      case .describedTarget(let target):
+        switch target.productType {
+        case .library: return true
+        case .test, .none: return false
+        }
+      case .sourceTarget: return true
+      case .testTarget: return false
       }
-      return true
     }
     let targets = try config.inputTargetNames.compactMap({ targetName throws -> TargetType? in
       return try Generator.resolveTarget(targetName: targetName,
                                          projectPath: config.projectPath,
                                          isValidTarget: isSourceTarget,
                                          getCachedTarget: getCachedSourceTarget,
-                                         getXcodeProj: getXcodeProj)
+                                         getProject: getProject)
     })
     
     // Resolve unspecified output paths to the default mock file output destination.
@@ -159,7 +186,7 @@ class Generator {
     let pruningPipeline = config.disableThunkStubs ? nil :
       PruningPipeline(config: config,
                       getCachedTarget: getCachedTestTarget,
-                      getXcodeProj: getXcodeProj,
+                      getProject: getProject,
                       environment: getBuildEnvironment)
     if let pruningOperations = pruningPipeline?.operations {
       queue.addOperations(pruningOperations, waitUntilFinished: false)
@@ -243,17 +270,17 @@ class Generator {
   
   static func resolveTarget(targetName: String,
                             projectPath: Path,
-                            isValidTarget: (PBXTarget) -> Bool,
+                            isValidTarget: (TargetType) -> Bool,
                             getCachedTarget: (String) -> TargetType?,
-                            getXcodeProj: (Path) throws -> XcodeProj) throws -> TargetType {
+                            getProject: (Path) throws -> Project) throws -> TargetType {
     // Check if the target is cached in the project.
     if let cachedTarget = getCachedTarget(targetName) {
       return cachedTarget
     }
     
     // Need to parse the Xcode project for the full `PBXTarget` object.
-    let xcodeproj = try getXcodeProj(projectPath)
-    let targets = xcodeproj.pbxproj.targets(named: targetName).filter(isValidTarget)
+    let project = try getProject(projectPath)
+    let targets = project.targets(named: targetName).filter(isValidTarget)
     
     if targets.count > 1 {
       logWarning("Found multiple targets named \(targetName.singleQuoted), using the first one")
@@ -264,7 +291,7 @@ class Generator {
         description: "Unable to find target named \(targetName.singleQuoted)"
       )
     }
-    return .pbxTarget(target)
+    return target
   }
 }
 

--- a/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
@@ -14,6 +14,8 @@ public struct SourceFile: Codable, Hashable {
   public let hash: String?
 }
 
+/// A sparse representation of dependencies is used since caching only relies on the unique set of
+/// dependency sources for a single module being mocked.
 public class CodableTargetDependency: TargetDependency, Codable {
   public let target: CodableTarget?
   
@@ -26,6 +28,10 @@ public class CodableTargetDependency: TargetDependency, Codable {
                                     sourceRoot: sourceRoot,
                                     ignoredDependencies: &ignoredDependencies,
                                     environment: environment)
+  }
+  
+  init(target: CodableTarget) {
+    self.target = target
   }
   
   public static func == (lhs: CodableTargetDependency, rhs: CodableTargetDependency) -> Bool {

--- a/Sources/MockingbirdGenerator/Parser/Project/Project.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/Project.swift
@@ -1,0 +1,23 @@
+//
+//  Project.swift
+//  MockingbirdGenerator
+//
+//  Created by typealias on 9/23/20.
+//
+
+import Foundation
+import XcodeProj
+
+public enum Project {
+  case xcode(_ xcodeProj: XcodeProj)
+  case json(_ jsonProject: JSONProject)
+  
+  public func targets(named name: String) -> [TargetType] {
+    switch self {
+    case .xcode(let xcodeProj):
+      return xcodeProj.pbxproj.targets(named: name).map({ .pbxTarget($0) })
+    case .json(let jsonProject):
+      return jsonProject.targets(named: name).map({ .describedTarget($0) })
+    }
+  }
+}

--- a/Sources/MockingbirdGenerator/Parser/Project/ProjectDescription.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/ProjectDescription.swift
@@ -1,0 +1,87 @@
+//
+//  ProjectDescription.swift
+//  MockingbirdGenerator
+//
+//  Created by typealias on 9/23/20.
+//
+
+import Foundation
+import PathKit
+
+public struct ProjectDescription: Codable, Hashable {
+  public let targets: [TargetDescription]
+}
+
+public struct TargetDescription: Codable, Hashable {
+  public let name: String
+  public let c99name: String?
+  public let type: String
+  public let path: Path
+  public let sources: [Path]
+  public let dependencies: [String]
+  
+  public var productModuleName: String {
+    return c99name ?? name.escapingForModuleName()
+  }
+}
+
+public enum TargetDescriptionType: String {
+  case library = "library"
+  case test = "test"
+  var isTestBundle: Bool { return self == .test }
+}
+
+public struct DescribedTargetDependency: TargetDependency {
+  public let target: DescribedTarget?
+}
+
+public struct DescribedTarget: Target {
+  public var name: String { return description.name }
+  public let dependencies: [DescribedTargetDependency]
+  public let description: TargetDescription
+  public let productType: TargetDescriptionType?
+  
+  public init(from description: TargetDescription,
+              descriptions: [TargetDescription],
+              processedTargets: [String] = []) {
+    self.description = description
+    self.productType = TargetDescriptionType(rawValue: description.type)
+    self.dependencies = description.dependencies.compactMap({ name in
+      guard let dependency = descriptions.first(where: { $0.productModuleName == name })
+      else { return nil }
+      let attributedProcessedTargets = processedTargets + [dependency.productModuleName]
+      guard !processedTargets.contains(dependency.productModuleName) else {
+        logWarning("Breaking circular dependency \(attributedProcessedTargets.joined(separator: " -> "))")
+        return nil
+      }
+      let target = DescribedTarget(from: dependency,
+                                   descriptions: descriptions,
+                                   processedTargets: attributedProcessedTargets)
+      return DescribedTargetDependency(target: target)
+    })
+  }
+  
+  public func resolveProductModuleName(environment: () -> [String: Any]) -> String {
+    return description.productModuleName
+  }
+  
+  public func findSourceFilePaths(sourceRoot: Path) -> [Path] {
+    return description.sources.map({ description.path + $0 })
+  }
+}
+
+public class JSONProject {
+  let path: Path
+  let descriptions: [TargetDescription]
+  
+  required public init(path: Path) throws {
+    self.path = path
+    self.descriptions = try JSONDecoder().decode(ProjectDescription.self, from: path.read()).targets
+  }
+  
+  public func targets(named name: String) -> [DescribedTarget] {
+    return descriptions
+      .filter({ $0.name == name })
+      .map({ DescribedTarget(from: $0, descriptions: descriptions) })
+  }
+}

--- a/Sources/MockingbirdGenerator/Parser/Project/TargetType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/TargetType.swift
@@ -10,12 +10,14 @@ import XcodeProj
 
 public enum TargetType {
   case pbxTarget(_ pbxTarget: PBXTarget)
+  case describedTarget(_ describedTarget: DescribedTarget)
   case sourceTarget(_ sourceTarget: SourceTarget)
   case testTarget(_ testTarget: TestTarget)
   
   public var name: String {
     switch self {
     case .pbxTarget(let target): return target.name
+    case .describedTarget(let target): return target.name
     case .sourceTarget(let target): return target.name
     case .testTarget(let target): return target.name
     }
@@ -24,6 +26,8 @@ public enum TargetType {
   public func resolveProductModuleName(environment: () -> [String: Any]) -> String {
     switch self {
     case .pbxTarget(let target):
+      return target.resolveProductModuleName(environment: environment)
+    case .describedTarget(let target):
       return target.resolveProductModuleName(environment: environment)
     case .sourceTarget(let target):
       return target.resolveProductModuleName(environment: environment)


### PR DESCRIPTION
⚠️ Stack **1 of n** ⚠️ 

Custom build systems such as Buck or Bazel need a way to generate mocks without an `.xcodeproj` file. This adds support for passing a JSON project description containing all of the required module and dependency graph information usually parsed from an Xcode project. The description format is roughly compatible with the output from `$ swift package describe --type JSON`, although adding the `dependency` field needs to be upstreamed.

```json
{
  "targets": [
    {
      "name": "MyLibrary",
      "type": "library",
      "path": "/path/to/my-library",
      "dependencies": [],
      "sources": [
        "SourceFileA.swift",
        "SourceFileB.swift"
      ]
    },
    {
      "name": "MyOtherLibrary",
      "type": "library",
      "path": "/path/to/my-other-library",
      "dependencies": [
        "MyLibrary"
      ],
      "sources": [
        "SourceFileA.swift",
        "SourceFileB.swift"
      ]
    },
    {
      "name": "MyLibraryTests",
      "type": "test",
      "path": "/path/to/my-library-tests",
      "dependencies": [
        "MyLibrary"
      ],
      "sources": [
        "SourceFileA.swift",
        "SourceFileB.swift"
      ]
    }
  ]
}
```

The `--project` generator option now accepts arbitrary files. Iff a file with an `xcodeproj` extension is provided then it is read as an Xcode project. Cache metadata is stored in the same enclosing directory as the project description file under the `.mockingbird` subdirectory.

Since builds are run outside of an Xcode testing context, it's necessary to optionally provide a host test target with the `--testbundle` option to enable thunk pruning support.

```bash
mockingbird generate \
  --target MyLibrary \
  --testbundle MyLibraryTests \
  --project /path/to/project-desc.json
```