### PR TITLE
Add closure attribute support to closure parameters

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		28DAD96E251BDD66001A0B3F /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DAD96D251BDD66001A0B3F /* Project.swift */; };
 		28DDDFC126B8571D002556C7 /* DynamicCast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DDDFC026B8571D002556C7 /* DynamicCast.swift */; };
 		8356225C26A94CBE005CD5C5 /* TargetDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8356225B26A94CBE005CD5C5 /* TargetDescriptionTests.swift */; };
+		BEF1BBBD2700073C009E25E6 /* ClosureAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1BBBC2700073C009E25E6 /* ClosureAttributesTests.swift */; };
+		BEF1BBBF270007C6009E25E6 /* ClosureAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF1BBBE270007C6009E25E6 /* ClosureAttributes.swift */; };
 		D314ED7F24CE1C10000CC23D /* GenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314ED7E24CE1C10000CC23D /* GenericsTests.swift */; };
 		D3643B6C247B78A5002DF069 /* Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B6B247B78A4002DF069 /* Function.swift */; };
 		D3643B72247C5107002DF069 /* String+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3643B71247C5107002DF069 /* String+Components.swift */; };
@@ -590,6 +592,8 @@
 		28DDDFC026B8571D002556C7 /* DynamicCast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicCast.swift; sourceTree = "<group>"; };
 		8356225B26A94CBE005CD5C5 /* TargetDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetDescriptionTests.swift; sourceTree = "<group>"; };
 		942B00CDCB48ADC877A01AEE /* MockingbirdTestsHostMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = MockingbirdTestsHostMocks.generated.swift; path = Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift; sourceTree = "<group>"; };
+		BEF1BBBC2700073C009E25E6 /* ClosureAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureAttributesTests.swift; sourceTree = "<group>"; };
+		BEF1BBBE270007C6009E25E6 /* ClosureAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureAttributes.swift; sourceTree = "<group>"; };
 		D314ED7E24CE1C10000CC23D /* GenericsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericsTests.swift; sourceTree = "<group>"; };
 		D3643B6B247B78A4002DF069 /* Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function.swift; sourceTree = "<group>"; };
 		D3643B71247C5107002DF069 /* String+Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Components.swift"; sourceTree = "<group>"; };
@@ -1217,6 +1221,7 @@
 				OBJ_146 /* ClassInitializers.swift */,
 				OBJ_147 /* ClassOnlyProtocols.swift */,
 				OBJ_148 /* ClassScopedTypes.swift */,
+				BEF1BBBE270007C6009E25E6 /* ClosureAttributes.swift */,
 				OBJ_149 /* ClosureParameters.swift */,
 				OBJ_150 /* Collections.swift */,
 				OBJ_151 /* CompilationDirectives.swift */,
@@ -1421,6 +1426,7 @@
 				OBJ_252 /* ArgumentCaptorTests.swift */,
 				OBJ_253 /* ArgumentMatchingTests.swift */,
 				OBJ_254 /* AsyncVerificationTests.swift */,
+				BEF1BBBC2700073C009E25E6 /* ClosureAttributesTests.swift */,
 				OBJ_255 /* ClosureParameterTests.swift */,
 				D3E6F67324838182000D1971 /* ChainedStubbingTests.swift */,
 				OBJ_256 /* CollectionArgumentMatchingTests.swift */,
@@ -2102,6 +2108,7 @@
 				OBJ_1032 /* ExtensionsMockableTests.swift in Sources */,
 				OBJ_1033 /* ExtensionsStubbableTests.swift in Sources */,
 				OBJ_1034 /* ExternalModuleClassScopedTypesMockableTests.swift in Sources */,
+				BEF1BBBD2700073C009E25E6 /* ClosureAttributesTests.swift in Sources */,
 				OBJ_1035 /* ExternalModuleClassScopedTypesStubbableTests.swift in Sources */,
 				287C4F5426A36FFF00A7E0D9 /* DynamicSwiftTests.swift in Sources */,
 				OBJ_1036 /* ExternalModuleTypesMockableTests.swift in Sources */,
@@ -2187,6 +2194,7 @@
 				OBJ_1141 /* FakeableTypes.swift in Sources */,
 				OBJ_1142 /* Generics.swift in Sources */,
 				OBJ_1143 /* Grandparent.swift in Sources */,
+				BEF1BBBF270007C6009E25E6 /* ClosureAttributes.swift in Sources */,
 				OBJ_1144 /* GrandparentProtocol.swift in Sources */,
 				OBJ_1145 /* InheritedTypeQualification.swift in Sources */,
 				OBJ_1146 /* Initializers.swift in Sources */,

--- a/Sources/MockingbirdTestsHost/ClosureAttributes.swift
+++ b/Sources/MockingbirdTestsHost/ClosureAttributes.swift
@@ -1,0 +1,55 @@
+//
+//  ClosureAttributes.swift
+//  MockingbirdTestsHost
+//
+//  Created by Peter Tolsma on 9/25/21.
+//
+
+import Foundation
+
+class ClosureAttributesGenericBase<M> {
+  func doGenericEscaping(output: @escaping () -> M?) -> M? {
+    output()
+  }
+
+  func doConcreteEscaping(output: @escaping () -> Int) -> Int {
+    output()
+  }
+
+  func doGenericInout(output: inout () -> M) -> M {
+    output()
+  }
+
+  func doConcreteInout(output: inout () -> Int) -> Int {
+    output()
+  }
+
+  func doGenericAutoclosure(output: @autoclosure () -> M) -> M {
+    output()
+  }
+
+  func doConcreteAutoclosure(output: @autoclosure () -> Int) -> Int {
+    output()
+  }
+
+  func doGenericEscapingAutoclosure(output: @escaping @autoclosure () -> M) -> M {
+    output()
+  }
+
+  func doConcreteEscapingAutoclosure(output: @escaping @autoclosure () -> Int) -> Int {
+    output()
+  }
+}
+
+class ClosureAttributesConcreteChild: ClosureAttributesGenericBase<String> {
+  func doAnotherThing() -> String {
+    return doGenericEscaping { "42" } ?? "21"
+  }
+}
+
+protocol ClosureAttributesProtocol {
+  func doEscaping(output: @escaping () -> Double) -> Double
+  func doInout(output: inout () -> [Character]) -> [Character]
+  func doAutoclosure(output: @autoclosure () -> String) -> String
+  func doEscapingAutoclosure(output: @escaping @autoclosure () -> Range<Int>) -> Range<Int>
+}

--- a/Tests/MockingbirdTests/Framework/ClosureAttributesTests.swift
+++ b/Tests/MockingbirdTests/Framework/ClosureAttributesTests.swift
@@ -1,0 +1,94 @@
+//
+//  ClosureAttributeTests.swift
+//  MockingbirdTests
+//
+//  Created by Peter Tolsma on 9/25/21.
+//
+
+import XCTest
+import Mockingbird
+@testable import MockingbirdTestsHost
+
+class ClosureAttributesTests: XCTestCase {
+  var concreteClassMock: ClosureAttributesConcreteChildMock!
+  var protocolMock: ClosureAttributesProtocolMock!
+
+  override func setUp() {
+    concreteClassMock = mock(ClosureAttributesConcreteChild.self)
+    protocolMock = mock(ClosureAttributesProtocol.self)
+  }
+
+  // MARK: - Class Tests
+
+  func test_classMock_genericEscaping_wildcardMatching() {
+    given(concreteClassMock.doGenericEscaping(output: any())) ~> nil
+    let closure: () -> String? = { "suh" }
+    XCTAssertEqual(concreteClassMock.doGenericEscaping(output: closure), nil)
+  }
+
+  func test_classMock_concreteEscaping_wildcardMatching() {
+    given(concreteClassMock.doConcreteEscaping(output: any())) ~> 84
+    let closure: () -> Int = { 32 }
+    XCTAssertEqual(concreteClassMock.doConcreteEscaping(output: closure), 84)
+  }
+
+  func test_classMock_genericInout_wildcardMatching() {
+    given(concreteClassMock.doGenericInout(output: any())) ~> "gabbagool"
+    var closure: () -> String = { "ABBA" }
+    XCTAssertEqual(concreteClassMock.doGenericInout(output: &closure), "gabbagool")
+  }
+
+  func test_classMock_concreteInout_wildcardMatching() {
+    given(concreteClassMock.doConcreteInout(output: any())) ~> 99
+    var closure: () -> Int = { 33 }
+    XCTAssertEqual(concreteClassMock.doConcreteInout(output: &closure), 99)
+  }
+
+  func test_classMock_genericAutoclosure_wildcardMatching() {
+    given(concreteClassMock.doGenericAutoclosure(output: any())) ~> "autobot"
+    XCTAssertEqual(concreteClassMock.doGenericAutoclosure(output: "decepticon"), "autobot")
+  }
+
+  func test_classMock_concreteAutoclosure_wildcardMatching() {
+    given(concreteClassMock.doConcreteAutoclosure(output: any())) ~> 32
+    XCTAssertEqual(concreteClassMock.doConcreteAutoclosure(output: 77), 32)
+  }
+
+  func test_classMock_genericEscapingAutoclosure_wildcardMatching() {
+    given(concreteClassMock.doGenericEscapingAutoclosure(output: any())) ~> "birb"
+    let someString = "on a scooter"
+    XCTAssertEqual(concreteClassMock.doGenericEscapingAutoclosure(output: someString), "birb")
+  }
+
+  func test_classMock_concreteEscapingAutoclosure_wildcardMatching() {
+    given(concreteClassMock.doConcreteEscapingAutoclosure(output: any())) ~> 33334
+    let someInt = -8
+    XCTAssertEqual(concreteClassMock.doConcreteEscapingAutoclosure(output: someInt), 33334)
+  }
+
+  // MARK: - Protocol Tests
+
+  func test_protocolMock_escaping_wildcardMatching() {
+    given(protocolMock.doEscaping(output: any())) ~> 14.3
+    let closure: () -> Double = { 33.0 }
+    XCTAssertEqual(protocolMock.doEscaping(output: closure), 14.3)
+  }
+
+  func test_protocolMock_inout_wildcardMatching() {
+    given(protocolMock.doInout(output: any())) ~> Array("mansionz")
+    var closure: () -> [Character] = { Array("The Life Of A Troubadour") }
+    XCTAssertEqual(protocolMock.doInout(output: &closure), Array("mansionz"))
+  }
+
+  func test_protocolMock_autoclosure_wildcardMatching() {
+    given(protocolMock.doAutoclosure(output: any())) ~> "auaaa"
+    let someString = "asdfs"
+    XCTAssertEqual(protocolMock.doAutoclosure(output: someString), "auaaa")
+  }
+
+  func test_protocolMock_escapingAutoclosure_wildcardMatching() {
+    given(protocolMock.doEscapingAutoclosure(output: any())) ~> (-30..<30)
+    let someRange = 0..<3
+    XCTAssertEqual(protocolMock.doEscapingAutoclosure(output: someRange), -30..<30)
+  }
+}


### PR DESCRIPTION
Hi all.

We ran into the issue described in #197 where we couldn't generate mocks with escaping generic closures.

I drilled down a bit and it seems like attributes for closure parameters in general aren't yet supported(?). This PR adds support for the `@escaping` and `@autoclosure` attributes as well as the `inout` type annotation.

I saw some comments in the source(wrt `Parameter`) about eventually moving some of this to SwiftSyntax. I admit I'm not familiar with SwiftSyntax, so here's my stab at adding closure attribute support without it.

Added some tests as well. Very much not familiar with the codebase, but hopefully this is on the right track 🙂 

PS: I didn't add support for `convention(_)`. Do we want this?