### PR TITLE
Added possibility to change the download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,10 @@ Download and unpack a compatible asset bundle. Bundles will never overwrite exis
 | --- | --- |
 | `starter-pack` | Starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
 
+| Option | Default Value | Description |
+| --- | --- | --- |
+| `--url` | `https://github.com/birdrides/mockingbird/releases/download` | The base URL containing downloadable asset bundles. |
+
 ### Global Options
 
 | Flag | Description |

--- a/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -304,14 +304,6 @@ extension ArgumentParser.Result {
       throw ArgumentParserError.expectedValue(option: "--target <target name>")
     }
   }
-    
-  func getBaseUrl(using argument: OptionArgument<String>) throws -> String? {
-    if let url = get(argument) {
-      return url
-    } else {
-      throw ArgumentParserError.expectedValue(option: "--url <base url>")
-    }
-  }
   
   func getOutputDirectory(using argument: OptionArgument<PathArgument>) throws -> Path {
     if let rawOutput = get(argument)?.path.pathString {

--- a/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -142,10 +142,10 @@ extension ArgumentParser {
                usage: "List of diagnostic generator warnings to enable.")
   }
     
-  func addDownloadUrl() -> OptionArgument<String> {
+  func addBaseUrl() -> OptionArgument<String> {
     return add(option: "--url",
                kind: String.self,
-               usage: "The url where the file should be downloaded from.")
+               usage: "The base URL containing downloadable asset bundles.")
   }
   
   // MARK: Global Options
@@ -305,11 +305,11 @@ extension ArgumentParser.Result {
     }
   }
     
-  func getDownloadUrl(using argument: OptionArgument<String>) throws -> String? {
+  func getBaseUrl(using argument: OptionArgument<String>) throws -> String? {
     if let url = get(argument) {
       return url
     } else {
-      throw ArgumentParserError.expectedValue(option: "--url <download url>")
+      throw ArgumentParserError.expectedValue(option: "--url <base url>")
     }
   }
   

--- a/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
+++ b/Sources/MockingbirdCli/Interface/ArgumentParser+Extensions.swift
@@ -141,6 +141,12 @@ extension ArgumentParser {
                kind: [DiagnosticType].self,
                usage: "List of diagnostic generator warnings to enable.")
   }
+    
+  func addDownloadUrl() -> OptionArgument<String> {
+    return add(option: "--url",
+               kind: String.self,
+               usage: "The url where the file should be downloaded from.")
+  }
   
   // MARK: Global Options
   
@@ -296,6 +302,14 @@ extension ArgumentParser.Result {
       return target
     } else {
       throw ArgumentParserError.expectedValue(option: "--target <target name>")
+    }
+  }
+    
+  func getDownloadUrl(using argument: OptionArgument<String>) throws -> String? {
+    if let url = get(argument) {
+      return url
+    } else {
+      throw ArgumentParserError.expectedValue(option: "--url <download url>")
     }
   }
   

--- a/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
@@ -84,7 +84,7 @@ final class DownloadCommand: BaseCommand {
                                                    environment: environment,
                                                    workingPath: workingPath)
     let inferredRootPath = projectPath.parent()
-    let baseUrl = try arguments.getBaseUrl(using: baseUrlArgument) ?? Constants.defaultBaseUrl
+    let baseUrl = arguments.get(baseUrlArgument) ?? Constants.defaultBaseUrl
     
     try super.run(with: arguments, environment: environment, workingPath: workingPath)
     guard let type = arguments.get(assetBundleTypeArgument) else { return }

--- a/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/DownloadCommand.swift
@@ -11,6 +11,8 @@ import PathKit
 import SPMUtility
 import ZIPFoundation
 
+private var downloadUrl: String = "https://github.com/birdrides/mockingbird/releases/download"
+
 enum AssetBundleType: String, ArgumentKind, CaseIterable, CustomStringConvertible {
   case starterPack = "starter-pack"
   
@@ -39,7 +41,7 @@ enum AssetBundleType: String, ArgumentKind, CaseIterable, CustomStringConvertibl
   
   private func assetBundleUrl(for fileName: String) -> Foundation.URL {
     return Foundation.URL(string:
-      "https://github.com/birdrides/mockingbird/releases/download/\(mockingbirdVersion)/\(fileName)"
+      "\(downloadUrl)/\(mockingbirdVersion)/\(fileName)"
     )!
   }
   var url: Foundation.URL {
@@ -66,11 +68,14 @@ final class DownloadCommand: BaseCommand {
   
   private let assetBundleTypeArgument: PositionalArgument<AssetBundleType>
   private let projectPathArgument: OptionArgument<PathArgument>
+    
+  private let downloadUrlArgument: OptionArgument<String>
   
   required init(parser: ArgumentParser) {
     let subparser = parser.add(subparser: Constants.name, overview: Constants.overview)
     self.assetBundleTypeArgument = subparser.addAssetBundleType()
     self.projectPathArgument = subparser.addProjectPath()
+    self.downloadUrlArgument = subparser.addDownloadUrl()
     super.init(parser: subparser)
   }
   
@@ -81,6 +86,10 @@ final class DownloadCommand: BaseCommand {
                                                    environment: environment,
                                                    workingPath: workingPath)
     let inferredRootPath = projectPath.parent()
+    
+    if let newDownloadUrl = try arguments.getDownloadUrl(using: downloadUrlArgument) {
+        downloadUrl = newDownloadUrl
+    }
     
     try super.run(with: arguments, environment: environment, workingPath: workingPath)
     guard let type = arguments.get(assetBundleTypeArgument) else { return }


### PR DESCRIPTION
In order to cache the mockingbird package on a local server and downloading it from there, the hardcoded github link must be changeable.
I havn't tried this MR locally so please review it.
Link to my already created Feature Request: https://github.com/birdrides/mockingbird/issues/200