### PR TITLE
[3/n] Change default thunk pruning level to 'omit'

### DIFF
--- a/.github/workflows/build-framework-cli.yml
+++ b/.github/workflows/build-framework-cli.yml
@@ -32,6 +32,7 @@ jobs:
           --header '// Header line 1' '// Header line 2' \
           --diagnostics all \
           --loglevel verbose \
+          --prune stub \
           --verbose
     - name: Test
       run: make clean-test
@@ -48,6 +49,7 @@ jobs:
           --disable-cache \
           --diagnostics all \
           --loglevel verbose \
+          --prune stub \
           --verbose
     - name: Test Flakiness
       run: make test-flaky
@@ -63,6 +65,7 @@ jobs:
           --disable-cache \
           --diagnostics all \
           --loglevel verbose \
+          --prune stub \
           --verbose
     - name: Test All Thunks
       run: make clean-test
@@ -98,6 +101,7 @@ jobs:
           --header '// Header line 1' '// Header line 2' \
           --diagnostics all \
           --loglevel verbose \
+          --prune stub \
           --verbose
     - name: Test
       run: make clean-test
@@ -135,6 +139,7 @@ jobs:
           --header '// Header line 1' '// Header line 2' \
           --diagnostics all \
           --loglevel verbose \
+          --prune stub \
           --verbose
     - name: Test
       run: make clean-test

--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -1630,7 +1630,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\n${BUILT_PRODUCTS_DIR}/MockingbirdCli generate \\\n  --targets 'MockingbirdTestsHost' 'MockingbirdShadowedTestsHost' \\\n  --outputs \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift\" \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdShadowedTestsHostMocks.generated.swift\" \\\n  --support \"${SRCROOT}/Sources/MockingbirdSupport\" \\\n  --diagnostics all \\\n  --disable-cache \\\n  --verbose\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-16BC195B-65B7-4763-B2C9-AEA49F30A43A'\n";
+			shellScript = "set -e\n\n${BUILT_PRODUCTS_DIR}/MockingbirdCli generate \\\n  --targets 'MockingbirdTestsHost' 'MockingbirdShadowedTestsHost' \\\n  --outputs \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift\" \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdShadowedTestsHostMocks.generated.swift\" \\\n  --support \"${SRCROOT}/Sources/MockingbirdSupport\" \\\n  --diagnostics all \\\n  --disable-cache \\\n  --prune stub \\\n  --verbose\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-16BC195B-65B7-4763-B2C9-AEA49F30A43A'\n";
 		};
 		D372A59C2455878B0000E80A /* Generate Embedded Dylibs */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/README-0.17.md
+++ b/README-0.17.md
@@ -628,7 +628,7 @@ Configure a test target to use mocks.
 | `--condition` | `(none)` | [Compilation condition](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID538) to wrap all generated mocks in, e.g. `DEBUG`. |
 | `--diagnostics` | `(none)` | List of [diagnostic generator warnings](https://github.com/birdrides/mockingbird/wiki/Diagnostic-Warnings-and-Errors) to enable. |
 | `--loglevel` |  `(none)` | The log level to use when generating mocks, `quiet` or `verbose`. |
-| `--prune` | `stub` | The [pruning method](#thunk-pruning) to use on unreferenced types. |
+| `--prune` | `omit` | The [pruning method](#thunk-pruning) to use on unreferenced types. |
 
 | Flag | Description |
 | --- | --- |

--- a/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/GenerateCommand.swift
@@ -111,7 +111,7 @@ final class GenerateCommand: BaseCommand {
       supportPath: supportPath,
       header: arguments.get(headerArgument),
       compilationCondition: arguments.get(compilationConditionArgument),
-      pruningMethod: arguments.get(pruningMethod) ?? .stub,
+      pruningMethod: arguments.get(pruningMethod) ?? .omit,
       shouldImportModule: arguments.get(disableModuleImportArgument) != true,
       onlyMockProtocols: arguments.get(onlyMockProtocolsArgument) == true,
       disableSwiftlint: arguments.get(disableSwiftlintArgument) == true,


### PR DESCRIPTION
Although the parser+generator is relatively mature, the surface area of source changes with the potential to cause broken generated mocks is still quite large. To improve the developer experience and initial setup process, this change flips the default thunk pruning level from 'stub' which still generates *declarations* for unused types, to 'omit' which only creates mocks for referenced types in tests.

See also: https://github.com/birdrides/mockingbird/pull/174