### PR TITLE
Add targetName to lock file name

### DIFF
--- a/Sources/MockingbirdCli/Interface/Generator+Pipeline.swift
+++ b/Sources/MockingbirdCli/Interface/Generator+Pipeline.swift
@@ -23,6 +23,7 @@ extension Generator {
       })
     }
     private let mockedTypesResult: FindMockedTypesOperation.Result?
+    private let environmentTargetName: String?
     
     init(inputTarget: TargetType,
          outputPath: Path,
@@ -31,6 +32,7 @@ extension Generator {
          environment: @escaping () -> [String: Any]) throws {
       self.inputTarget = inputTarget
       self.outputPath = outputPath
+      self.environmentTargetName = config.environmentTargetName
       
       // Extract sources.
       let extractSources: ExtractSourcesAbstractOperation
@@ -173,7 +175,7 @@ extension Generator {
       }
       
       let data = try JSONEncoder().encode(target)
-      let filePath = cacheDirectory.targetLockFilePath(for: target.name)
+      let filePath = cacheDirectory.targetLockFilePath(for: target.name, testBundle: self.environmentTargetName)
       try filePath.write(data)
       log("Cached pipeline input target \(inputTarget.name.singleQuoted) to \(filePath.absolute())")
     }
@@ -185,7 +187,7 @@ extension Generator {
                               configHash: String,
                               cacheDirectory: Path,
                               sourceRoot: Path) -> SourceTarget? {
-    let filePath = cacheDirectory.targetLockFilePath(for: targetName)
+    let filePath = cacheDirectory.targetLockFilePath(for: targetName, testBundle: self.config.environmentTargetName)
     
     guard filePath.exists else {
       log("No cached source target metadata exists for \(targetName.singleQuoted) at \(filePath.absolute())")

--- a/Sources/MockingbirdCli/Interface/Generator+PruningPipeline.swift
+++ b/Sources/MockingbirdCli/Interface/Generator+PruningPipeline.swift
@@ -16,6 +16,7 @@ extension Generator {
     let operations: [BasicOperation]
     let testTarget: TargetType
     let findMockedTypesOperation: FindMockedTypesOperation
+    private let environmentTargetName: String
     
     init?(config: Configuration,
           getCachedTarget: (String) -> TargetType?,
@@ -25,6 +26,7 @@ extension Generator {
         let environmentSourceRoot = config.environmentSourceRoot,
         let environmentTargetName = config.environmentTargetName
         else { return nil }
+      self.environmentTargetName = environmentTargetName
       
       let isTestTarget: (TargetType) -> Bool = { target in
         switch target {
@@ -144,7 +146,7 @@ extension Generator {
       }
       
       let data = try JSONEncoder().encode(target)
-      let filePath = cacheDirectory.targetLockFilePath(for: target.name)
+      let filePath = cacheDirectory.targetLockFilePath(for: target.name, testBundle:  environmentTargetName)
       try filePath.write(data)
       log("Cached pipeline test target \(target.name.singleQuoted) to \(filePath.absolute())")
     }
@@ -156,7 +158,7 @@ extension Generator {
                             configHash: String,
                             cacheDirectory: Path,
                             sourceRoot: Path) -> TestTarget? {
-    let filePath = cacheDirectory.targetLockFilePath(for: targetName)
+    let filePath = cacheDirectory.targetLockFilePath(for: targetName, testBundle: self.config.environmentTargetName)
     
     guard filePath.exists else {
       log("No cached test target metadata exists for \(targetName.singleQuoted) at \(filePath.absolute())")

--- a/Sources/MockingbirdCli/Interface/Generator.swift
+++ b/Sources/MockingbirdCli/Interface/Generator.swift
@@ -300,8 +300,14 @@ extension Path {
     return absolute() + Path("MockingbirdMocks")
   }
   
-  func targetLockFilePath(for targetName: String) -> Path {
-    return self + "\(targetName).lock"
+  func targetLockFilePath(for targetName: String, testBundle: String?) -> Path {
+    var lockFileName: String
+    if let testBundle = testBundle {
+      lockFileName = "\(targetName)-\(testBundle).lock"
+    } else {
+      lockFileName = "\(targetName).lock"
+    }
+    return self + lockFileName
   }
 }
 


### PR DESCRIPTION
This PR adds `targetName` to the lock file name, to make sure cache doesn't get invalidated when generating mocks for a different target.

It fixes issue https://github.com/birdrides/mockingbird/issues/191