### PR TITLE
[9/y] Fix nested optional codegen

### DIFF
--- a/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
@@ -83,7 +83,7 @@ class ThunkTemplate: Template {
                   unlabeledArguments: [
                     FunctionCallTemplate(
                       name: "mkbImpl",
-                      unlabeledArguments: unlabledArguments,
+                      unlabeledArguments: unlabledArguments.map({ $0 + " as Any?" }),
                       isThrowing: isThrowing).render()
                   ])) as \(returnType)
         """).render()

--- a/Sources/MockingbirdTestsHost/Optionals.swift
+++ b/Sources/MockingbirdTestsHost/Optionals.swift
@@ -30,8 +30,9 @@ protocol OptionalsProtocol {
   func methodWithMultiUnwrappedOptionalCompoundParameter(param: (Bool?, Int)???!)
   func methodWithMultiUnwrappedOptionalCompoundReturn() -> (Bool?, Int)???!
   
-  var optionalVariable: Bool? { get }
-  var optionalBridgedVariable: NSString? { get }
-  var unwrappedOptionalVariable: Bool! { get }
-  var multiUnwrappedOptionalVariable: Bool???! { get }
+  var optionalVariable: Bool? { get set }
+  var optionalBridgedVariable: NSString? { get set }
+  var unwrappedOptionalVariable: Bool! { get set }
+  var nestedOptionalVariable: Bool?? { get set }
+  var nestedUnwrappedOptionalVariable: Bool???! { get set }
 }


### PR DESCRIPTION
**Stack:**
📚 #248 ***← [9/y] Fix nested optional codegen***
📚 #247 [8/y] Fix wildcard arg matching for Obj-C param types
📚 #246 [7/y] Fix stubbing nil values in Obj-C mocks
📚 #254 [6/y] Update example projects
📚 #253 [5/y] Improve support for configuring SPM Xcode projects
📚 #252 [4/y] Show help message no mockable types are generated
📚 #251 [3/y] Fix unavailable generic protocol mock initializer
📚 #250 [2/y] Fix generator caching for multi-project setups
📚 #249 [1/y] Optimize dependency graph traversal
📚 #245 Replace SwiftPM with Swift Argument Parser

This fixes the implicit type coercion when bridging nested optional property setters to `Any?` for dynamic mocking.

### Before

```swift
// warning: Expression implicitly coerced from 'String??' to 'Any?'
if let mkbImpl = mkbImpl as? (Any?) -> Any? { return Mockingbird.dynamicCast(mkbImpl(newValue)) as Void }
```

### After

```swift
if let mkbImpl = mkbImpl as? (Any?) -> Any? { return Mockingbird.dynamicCast(mkbImpl(newValue as Any?)) as Void }
```