### PR TITLE
[3/n] Remove protocol extension methods

### DIFF
--- a/Sources/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -282,8 +282,8 @@ class MockableType: Hashable, Comparable {
       for rawType in rawTypes {
         guard let substructure = rawType.dictionary[SwiftDocKey.substructure.rawValue]
           as? [StructureDictionary] else { continue }
-        // Cannot override declarations in extensions for classes.
-        guard baseRawType.kind != .class || rawType.kind != .extension else { continue }
+        // Cannot override declarations in extensions as they are statically defined.
+        guard rawType.kind != .extension else { continue }
         for structure in substructure {
           if let method = Method(from: structure,
                                  rootKind: baseRawType.kind,

--- a/Tests/MockingbirdTests/E2E/ExtensionsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExtensionsMockableTests.swift
@@ -8,19 +8,19 @@
 
 import Foundation
 import Mockingbird
-import MockingbirdTestsHost
+@testable import MockingbirdTestsHost
 
 // MARK: - Mockable declarations
 
 private protocol MockableExtendableProtocol: Mock {
   func trivialBaseMethod()
   var baseVariable: Bool { get }
-  
+
   func trivialExtendedMethod()
   func parameterizedExtendedMethod(param1: Bool)
   func parameterizedReturningExtendedMethod(param1: Bool) -> Bool
   var extendedVariable: Bool { get }
-  
+
   func anotherTrivialExtendedMethod()
   var anotherExtendedVariable: Bool { get }
 }
@@ -37,15 +37,3 @@ private protocol MockableNonExtendableClass: Mock {
   var baseVariable: Bool { get }
 }
 extension NonExtendableClassMock: MockableNonExtendableClass {}
-
-// MARK: - Non-mockable declarations
-
-private extension NonExtendableClassMock {
-  func trivialExtendedMethod() {}
-  func parameterizedExtendedMethod(param1: Bool) {}
-  func parameterizedReturningExtendedMethod(param1: Bool) -> Bool { return true }
-  var extendedVariable: Bool { return true }
-  
-  // MARK: Encodable
-  func encode(to encoder: Encoder) throws {}
-}

--- a/Tests/MockingbirdTests/E2E/ExtensionsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExtensionsStubbableTests.swift
@@ -15,16 +15,6 @@ import Mockingbird
 private protocol StubbableExtendableProtocol {
   func trivialBaseMethod() -> Mockable<FunctionDeclaration, () -> Void, Void>
   func getBaseVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool>
-  
-  func trivialExtendedMethod() -> Mockable<FunctionDeclaration, () -> Void, Void>
-  func parameterizedExtendedMethod(param1: @escaping @autoclosure () -> Bool)
-    -> Mockable<FunctionDeclaration, (Bool) -> Void, Void>
-  func parameterizedReturningExtendedMethod(param1: @escaping @autoclosure () -> Bool)
-    -> Mockable<FunctionDeclaration, (Bool) -> Bool, Bool>
-  func getExtendedVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool>
-  
-  func anotherTrivialExtendedMethod() -> Mockable<FunctionDeclaration, () -> Void, Void>
-  func getAnotherExtendedVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool>
 }
 extension ExtendableProtocolMock: StubbableExtendableProtocol {}
 
@@ -43,15 +33,33 @@ extension NonExtendableClassMock: StubbableNonExtendableClass {}
 // MARK: - Non-stubbable declarations
 
 extension ExtendableProtocolMock {
-  func setBaseVariable(_ newValue: @escaping @autoclosure () -> Bool)
-    -> Mockable<PropertySetterDeclaration, (Bool) -> Void, Void> { fatalError() }
+  func trivialExtendedMethod() -> Mockable<FunctionDeclaration, () -> Void, Void> { fatalError() }
+  func parameterizedExtendedMethod(param1: @escaping @autoclosure () -> Bool)
+  -> Mockable<FunctionDeclaration, (Bool) -> Void, Void> { fatalError() }
+  func parameterizedReturningExtendedMethod(param1: @escaping @autoclosure () -> Bool)
+  -> Mockable<FunctionDeclaration, (Bool) -> Bool, Bool> { fatalError() }
+  
+  func getExtendedVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool> { fatalError() }
   func setExtendedVariable(_ newValue: @escaping @autoclosure () -> Bool)
     -> Mockable<PropertySetterDeclaration, (Bool) -> Void, Void> { fatalError() }
+  
+  func anotherTrivialExtendedMethod() -> Mockable<FunctionDeclaration, () -> Void, Void> { fatalError() }
+
+  func getAnotherExtendedVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool> { fatalError() }
   func setAnotherExtendedVariable(_ newValue: @escaping @autoclosure () -> Bool)
     -> Mockable<PropertySetterDeclaration, (Bool) -> Void, Void> { fatalError() }
 }
 
 extension NonExtendableClassMock {
-  func setBaseVariable(_ newValue: @escaping @autoclosure () -> Bool)
+  func trivialExtendedMethod() -> Mockable<FunctionDeclaration, () -> Void, Void> { fatalError() }
+  func parameterizedExtendedMethod(param1: @escaping @autoclosure () -> Bool)
+  -> Mockable<FunctionDeclaration, (Bool) -> Void, Void> { fatalError() }
+  func parameterizedReturningExtendedMethod(param1: @escaping @autoclosure () -> Bool)
+  -> Mockable<FunctionDeclaration, (Bool) -> Bool, Bool> { fatalError() }
+
+  func getExtendedVariable() -> Mockable<PropertyGetterDeclaration, () -> Bool, Bool> { fatalError() }
+  func setExtendedVariable(_ newValue: @escaping @autoclosure () -> Bool)
     -> Mockable<PropertySetterDeclaration, (Bool) -> Void, Void> { fatalError() }
+
+  func encode(to encoder: @escaping @autoclosure () -> Encoder) -> Mockable<FunctionDeclaration, (Encoder) throws -> Void, Void> { fatalError() }
 }


### PR DESCRIPTION
Although methods defined in protocol extensions can be re-defined in a conforming type, static dispatch means that the original method will always be called. Currently the generator creates mocking code for protocol extensions which was leading to unexpected results in tests for stubbing and verification.