### PR TITLE
Remove cache buster file before generating mocks

### DIFF
--- a/Sources/MockingbirdCli/Interface/Installer.swift
+++ b/Sources/MockingbirdCli/Interface/Installer.swift
@@ -351,14 +351,13 @@ class Installer {
                                                    style: .bash,
                                                    shouldNormalize: false)
       let shellScript = """
-      set -e
-      
-      \(cliPath) generate \\
-        \(options.joined(separator: " \\\n  "))
+      set -eu
       
       # Ensure mocks are generated prior to running Compile Sources
       rm -f '\(cacheBreakerPath.absolute())'
       
+      \(cliPath) generate \\
+        \(options.joined(separator: " \\\n  "))
       """
       return PBXShellScriptBuildPhase(name: Constants.buildPhaseName,
                                       inputPaths: ["\(cacheBreakerPath.absolute())"],


### PR DESCRIPTION
If the generator crashes or is interrupted, the cache buster file is never removed which means Xcode will cache the failed result until the project is cleaned.