### PR TITLE
[3/y] Fix unavailable generic protocol mock initializer

### DIFF
--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionDefinitionTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionDefinitionTemplate.swift
@@ -8,15 +8,18 @@
 import Foundation
 
 struct FunctionDefinitionTemplate: Template {
+  let leadingTrivia: String
   let attributes: [String]
   let declaration: String
   let genericConstraints: [String]
   let body: String
   
-  init(attributes: [String] = [],
+  init(leadingTrivia: String = "",
+       attributes: [String] = [],
        declaration: String,
        genericConstraints: [String] = [],
        body: String) {
+    self.leadingTrivia = leadingTrivia
     self.attributes = attributes
     self.declaration = declaration
     self.genericConstraints = genericConstraints
@@ -27,6 +30,7 @@ struct FunctionDefinitionTemplate: Template {
     let genericConstraintsString = genericConstraints.isEmpty ? "" :
       " where \(separated: genericConstraints)"
     return String(lines: [
+      leadingTrivia,
       attributes.filter({ !$0.isEmpty }).joined(separator: " "),
       declaration + genericConstraintsString + " " + BlockTemplate(body: body).render()
     ])

--- a/Sources/MockingbirdTestsHost/ExternalModuleTypes.swift
+++ b/Sources/MockingbirdTestsHost/ExternalModuleTypes.swift
@@ -8,6 +8,7 @@
 import Foundation
 import MockingbirdModuleTestsHost
 import MockingbirdShadowedTestsHost
+import CoreBluetooth
 
 protocol LocalPublicExternalProtocol: PublicExternalProtocol {}
 
@@ -15,6 +16,14 @@ protocol LocalPublicExternalProtocol: PublicExternalProtocol {}
 class SubclassingExternalClass: ExternalClass {
   var internalVariable = true
   func internalMethod() {}
+}
+
+/// Cannot be mocked because of external inheritence without corresponding supporting source files.
+class SubclassingMissingExternalClass: CBCentralManager {}
+class SubclassingMissingExternalClassGeneric<T>: CBCentralManager {}
+protocol InheritingMissingExternalClass: CBCentralManager {}
+protocol InheritingMissingExternalClassGeneric: CBCentralManager {
+  associatedtype T
 }
 
 // MARK: - Inherited external initializer


### PR DESCRIPTION
**Stack:**
📚 #254 [6/y] Update example projects
📚 #253 [5/y] Improve support for configuring SPM Xcode projects
📚 #252 [4/y] Show help message no mockable types are generated
📚 #251 ***← [3/y] Fix unavailable generic protocol mock initializer***
📚 #250 [2/y] Fix generator caching for multi-project setups
📚 #249 [1/y] Optimize dependency graph traversal
📚 #245 Replace SwiftPM with Swift Argument Parser

Mock initializer functions were not migrated to use the new templates in 0.18. This caused unavailable generic protocols (e.g. inheriting from an opaque external type) to generate malformed output.

### Before

```swift
// error: Consecutive statements on a line must be separated by ';'
public enum InheritingMissingExternalClassGeneric<T> {
}@available(*, unavailable, message: "'InheritingMissingExternalClassGeneric' inherits from the externally-defined type 'CBCentralManager' which needs to be declared in a supporting source file")
```

### After

```swift
public enum InheritingMissingExternalClassGeneric<T> {
}
@available(*, unavailable, message: "'InheritingMissingExternalClassGeneric' inherits from the externally-defined type 'CBCentralManager' which needs to be declared in a supporting source file")
```