### PR TITLE
Add versioned CLI launcher

### DIFF
--- a/.github/workflows/build-framework-cli.yml
+++ b/.github/workflows/build-framework-cli.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Build and Install CLI
       run: |
         make print-debug-info | grep "Mockingbird rpath: /var/tmp/mockingbird/$(make get-version)/libs"
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make print-debug-info
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make install
+        PREFIX=$(pwd) HERMETIC=1 make print-debug-info
+        PREFIX=$(pwd) HERMETIC=1 make install
     - name: Set Up Caching Target
       run: |
         ./bin/mockingbird install \
@@ -86,8 +86,8 @@ jobs:
     - name: Build and Install CLI
       run: |
         make print-debug-info | grep "Mockingbird rpath: /var/tmp/mockingbird/$(make get-version)/libs"
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make print-debug-info
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make install
+        PREFIX=$(pwd) HERMETIC=1 make print-debug-info
+        PREFIX=$(pwd) HERMETIC=1 make install
     - name: Set Up Target
       run: |
         ./bin/mockingbird install \
@@ -123,8 +123,8 @@ jobs:
     - name: Build and Install CLI
       run: |
         make print-debug-info | grep "Mockingbird rpath: /var/tmp/mockingbird/$(make get-version)/libs"
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make print-debug-info
-        PREFIX=$(pwd) USE_RELATIVE_RPATH=1 make install
+        PREFIX=$(pwd) HERMETIC=1 make print-debug-info
+        PREFIX=$(pwd) HERMETIC=1 make install
     - name: Set Up Target
       run: |
         ./bin/mockingbird install \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Import Secrets
       uses: apple-actions/import-codesign-certs@v1
-      with: 
+      with:
         p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
         p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
     - name: Print Debug Info
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Import Secrets
       uses: apple-actions/import-codesign-certs@v1
-      with: 
+      with:
         p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
         p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
     - name: Print Debug Info
@@ -77,7 +77,7 @@ jobs:
       env:
         AC_USERNAME: ${{ secrets.AC_USERNAME }}
         AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        USE_RELATIVE_RPATH: 1
+        HERMETIC: 1
       run: make signed-release
     - name: Document SHAs
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,11 @@
 *.xcodeproj/GeneratedModuleMap/
 build/
 DerivedData
-Mockingbird.pkg
-Mockingbird.zip
-MockingbirdCli.pkg
-MockingbirdCli.zip
+Mockingbird*.pkg
+Mockingbird*.zip
+MockingbirdCli*.pkg
+MockingbirdCli*.zip
 MockingbirdSupport.zip
-mockingbird
 Mockingbird-*.framework
 bin/
 var/

--- a/README-0.17.md
+++ b/README-0.17.md
@@ -73,7 +73,7 @@ verify(bird.fly()).wasCalled()
 
 ## Installation
 
-Select your preferred dependency manager below for installation instructions and example projects. 
+Select your preferred dependency manager below for installation instructions and example projects.
 
 <details><summary><b>CocoaPods</b></summary>
 
@@ -86,29 +86,22 @@ target 'MyAppTests' do
 end
 ```
 
-Initialize the pod and install the CLI.
+In your project directory, initialize the pod and download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
 
 ```console
 $ pod install
-$ (cd Pods/MockingbirdFramework && make install-prebuilt)
-```
-
-Then download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
-
-```console
-$ mockingbird download starter-pack
+$ Pods/MockingbirdFramework/mockingbird download starter-pack
 ```
 
 Finally, configure a test target to generate mocks for each listed source module. For advanced usages, see the [available installer options](#install) and how to [set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
 
 ```console
-$ mockingbird install --target MyAppTests --sources MyApp MyLibrary1 MyLibrary2
+$ Pods/MockingbirdFramework/mockingbird install --target MyAppTests --sources MyApp MyLibrary1 MyLibrary2
 ```
 
 Optional but recommended:
 
 - [Exclude generated files from source control](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#source-control-exclusion)
-- [Pin the binary for hermetic builds](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#pin-the-binary)
 
 Have questions or issues?
 
@@ -126,17 +119,11 @@ Add the framework to your `Cartfile`.
 github "birdrides/mockingbird" ~> 0.17
 ```
 
-Build the framework with Carthage, [link it to your test target](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets), and install the CLI.
+In your project directory, build the framework, [link it to your test target](https://github.com/birdrides/mockingbird/wiki/Linking-Test-Targets), and download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
 
 ```console
 $ carthage update
-$ (cd Carthage/Checkouts/mockingbird && make install-prebuilt)
-```
-
-Then download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
-
-```console
-$ mockingbird download starter-pack
+$ Carthage/Checkouts/mockingbird download starter-pack
 ```
 
 Finally, configure a test target to generate mocks for each listed source module. For advanced usages, see the [available installer options](#install) and how to [set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
@@ -148,7 +135,6 @@ $ mockingbird install --target MyAppTests --sources MyApp MyLibrary1 MyLibrary2
 Optional but recommended:
 
 - [Exclude generated files from source control](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#source-control-exclusion)
-- [Pin the binary for hermetic builds](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#pin-the-binary)
 
 Have questions or issues?
 
@@ -191,30 +177,24 @@ let package = Package(
 
 </details>
 
-In your project directory, initialize the package dependency and install the CLI.
+In your project directory, initialize the package dependency and download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
 
 ```console
 $ xcodebuild -resolvePackageDependencies
 $ DERIVED_DATA=$(xcodebuild -showBuildSettings | pcregrep -o1 'OBJROOT = (/.*)/Build')
-$ (cd "${DERIVED_DATA}/SourcePackages/checkouts/mockingbird" && make install-prebuilt)
-```
-
-Then download the starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files).
-
-```console
-$ mockingbird download starter-pack
+$ REPO_PATH="${DERIVED_DATA}/SourcePackages/checkouts/mockingbird"
+$ REPO_PATH/mockingbird download starter-pack
 ```
 
 Finally, configure a test target to generate mocks for each listed source module. For advanced usages, see the [available installer options](#install) and how to [set up targets manually](https://github.com/birdrides/mockingbird/wiki/Manual-Setup).
 
 ```console
-$ mockingbird install --target MyPackageTests --sources MyPackage MyLibrary1 MyLibrary2
+$ REPO_PATH/mockingbird install --target MyPackageTests --sources MyPackage MyLibrary1 MyLibrary2
 ```
 
 Optional but recommended:
 
 - [Exclude generated files from source control](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#source-control-exclusion)
-- [Pin the binary for hermetic builds](https://github.com/birdrides/mockingbird/wiki/Integration-Tips#pin-the-binary)
 
 Have questions or issues?
 
@@ -337,7 +317,7 @@ bird.useDefaultValues(from: .standardProvider)
 print(bird.name)  // Prints ""
 ```
 
-You can create custom value providers by registering values for types. 
+You can create custom value providers by registering values for types.
 
 ```swift
 var valueProvider = ValueProvider()
@@ -479,7 +459,7 @@ inOrder(with: .noInvocationsAfter) {
 
 #### Asynchronous Verification
 
-Mocked methods that are invoked asynchronously can be verified using an `eventually` block which returns an `XCTestExpectation`. 
+Mocked methods that are invoked asynchronously can be verified using an `eventually` block which returns an `XCTestExpectation`.
 
 ```swift
 DispatchQueue.main.async {
@@ -607,9 +587,9 @@ Usage is determined by statically analyzing test target sources for calls to `mo
 
 Generate mocks for a set of targets in a project.
 
-`mockingbird generate` 
+`mockingbird generate`
 
-| Option | Default Value | Description | 
+| Option | Default Value | Description |
 | --- | --- | --- |
 | `--targets` | *(required)* | List of target names to generate mocks for. |
 | `--project` | [`(inferred)`](#--project) | Path to an `.xcodeproj` file or a [JSON project description](https://github.com/birdrides/mockingbird/wiki/Manual-Setup#generating-mocks-for-non-xcode-projects). |
@@ -681,6 +661,10 @@ Download and unpack a compatible asset bundle. Bundles will never overwrite exis
 | --- | --- |
 | `starter-pack` | Starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
 
+| Option | Default Value | Description |
+| --- | --- | --- |
+| `--url` | `https://github.com/birdrides/mockingbird/releases/download` | The base URL containing downloadable asset bundles. |
+
 ### Global Options
 
 | Flag | Description |
@@ -696,7 +680,7 @@ Mockingbird first checks the environment variable `PROJECT_FILE_PATH` set by the
 
 #### `--srcroot`
 
-Mockingbird checks the environment variables `SRCROOT` and `SOURCE_ROOT` set by the Xcode build context and then falls back to the directory containing the `.xcodeproj` project file. Note that source root is ignored when using JSON project descriptions. 
+Mockingbird checks the environment variables `SRCROOT` and `SOURCE_ROOT` set by the Xcode build context and then falls back to the directory containing the `.xcodeproj` project file. Note that source root is ignored when using JSON project descriptions.
 
 #### `--outputs`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ verify(bird.fly()).wasCalled()
 
 ## Installation
 
-Select your preferred dependency manager below for installation instructions and example projects. 
+Select your preferred dependency manager below for installation instructions and example projects.
 
 <details><summary><b>CocoaPods</b></summary>
 
@@ -337,7 +337,7 @@ bird.useDefaultValues(from: .standardProvider)
 print(bird.name)  // Prints ""
 ```
 
-You can create custom value providers by registering values for types. 
+You can create custom value providers by registering values for types.
 
 ```swift
 var valueProvider = ValueProvider()
@@ -479,7 +479,7 @@ inOrder(with: .noInvocationsAfter) {
 
 #### Asynchronous Verification
 
-Mocked methods that are invoked asynchronously can be verified using an `eventually` block which returns an `XCTestExpectation`. 
+Mocked methods that are invoked asynchronously can be verified using an `eventually` block which returns an `XCTestExpectation`.
 
 ```swift
 DispatchQueue.main.async {
@@ -607,9 +607,9 @@ Usage is determined by statically analyzing test target sources for calls to `mo
 
 Generate mocks for a set of targets in a project.
 
-`mockingbird generate` 
+`mockingbird generate`
 
-| Option | Default Value | Description | 
+| Option | Default Value | Description |
 | --- | --- | --- |
 | `--targets` | *(required)* | List of target names to generate mocks for. |
 | `--project` | [`(inferred)`](#--project) | Path to an `.xcodeproj` file or a [JSON project description](https://github.com/birdrides/mockingbird/wiki/Manual-Setup#generating-mocks-for-non-xcode-projects). |
@@ -681,10 +681,6 @@ Download and unpack a compatible asset bundle. Bundles will never overwrite exis
 | --- | --- |
 | `starter-pack` | Starter [supporting source files](https://github.com/birdrides/mockingbird/wiki/Supporting-Source-Files). |
 
-| Option | Default Value | Description |
-| --- | --- | --- |
-| `--url` | `https://github.com/birdrides/mockingbird/releases/download` | The base URL containing downloadable asset bundles. |
-
 ### Global Options
 
 | Flag | Description |
@@ -700,7 +696,7 @@ Mockingbird first checks the environment variable `PROJECT_FILE_PATH` set by the
 
 #### `--srcroot`
 
-Mockingbird checks the environment variables `SRCROOT` and `SOURCE_ROOT` set by the Xcode build context and then falls back to the directory containing the `.xcodeproj` project file. Note that source root is ignored when using JSON project descriptions. 
+Mockingbird checks the environment variables `SRCROOT` and `SOURCE_ROOT` set by the Xcode build context and then falls back to the directory containing the `.xcodeproj` project file. Note that source root is ignored when using JSON project descriptions.
 
 #### `--outputs`
 

--- a/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/InstallCommand.swift
@@ -31,6 +31,8 @@ class InstallCommand: BaseCommand, AliasableCommand {
   private enum Constants {
     static let name = "install"
     static let overview = "Configure a test target to use mocks."
+    
+    static let launcherEnvironmentKey = "MKB_LAUNCHER"
   }
   override var name: String { return Constants.name }
   override var overview: String { return Constants.overview }
@@ -105,6 +107,10 @@ class InstallCommand: BaseCommand, AliasableCommand {
     let supportPath = try arguments.getSupportPath(using: supportPathArgument,
                                                    sourceRoot: sourceRoot)
     
+    let launcherPath = environment[Constants.launcherEnvironmentKey]
+    let realBinaryPath = CommandLine.arguments[0]
+    let cliPath = Path(launcherPath ?? realBinaryPath)
+    
     let config = Installer.InstallConfiguration(
       projectPath: projectPath,
       sourceRoot: sourceRoot,
@@ -112,7 +118,7 @@ class InstallCommand: BaseCommand, AliasableCommand {
       destinationTargetName: destinationTarget,
       outputPaths: outputs,
       supportPath: supportPath,
-      cliPath: Path(CommandLine.arguments[0]),
+      cliPath: cliPath,
       header: arguments.get(headerArgument),
       compilationCondition: arguments.get(compilationConditionArgument),
       diagnostics: arguments.get(diagnosticsArgument),

--- a/mockingbird
+++ b/mockingbird
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eu
+cd "$(dirname "$0")"
+
+version=${MKB_VERSION:-"$(make get-version)"}
+
+# Hermetic builds extract dylib dependencies into the enclosing directory
+# making them safer in sandboxed environments like a CI.
+hermetic=${HERMETIC:-1}
+
+versionString="${version}"
+if [[ "${hermetic}" -ne 1 ]]; then
+  versionString="${versionString}-portable"
+fi
+echo "Using Mockingbird v${versionString}"
+
+binaryPath="bin/${versionString}/mockingbird"
+
+# Download a versioned binary if needed.
+if [[ ! -f "${binaryPath}" ]]; then
+  downloadUrl="$(make get-release-url)"
+  echo "Downloading CLI from ${downloadUrl}"
+  HERMETIC="${hermetic}" make download
+fi
+
+MKB_LAUNCHER="$0" "${binaryPath}" "$@"


### PR DESCRIPTION
Most devs currently don’t pin the CLI because it’s not part of the happy path in the setup instructions. Devs that do decide to pin the CLI usually do so by checking it into source control which is not sustainable long term.

This change makes pinning the binary part of the happy path of setting up the framework for all package managers by adding a “launcher” to abstract the CLI initialization process. The launcher allows the CLI to be downloaded on-demand from an artifact provider. By default, GitHub’s release artifacts is used, but it’s possible to set the download URL at various levels:

- `REPO_URL` for artifacts hosted on a forked GitHub repo
- `ARTIFACTS_URL` for versioned artifacts at `/<version>/Mockingbird.zip`
- `ZIP_RELEASE_URL` for artifacts at arbitrary URLs

A side effect of the launcher is that it’s now trivial to run against an arbitrary CLI version simply by setting the `MKB_VERSION` env var.