### PR TITLE
[4/y] Show help message no mockable types are generated

### DIFF
--- a/Sources/MockingbirdCli/Interface/Handlers/Generator+Pipeline.swift
+++ b/Sources/MockingbirdCli/Interface/Handlers/Generator+Pipeline.swift
@@ -89,6 +89,7 @@ extension Generator {
         findMockedTypesResult: findMockedTypesOperation?.result,
         config: GenerateFileConfig(
           moduleName: moduleName,
+          testTargetName: config.environmentTargetName,
           outputPath: outputPath,
           header: config.header,
           compilationCondition: config.compilationCondition,

--- a/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
@@ -12,6 +12,7 @@ import os.log
 
 public struct GenerateFileConfig {
   let moduleName: String
+  let testTargetName: String?
   let outputPath: Path
   let header: [String]
   let compilationCondition: String?
@@ -20,6 +21,7 @@ public struct GenerateFileConfig {
   let pruningMethod: PruningMethod
   
   public init(moduleName: String,
+              testTargetName: String?,
               outputPath: Path,
               header: [String],
               compilationCondition: String?,
@@ -27,6 +29,7 @@ public struct GenerateFileConfig {
               disableSwiftlint: Bool,
               pruningMethod: PruningMethod) {
     self.moduleName = moduleName
+    self.testTargetName = testTargetName
     self.outputPath = outputPath
     self.header = header
     self.compilationCondition = compilationCondition


### PR DESCRIPTION
**Stack:**
📚 #254 [6/y] Update example projects
📚 #253 [5/y] Improve support for configuring SPM Xcode projects
📚 #252 ***← [4/y] Show help message no mockable types are generated***
📚 #251 [3/y] Fix unavailable generic protocol mock initializer
📚 #250 [2/y] Fix generator caching for multi-project setups
📚 #249 [1/y] Optimize dependency graph traversal
📚 #245 Replace SwiftPM with Swift Argument Parser

Thunk pruning can be confusing now that `omit` is the default method. To improve the developer onboarding experience, we can generate an inline comment when there are no mocked types available.
