### PR TITLE
[5/y] Improve support for configuring SPM Xcode projects

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2803D96927781A4D00651C60 /* String+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D96827781A4D00651C60 /* String+Regex.swift */; };
 		281B6246251DC7220084EBED /* MockingbirdShadowedTestsHost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 281B6226251DC5AD0084EBED /* MockingbirdShadowedTestsHost.framework */; };
 		281B6286251DC7FC0084EBED /* ModuleNameShadowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281B61F1251DBBDE0084EBED /* ModuleNameShadowing.swift */; };
 		281B62FF251DCCFC0084EBED /* MockingbirdShadowedTestsHostMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281B62FE251DCCFC0084EBED /* MockingbirdShadowedTestsHostMocks.generated.swift */; };
@@ -494,6 +495,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2803D96827781A4D00651C60 /* String+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
 		281B61F1251DBBDE0084EBED /* ModuleNameShadowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleNameShadowing.swift; sourceTree = "<group>"; };
 		281B6226251DC5AD0084EBED /* MockingbirdShadowedTestsHost.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MockingbirdShadowedTestsHost.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		281B62CF251DCAB90084EBED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1166,6 +1168,7 @@
 				D36A3DCA24922D6B007964DC /* Encodable+SHA1.swift */,
 				2838FD2027756314007A1CB4 /* Path+Abbreviate.swift */,
 				28C28E7826C0EE4D00729617 /* Path+Symlink.swift */,
+				2803D96827781A4D00651C60 /* String+Regex.swift */,
 				28C28E7A26C0FB2700729617 /* TimeUnit.swift */,
 			);
 			path = Utils;
@@ -2109,7 +2112,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\n${BUILT_PRODUCTS_DIR}/MockingbirdCli generate \\\n  --targets 'MockingbirdTestsHost' 'MockingbirdShadowedTestsHost' \\\n  --outputs \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift\" \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdShadowedTestsHostMocks.generated.swift\" \\\n  --support \"${SRCROOT}/Sources/MockingbirdSupport\" \\\n  --diagnostics all \\\n  --disable-cache \\\n  --prune stub \\\n  --verbose\n";
+			shellScript = "set -eu\n\n# Prevent Xcode 13 from running this script while indexing.\n[[ \"${ACTION}\" == \"indexbuild\" ]] && exit 0\n\n\"${BUILT_PRODUCTS_DIR}/MockingbirdCli\" generate \\\n  --targets 'MockingbirdTestsHost' 'MockingbirdShadowedTestsHost' \\\n  --outputs \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdTestsHostMocks.generated.swift\" \"${SRCROOT}/Tests/MockingbirdTests/Mocks/MockingbirdShadowedTestsHostMocks.generated.swift\" \\\n  --support \"${SRCROOT}/Sources/MockingbirdSupport\" \\\n  --diagnostics all \\\n  --disable-cache \\\n  --prune stub \\\n  --verbose\n";
 		};
 		D372A59C2455878B0000E80A /* Generate Embedded Dylibs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2316,6 +2319,7 @@
 				D3DC37952492140D001E02A5 /* Generator+PruningPipeline.swift in Sources */,
 				2852643F2775882B000298B3 /* SwiftFilePath.swift in Sources */,
 				28C28E7B26C0FB2700729617 /* TimeUnit.swift in Sources */,
+				2803D96927781A4D00651C60 /* String+Regex.swift in Sources */,
 				28C2EE4A2771AA41003CD0D5 /* ExtendedGeneratorTypes.swift in Sources */,
 				OBJ_814 /* Generator.swift in Sources */,
 				OBJ_815 /* Installer.swift in Sources */,

--- a/Sources/MockingbirdCli/Interface/Commands/Generate.swift
+++ b/Sources/MockingbirdCli/Interface/Commands/Generate.swift
@@ -38,8 +38,11 @@ extension Mockingbird {
                    .customLong("output"),
                    .customShort("o")],
             parsing: .upToNextOption,
-            help: "List of mock output file paths for each target.")
+            help: "List of output file paths corresponding to each target.")
     var outputs: [SwiftFilePath] = [] // TODO: This will be optional in generator v2
+    
+    @Option(help: "The directory where generated files should be output.")
+    var outputDir: DirectoryPath?
     
     @Option(help: "The directory containing supporting source files.")
     var support: DirectoryPath?
@@ -80,6 +83,7 @@ extension Mockingbird {
       let project: Path
       let srcroot: Path
       let outputs: [Path]
+      let outputDir: Path?
       let support: Path
       let testbundle: String?
       let header: [String]
@@ -134,6 +138,7 @@ extension Mockingbird {
         project: validProject.path,
         srcroot: validSrcroot.path,
         outputs: outputs.map({ $0.path }),
+        outputDir: outputDir?.path, // Managed by the generator.
         support: validSupportPath,
         testbundle: validTestBundle?.name,
         header: header,
@@ -162,6 +167,7 @@ extension Mockingbird {
         environmentSourceRoot: arguments.environmentSourceRoot,
         environmentTargetName: arguments.environmentTargetName,
         outputPaths: arguments.outputs,
+        outputDir: arguments.outputDir,
         supportPath: arguments.support,
         header: arguments.header,
         compilationCondition: arguments.condition,
@@ -185,6 +191,7 @@ extension Mockingbird.Generate: EncodableArguments {
     case project
     case srcroot
     case outputs
+    case outputDir
     case support
     case testbundle
     case header
@@ -211,6 +218,7 @@ extension Mockingbird.Generate: EncodableArguments {
     try container.encode(project, forKey: .project)
     try container.encode(srcroot, forKey: .srcroot)
     try container.encode(outputs, forKey: .outputs)
+    try container.encode(outputDir, forKey: .outputDir)
     try container.encode(support, forKey: .support)
     try container.encode(testbundle, forKey: .testbundle)
     try container.encode(header, forKey: .header)

--- a/Sources/MockingbirdCli/Utils/String+Regex.swift
+++ b/Sources/MockingbirdCli/Utils/String+Regex.swift
@@ -1,0 +1,24 @@
+//
+//  String+Regex.swift
+//  MockingbirdCli
+//
+//  Created by typealias on 12/25/21.
+//
+
+import Foundation
+
+extension String {
+  /// Returns all matches and capture groups given a regex pattern. First element is the full match.
+  func components(matching pattern: String) -> [[Substring]] {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+    return regex
+      .matches(in: self, range: NSMakeRange(0, count))
+      .map({ result -> [Substring] in
+        return (0..<result.numberOfRanges)
+          .map({ index -> NSRange in result.range(at: index) })
+          .filter({ range -> Bool in range.location != NSNotFound })
+          .compactMap({ range -> Range<Index>? in Range(range, in: self) })
+          .map({ range -> Substring in self[range] })
+      })
+  }
+}


### PR DESCRIPTION
**Stack:**
📚 #254 [6/y] Update example projects
📚 #253 ***← [5/y] Improve support for configuring SPM Xcode projects***
📚 #252 [4/y] Show help message no mockable types are generated
📚 #251 [3/y] Fix unavailable generic protocol mock initializer
📚 #250 [2/y] Fix generator caching for multi-project setups
📚 #249 [1/y] Optimize dependency graph traversal
📚 #245 Replace SwiftPM with Swift Argument Parser

Current support for Swift Package Manager is a bit rough for both Xcode project and package manifest setups, and we lack clear guidance for the latter in the README (see #236).

One major issue is that using the configurator against an SwiftPM Xcode project links the CLI in derived data with a home-relative path, which isn’t guaranteed to be portable between development environments. Another is that SwiftPM packages which typically rely on path-based source lists must either output each mock file into the `Test/TargetName` directory or use the default `MockingbirdMocks` output path and modify the target definition in the manifest.

Since Swift Package Manager is gaining popularity in the iOS ecosystem, it makes sense to streamline our integration and bring it up to parity with CocoaPods and Carthage.

**Changes:**
- Make configured build phase portable between machines by rewriting paths in derived data
- Remove dependency on `pcregrep` in SwiftPM quick start guide
- Add ability to specify output directory in generate command