### PR TITLE
[3/x] Codemod Xcode-generated file header comments

### DIFF
--- a/Sources/MockingbirdAutomationCli/main.swift
+++ b/Sources/MockingbirdAutomationCli/main.swift
@@ -1,10 +1,3 @@
-//
-//  main.swift
-//  MockingbirdAutomation
-//
-//  Created by typealias on 12/30/21.
-//
-
 import Foundation
 import ArgumentParser
 

--- a/Sources/MockingbirdCli/Arguments/BinaryPath.swift
+++ b/Sources/MockingbirdCli/Arguments/BinaryPath.swift
@@ -1,10 +1,3 @@
-//
-//  BinaryPath.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/8/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Arguments/DirectoryPath.swift
+++ b/Sources/MockingbirdCli/Arguments/DirectoryPath.swift
@@ -1,10 +1,3 @@
-//
-//  DirectoryPath.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import ArgumentParser
 import Foundation
 import PathKit

--- a/Sources/MockingbirdCli/Arguments/ExtendedGeneratorTypes.swift
+++ b/Sources/MockingbirdCli/Arguments/ExtendedGeneratorTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ExtendedGeneratorTypes.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/20/21.
-//
-
 import ArgumentParser
 import MockingbirdGenerator
 

--- a/Sources/MockingbirdCli/Arguments/InferableArgument.swift
+++ b/Sources/MockingbirdCli/Arguments/InferableArgument.swift
@@ -1,10 +1,3 @@
-//
-//  InferableArgument.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdCli/Arguments/SupportingSourcesPath.swift
+++ b/Sources/MockingbirdCli/Arguments/SupportingSourcesPath.swift
@@ -1,10 +1,3 @@
-//
-//  SupportingSourcesPath.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Arguments/SwiftFilePath.swift
+++ b/Sources/MockingbirdCli/Arguments/SwiftFilePath.swift
@@ -1,10 +1,3 @@
-//
-//  SwiftFilePath.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/23/21.
-//
-
 import ArgumentParser
 import Foundation
 import PathKit

--- a/Sources/MockingbirdCli/Arguments/TestBundleName.swift
+++ b/Sources/MockingbirdCli/Arguments/TestBundleName.swift
@@ -1,10 +1,3 @@
-//
-//  TestBundleName.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/13/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Arguments/URLArgument.swift
+++ b/Sources/MockingbirdCli/Arguments/URLArgument.swift
@@ -1,10 +1,3 @@
-//
-//  URLArgument.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/21/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Arguments/ValidatableArgument.swift
+++ b/Sources/MockingbirdCli/Arguments/ValidatableArgument.swift
@@ -1,10 +1,3 @@
-//
-//  ValidatableArgument.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import ArgumentParser
 import Foundation
 

--- a/Sources/MockingbirdCli/Arguments/XcodeProjPath.swift
+++ b/Sources/MockingbirdCli/Arguments/XcodeProjPath.swift
@@ -1,10 +1,3 @@
-//
-//  Path+ExpressibleByArgument.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import ArgumentParser
 import Foundation
 import PathKit

--- a/Sources/MockingbirdCli/Commands/Configure.swift
+++ b/Sources/MockingbirdCli/Commands/Configure.swift
@@ -1,10 +1,3 @@
-//
-//  Configure.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/7/21.
-//
-
 import ArgumentParser
 import Foundation
 import PathKit

--- a/Sources/MockingbirdCli/Commands/Encoding/ArgumentsEncoder.swift
+++ b/Sources/MockingbirdCli/Commands/Encoding/ArgumentsEncoder.swift
@@ -1,10 +1,3 @@
-//
-//  ArgumentsEncoder.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/20/21.
-//
-
 import Foundation
 import MockingbirdGenerator
 import PathKit

--- a/Sources/MockingbirdCli/Commands/Encoding/FlagArgumentEncoding.swift
+++ b/Sources/MockingbirdCli/Commands/Encoding/FlagArgumentEncoding.swift
@@ -1,10 +1,3 @@
-//
-//  FlagArgumentEncoding.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/20/21.
-//
-
 import Foundation
 
 struct FlagArgumentEncoding: Encoder {

--- a/Sources/MockingbirdCli/Commands/Encoding/OptionArgumentEncoding.swift
+++ b/Sources/MockingbirdCli/Commands/Encoding/OptionArgumentEncoding.swift
@@ -1,10 +1,3 @@
-//
-//  OptionArgumentEncoding.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/20/21.
-//
-
 import Foundation
 import MockingbirdGenerator
 import PathKit

--- a/Sources/MockingbirdCli/Commands/Encoding/OptionGroupArgumentEncoding.swift
+++ b/Sources/MockingbirdCli/Commands/Encoding/OptionGroupArgumentEncoding.swift
@@ -1,10 +1,3 @@
-//
-//  OptionGroupArgumentEncoding.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/23/21.
-//
-
 import Foundation
 import MockingbirdGenerator
 import PathKit

--- a/Sources/MockingbirdCli/Commands/Generate.swift
+++ b/Sources/MockingbirdCli/Commands/Generate.swift
@@ -1,10 +1,3 @@
-//
-//  Generate.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/8/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Commands/Mockingbird.swift
+++ b/Sources/MockingbirdCli/Commands/Mockingbird.swift
@@ -1,10 +1,3 @@
-//
-//  Mockingbird.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/23/19.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdCommon

--- a/Sources/MockingbirdCli/Commands/Version.swift
+++ b/Sources/MockingbirdCli/Commands/Version.swift
@@ -1,10 +1,3 @@
-//
-//  Version.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/20/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdCommon

--- a/Sources/MockingbirdCli/Handlers/Downloader.swift
+++ b/Sources/MockingbirdCli/Handlers/Downloader.swift
@@ -1,10 +1,3 @@
-//
-//  Downloader.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/8/21.
-//
-
 import ArgumentParser
 import Foundation
 import MockingbirdCommon

--- a/Sources/MockingbirdCli/Handlers/Generator+Pipeline.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator+Pipeline.swift
@@ -1,10 +1,3 @@
-//
-//  Generator+Pipeline.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 6/7/20.
-//
-
 import Foundation
 import MockingbirdCommon
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Handlers/Generator+PruningPipeline.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator+PruningPipeline.swift
@@ -1,10 +1,3 @@
-//
-//  Generator+PruningPipeline.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 6/11/20.
-//
-
 import Foundation
 import MockingbirdGenerator
 import PathKit

--- a/Sources/MockingbirdCli/Handlers/Generator.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator.swift
@@ -1,11 +1,3 @@
-//
-//  Generator.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import MockingbirdCommon
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Handlers/Installer.swift
+++ b/Sources/MockingbirdCli/Handlers/Installer.swift
@@ -1,11 +1,3 @@
-//
-//  Installer.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import MockingbirdCommon
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Utilities/Encodable+SHA1.swift
+++ b/Sources/MockingbirdCli/Utilities/Encodable+SHA1.swift
@@ -1,10 +1,3 @@
-//
-//  Encodable+SHA1.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 6/11/20.
-//
-
 import Foundation
 import MockingbirdCommon
 

--- a/Sources/MockingbirdCli/Utilities/Path+Abbreviate.swift
+++ b/Sources/MockingbirdCli/Utilities/Path+Abbreviate.swift
@@ -1,10 +1,3 @@
-//
-//  Path+Abbreviate.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/23/21.
-//
-
 import Foundation
 import PathKit
 import MockingbirdGenerator

--- a/Sources/MockingbirdCli/Utilities/Path+Symlink.swift
+++ b/Sources/MockingbirdCli/Utilities/Path+Symlink.swift
@@ -1,10 +1,3 @@
-//
-//  Path+Symlink.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/8/21.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdCli/Utilities/TimeUnit.swift
+++ b/Sources/MockingbirdCli/Utilities/TimeUnit.swift
@@ -1,10 +1,3 @@
-//
-//  TimeInterval+Normalize.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 8/8/21.
-//
-
 import Foundation
 
 enum TimeUnit: CustomStringConvertible {

--- a/Sources/MockingbirdCli/main.swift
+++ b/Sources/MockingbirdCli/main.swift
@@ -1,11 +1,3 @@
-//
-//  main.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/4/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import MockingbirdGenerator
 

--- a/Sources/MockingbirdCommon/Data+SHA1.swift
+++ b/Sources/MockingbirdCommon/Data+SHA1.swift
@@ -1,10 +1,3 @@
-//
-//  String+SHA1.swift
-//  MockingbirdCommon
-//
-//  Created by typealias on 12/30/21.
-//
-
 import Foundation
 import CommonCrypto
 

--- a/Sources/MockingbirdCommon/ProcessInfo+ControlCodes.swift
+++ b/Sources/MockingbirdCommon/ProcessInfo+ControlCodes.swift
@@ -1,10 +1,3 @@
-//
-//  ProcessInfo+ControlCodes.swift
-//  MockingbirdCommon
-//
-//  Created by typealias on 12/27/21.
-//
-
 import Foundation
 
 public extension ProcessInfo {

--- a/Sources/MockingbirdCommon/String+ControlCodes.swift
+++ b/Sources/MockingbirdCommon/String+ControlCodes.swift
@@ -1,10 +1,3 @@
-//
-//  String+ControlCodes.swift
-//  MockingbirdCommon
-//
-//  Created by typealias on 12/27/21.
-//
-
 import Foundation
 
 public extension String {

--- a/Sources/MockingbirdCommon/String+Interpolation.swift
+++ b/Sources/MockingbirdCommon/String+Interpolation.swift
@@ -1,10 +1,3 @@
-//
-//  String+Interpolation.swift
-//  MockingbirdCommon
-//
-//  Created by typealias on 12/27/21.
-//
-
 import Foundation
 
 public extension String.StringInterpolation {

--- a/Sources/MockingbirdCommon/String+Regex.swift
+++ b/Sources/MockingbirdCommon/String+Regex.swift
@@ -1,10 +1,3 @@
-//
-//  String+Regex.swift
-//  MockingbirdCli
-//
-//  Created by typealias on 12/25/21.
-//
-
 import Foundation
 
 public extension String {

--- a/Sources/MockingbirdCommon/Synchronized.swift
+++ b/Sources/MockingbirdCommon/Synchronized.swift
@@ -1,11 +1,3 @@
-//
-//  Synchronized.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 public class Synchronized<T> {

--- a/Sources/MockingbirdCommon/Version.swift
+++ b/Sources/MockingbirdCommon/Version.swift
@@ -1,11 +1,3 @@
-//
-//  Version.swift
-//  MockingbirdShared
-//
-//  Created by Andrew Chang on 8/23/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 public let mockingbirdVersion = Version(shortString: "0.18.0")

--- a/Sources/MockingbirdFramework/Matching/ArgumentCaptor.swift
+++ b/Sources/MockingbirdFramework/Matching/ArgumentCaptor.swift
@@ -1,10 +1,3 @@
-//
-//  ArgumentCaptor.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Captures method arguments passed during mock invocations.

--- a/Sources/MockingbirdFramework/Matching/ArgumentMatcher.swift
+++ b/Sources/MockingbirdFramework/Matching/ArgumentMatcher.swift
@@ -1,10 +1,3 @@
-//
-//  ArgumentMatcher.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Matches argument values with a comparator.

--- a/Sources/MockingbirdFramework/Matching/ArgumentPosition.swift
+++ b/Sources/MockingbirdFramework/Matching/ArgumentPosition.swift
@@ -1,10 +1,3 @@
-//
-//  ArgumentPosition.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 /// Specifies the argument position for an argument matcher.

--- a/Sources/MockingbirdFramework/Matching/CollectionMatchers.swift
+++ b/Sources/MockingbirdFramework/Matching/CollectionMatchers.swift
@@ -1,10 +1,3 @@
-//
-//  CollectionMatchers.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// Matches any collection containing all of the values.

--- a/Sources/MockingbirdFramework/Matching/CountMatcher.swift
+++ b/Sources/MockingbirdFramework/Matching/CountMatcher.swift
@@ -1,10 +1,3 @@
-//
-//  CountMatcher.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Checks whether a number matches some expected count.

--- a/Sources/MockingbirdFramework/Matching/NonEscapingType.swift
+++ b/Sources/MockingbirdFramework/Matching/NonEscapingType.swift
@@ -1,10 +1,3 @@
-//
-//  NonEscapingType.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 import Foundation
 
 /// Types that cannot be stored and referenced later.

--- a/Sources/MockingbirdFramework/Matching/TypeFacade.swift
+++ b/Sources/MockingbirdFramework/Matching/TypeFacade.swift
@@ -1,10 +1,3 @@
-//
-//  TypeFacade.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 8/3/19.
-//
-
 import Foundation
 
 /// This is a hack to get strongly-typed stubbing/verification parameters. The goal is to have

--- a/Sources/MockingbirdFramework/Matching/WildcardMatchers.swift
+++ b/Sources/MockingbirdFramework/Matching/WildcardMatchers.swift
@@ -1,10 +1,3 @@
-//
-//  WildcardMatchers.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// Matches all argument values.

--- a/Sources/MockingbirdFramework/Mocking/Context.swift
+++ b/Sources/MockingbirdFramework/Mocking/Context.swift
@@ -1,10 +1,3 @@
-//
-//  Context.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 /// Container for mock state and metadata.

--- a/Sources/MockingbirdFramework/Mocking/Declaration.swift
+++ b/Sources/MockingbirdFramework/Mocking/Declaration.swift
@@ -1,10 +1,3 @@
-//
-//  Declaration.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 /// All mockable declaration types conform to this protocol.

--- a/Sources/MockingbirdFramework/Mocking/GenericStaticMockContext.swift
+++ b/Sources/MockingbirdFramework/Mocking/GenericStaticMockContext.swift
@@ -1,10 +1,3 @@
-//
-//  GenericStaticMockContext.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/23/21.
-//
-
 import Foundation
 
 /// Resolves runtime generic type names to a `StaticMock` instance.

--- a/Sources/MockingbirdFramework/Mocking/Mock.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mock.swift
@@ -1,10 +1,3 @@
-//
-//  Mock.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Foundation
 
 /// All generated mocks conform to this protocol.

--- a/Sources/MockingbirdFramework/Mocking/Mocking.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mocking.swift
@@ -1,10 +1,3 @@
-//
-//  Mocking.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Returns a mock of a given Swift type.

--- a/Sources/MockingbirdFramework/Mocking/MockingContext.swift
+++ b/Sources/MockingbirdFramework/Mocking/MockingContext.swift
@@ -1,10 +1,3 @@
-//
-//  MockingbirdMockingContext.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Stores invocations received by mocks.

--- a/Sources/MockingbirdFramework/Mocking/Proxying.swift
+++ b/Sources/MockingbirdFramework/Mocking/Proxying.swift
@@ -1,8 +1,0 @@
-//
-//  Proxying.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/21/21.
-//
-
-import Foundation

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBMocking.h
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBMocking.h
@@ -1,10 +1,3 @@
-//
-//  MKBMocking.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTestUtils.h
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTestUtils.h
@@ -1,10 +1,3 @@
-//
-//  MKBTestUtils.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/25/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTypeFacade.h
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTypeFacade.h
@@ -1,10 +1,3 @@
-//
-//  MKBTypeFacade.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBMocking.m
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBMocking.m
@@ -1,10 +1,3 @@
-//
-//  MKBMocking.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "../include/MKBMocking.h"
 #import <objc/runtime.h>
 

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTestUtils.m
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTestUtils.m
@@ -1,10 +1,3 @@
-//
-//  MKBTestUtils.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/25/21.
-//
-
 #import "../include/MKBTestUtils.h"
 
 void MKBStopTest(NSString *reason)

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTypeFacade.m
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTypeFacade.m
@@ -1,10 +1,3 @@
-//
-//  MKBTypeFacade.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "../include/MKBTypeFacade.h"
 
 @implementation MKBTypeFacade

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBBoolInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBBoolInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBBoolInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBBoolInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBBoolInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBBoolInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBBoolInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCStringInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCStringInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBCStringInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCStringInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCStringInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBCStringInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBCStringInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCharInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCharInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBCharInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCharInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBCharInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBCharInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBCharInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBClassInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBClassInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBClassInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBClassInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBClassInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBClassInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBClassInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBComparator.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBComparator.h
@@ -1,10 +1,3 @@
-//
-//  MKBComparator.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBComparator.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBComparator.m
@@ -1,10 +1,3 @@
-//
-//  MKBComparator.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBComparator.h"
 
 const MKBComparator MKBEquatableComparator = ^BOOL(id _Nullable lhs, id _Nullable rhs) {

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBDoubleInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBDoubleInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBDoubleInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBDoubleInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBDoubleInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBDoubleInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBDoubleInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBFloatInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBFloatInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBFloatInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBFloatInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBFloatInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBFloatInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBFloatInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBIntInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBIntInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBIntInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBIntInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBIntInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBIntInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBIntInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 @implementation MKBInvocationHandler

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandlerChain.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandlerChain.h
@@ -1,10 +1,3 @@
-//
-//  MKBInvocationHandlerChain.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import <Foundation/Foundation.h>
 #import "MKBInvocationHandler.h"
 

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandlerChain.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBInvocationHandlerChain.m
@@ -1,10 +1,3 @@
-//
-//  MKBInvocationHandlerChain.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBComparator.h"
 #import "MKBInvocationHandlerChain.h"
 #import "MKBInvocationHandler.h"

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBLongInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBLongInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBLongInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongLongInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongLongInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBLongLongInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongLongInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBLongLongInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBLongLongInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBLongLongInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBObjectInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBObjectInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBObjectInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBObjectInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBPointerInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBPointerInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBPointerInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBPointerInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBPointerInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBPointerInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBPointerInvocationHandler.h"
 #import "MKBComparator.h"
 #import "NSInvocation+MKBErrorObjectType.h"

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBSelectorInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBSelectorInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBSelectorInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBSelectorInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBSelectorInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBSelectorInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBSelectorInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBShortInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBShortInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBShortInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBShortInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBShortInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBShortInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBShortInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBStructInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBStructInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBStructInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBStructInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBStructInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBStructInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBStructInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedCharInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedCharInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedCharInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedCharInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedCharInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedCharInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBUnsignedCharInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedIntInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedIntInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedIntInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedIntInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedIntInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedIntInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBUnsignedIntInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedLongInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedLongInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBUnsignedLongInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongLongInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongLongInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedLongLongInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongLongInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedLongLongInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedLongLongInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBUnsignedLongLongInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedShortInvocationHandler.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedShortInvocationHandler.h
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedShortInvocationHandler.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBInvocationHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedShortInvocationHandler.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/MKBUnsignedShortInvocationHandler.m
@@ -1,10 +1,3 @@
-//
-//  MKBUnsignedShortInvocationHandler.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/19/21.
-//
-
 #import "MKBUnsignedShortInvocationHandler.h"
 #import "MKBComparator.h"
 #if MKB_SWIFTPM

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/NSInvocation+MKBErrorObjectType.h
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/NSInvocation+MKBErrorObjectType.h
@@ -1,10 +1,3 @@
-//
-//  NSInvocation+MKBErrorObjectType.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/20/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/NSInvocation+MKBErrorObjectType.m
+++ b/Sources/MockingbirdFramework/Objective-C/InvocationHandlers/NSInvocation+MKBErrorObjectType.m
@@ -1,10 +1,3 @@
-//
-//  NSInvocation+MKBErrorObjectType.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/20/21.
-//
-
 #import "NSInvocation+MKBErrorObjectType.h"
 
 @implementation NSInvocation (MKBErrorObjectType)

--- a/Sources/MockingbirdFramework/Objective-C/MKBClassMock.h
+++ b/Sources/MockingbirdFramework/Objective-C/MKBClassMock.h
@@ -1,10 +1,3 @@
-//
-//  MKBClassMock.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "MKBConcreteMock.h"
 #import <Foundation/Foundation.h>
 

--- a/Sources/MockingbirdFramework/Objective-C/MKBClassMock.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBClassMock.m
@@ -1,10 +1,3 @@
-//
-//  MKBClassMock.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "MKBClassMock.h"
 #import "MKBProtocolMock.h"
 #import "MKBProperty.h"

--- a/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.h
+++ b/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.h
@@ -1,10 +1,3 @@
-//
-//  MKBConcreteMock.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
@@ -1,10 +1,3 @@
-//
-//  MKBConcreteMock.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "MKBConcreteMock.h"
 #import "MKBProperty.h"
 #import "InvocationHandlers/MKBInvocationHandlerChain.h"

--- a/Sources/MockingbirdFramework/Objective-C/MKBProperty.h
+++ b/Sources/MockingbirdFramework/Objective-C/MKBProperty.h
@@ -1,10 +1,3 @@
-//
-//  MKBProperty.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/28/21.
-//
-
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 

--- a/Sources/MockingbirdFramework/Objective-C/MKBProperty.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBProperty.m
@@ -1,10 +1,3 @@
-//
-//  MKBProperty.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/28/21.
-//
-
 #import "MKBProperty.h"
 
 @implementation MKBProperty

--- a/Sources/MockingbirdFramework/Objective-C/MKBProtocolMock.h
+++ b/Sources/MockingbirdFramework/Objective-C/MKBProtocolMock.h
@@ -1,10 +1,3 @@
-//
-//  MKBProtocolMock.h
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "MKBConcreteMock.h"
 #import <Foundation/Foundation.h>
 

--- a/Sources/MockingbirdFramework/Objective-C/MKBProtocolMock.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBProtocolMock.m
@@ -1,10 +1,3 @@
-//
-//  MKBProtocolMock.m
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 #import "MKBProtocolMock.h"
 #import "MKBProperty.h"
 #import <objc/runtime.h>

--- a/Sources/MockingbirdFramework/Stubbing/DefaultValues.swift
+++ b/Sources/MockingbirdFramework/Stubbing/DefaultValues.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultValues.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Stubbing/DynamicStubbingManager.swift
+++ b/Sources/MockingbirdFramework/Stubbing/DynamicStubbingManager.swift
@@ -1,10 +1,3 @@
-//
-//  DynamicStubbingManager.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/20/21.
-//
-
 import Foundation
 
 /// An intermediate object used for stubbing Objective-C declarations returned by `given`.

--- a/Sources/MockingbirdFramework/Stubbing/ImplementationProvider.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ImplementationProvider.swift
@@ -1,10 +1,3 @@
-//
-//  ImplementationProvider.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// Provides implementation functions used to stub behavior and return values.

--- a/Sources/MockingbirdFramework/Stubbing/InvocationForwarding.swift
+++ b/Sources/MockingbirdFramework/Stubbing/InvocationForwarding.swift
@@ -1,10 +1,3 @@
-//
-//  InvocationForwarding.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Foundation
 
 /// Intermediary object for binding forwarding targets to a mock.

--- a/Sources/MockingbirdFramework/Stubbing/InvocationRecorder.swift
+++ b/Sources/MockingbirdFramework/Stubbing/InvocationRecorder.swift
@@ -1,10 +1,3 @@
-//
-//  InvocationRecorder.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/18/21.
-//
-
 import Foundation
 
 struct InvocationRecord {

--- a/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
+++ b/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
@@ -1,10 +1,3 @@
-//
-//  PropertyProviders.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Foundation
 
 /// Stubs a variable getter to return the last value received by the setter.

--- a/Sources/MockingbirdFramework/Stubbing/ProxyContext.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ProxyContext.swift
@@ -1,10 +1,3 @@
-//
-//  ProxyContext.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 /// Stores potential targets that can handle forwarded invocations from mocked calls.

--- a/Sources/MockingbirdFramework/Stubbing/SequenceProviders.swift
+++ b/Sources/MockingbirdFramework/Stubbing/SequenceProviders.swift
@@ -1,10 +1,3 @@
-//
-//  SequenceProviders.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// The sequence behavior when the number of invocations exceeds the number of values provided.

--- a/Sources/MockingbirdFramework/Stubbing/Stubbing+ObjC.swift
+++ b/Sources/MockingbirdFramework/Stubbing/Stubbing+ObjC.swift
@@ -1,10 +1,3 @@
-//
-//  Stubbing+ObjC.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/28/21.
-//
-
 import Foundation
 
 /// Stub a mocked Objective-C method or property by returning a single value.

--- a/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
+++ b/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
@@ -1,10 +1,3 @@
-//
-//  Stubbing.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Dispatch
 import Foundation
 import XCTest

--- a/Sources/MockingbirdFramework/Stubbing/StubbingContext+ObjC.swift
+++ b/Sources/MockingbirdFramework/Stubbing/StubbingContext+ObjC.swift
@@ -1,10 +1,3 @@
-//
-//  StubbingContext+ObjC.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/20/21.
-//
-
 import Foundation
 
 /// Used to forward errors thrown from stubbed implementations to the Objective-C runtime.

--- a/Sources/MockingbirdFramework/Stubbing/StubbingContext.swift
+++ b/Sources/MockingbirdFramework/Stubbing/StubbingContext.swift
@@ -1,10 +1,3 @@
-//
-//  StubbingContext.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Stubbing/TestKiller.swift
+++ b/Sources/MockingbirdFramework/Stubbing/TestKiller.swift
@@ -1,11 +1,3 @@
-//
-//  TestKiller.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 8/20/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Collections.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Collections.swift
@@ -1,10 +1,3 @@
-//
-//  ValueProvider+Collections.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 4/12/20.
-//
-
 #if canImport(Foundation)
 import Foundation
 #endif

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Foundation.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Foundation.swift
@@ -1,10 +1,3 @@
-//
-//  ValueProvider+Foundation.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 4/12/20.
-//
-
 import Foundation
 #if canImport(ObjectiveC)
 import ObjectiveC

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider+Tuples.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider+Tuples.swift
@@ -1,10 +1,3 @@
-//
-//  ValueProvider+Tuples.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 4/13/20.
-//
-
 import Foundation
 
 // Tuples only work for non-generic types, since generic parameters cannot be inferred here.

--- a/Sources/MockingbirdFramework/Stubbing/ValueProvider.swift
+++ b/Sources/MockingbirdFramework/Stubbing/ValueProvider.swift
@@ -1,10 +1,3 @@
-//
-//  ValueProvider.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 4/11/20.
-//
-
 import Foundation
 
 /// A type that can provide concrete instances of itself.

--- a/Sources/MockingbirdFramework/Utilities/Array+Extensions.swift
+++ b/Sources/MockingbirdFramework/Utilities/Array+Extensions.swift
@@ -1,11 +1,3 @@
-//
-//  Array+Extensions.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 8/20/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 extension Array {

--- a/Sources/MockingbirdFramework/Utilities/CwlDemangle.swift
+++ b/Sources/MockingbirdFramework/Utilities/CwlDemangle.swift
@@ -1,11 +1,3 @@
-//
-//  CwlDemangle.swift
-//  CwlDemangle
-//
-//  Created by Matt Gallagher on 2017/11/17.
-//  Copyright © 2017 Matt Gallagher. All rights reserved.
-//
-
 import Foundation
 
 /// This is likely to be the primary entry point to this file. Pass a string containing a Swift mangled symbol or type, get a parsed SwiftSymbol structure which can then be directly examined or printed.

--- a/Sources/MockingbirdFramework/Utilities/DynamicCast.swift
+++ b/Sources/MockingbirdFramework/Utilities/DynamicCast.swift
@@ -1,10 +1,3 @@
-//
-//  DynamicCast.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 8/2/21.
-//
-
 import Foundation
 
 /// Swift versions before 5.4 cannot cast from `Any` to a more optional type.

--- a/Sources/MockingbirdFramework/Utilities/MockingbirdBridge.swift
+++ b/Sources/MockingbirdFramework/Utilities/MockingbirdBridge.swift
@@ -1,10 +1,3 @@
-//
-//  MockingbirdBridge.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 8/24/21.
-//
-
 #if MKB_SWIFTPM
 @_exported import MockingbirdBridge
 #endif

--- a/Sources/MockingbirdFramework/Utilities/ObjCTypeEncodings.swift
+++ b/Sources/MockingbirdFramework/Utilities/ObjCTypeEncodings.swift
@@ -1,10 +1,3 @@
-//
-//  ObjCTypeEncodings.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/29/21.
-//
-
 import Foundation
 
 /// Maps Objective-C runtime type encodings to a Swift `ObjectIdentifier`.

--- a/Sources/MockingbirdFramework/Utilities/SourceLocation.swift
+++ b/Sources/MockingbirdFramework/Utilities/SourceLocation.swift
@@ -1,10 +1,3 @@
-//
-//  SourceLocation.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// References a line of code in a file.

--- a/Sources/MockingbirdFramework/Utilities/StackTrace.swift
+++ b/Sources/MockingbirdFramework/Utilities/StackTrace.swift
@@ -1,10 +1,3 @@
-//
-//  StackTrace.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 6/6/20.
-//
-
 import Foundation
 
 struct StackTrace {

--- a/Sources/MockingbirdFramework/Utilities/String+Extensions.swift
+++ b/Sources/MockingbirdFramework/Utilities/String+Extensions.swift
@@ -1,10 +1,3 @@
-//
-//  String+Extensions.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 extension String {

--- a/Sources/MockingbirdFramework/Verification/AsyncVerification.swift
+++ b/Sources/MockingbirdFramework/Verification/AsyncVerification.swift
@@ -1,10 +1,3 @@
-//
-//  AsyncVerification.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 3/8/20.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Verification/ExpectationGroup.swift
+++ b/Sources/MockingbirdFramework/Verification/ExpectationGroup.swift
@@ -1,10 +1,3 @@
-//
-//  ExpectationGroup.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 5/31/20.
-//
-
 import Foundation
 
 /// A deferred expectation that can be fulfilled when an invocation arrives later.

--- a/Sources/MockingbirdFramework/Verification/Invocation.swift
+++ b/Sources/MockingbirdFramework/Verification/Invocation.swift
@@ -1,10 +1,3 @@
-//
-//  MockingbirdInvocation.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 
 /// Attributes selectors to a specific member type.

--- a/Sources/MockingbirdFramework/Verification/MonotonicIncreasingIndex.swift
+++ b/Sources/MockingbirdFramework/Verification/MonotonicIncreasingIndex.swift
@@ -1,10 +1,3 @@
-//
-//  MonotonicIncreasingIndex.swift
-//  MockingbirdFramework
-//
-//  Created by typealias on 7/17/21.
-//
-
 import Foundation
 
 private let index = Synchronized<UInt>(0)

--- a/Sources/MockingbirdFramework/Verification/OrderedVerification.swift
+++ b/Sources/MockingbirdFramework/Verification/OrderedVerification.swift
@@ -1,10 +1,3 @@
-//
-//  OrderedVerification.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 3/8/20.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Verification/TestFailure.swift
+++ b/Sources/MockingbirdFramework/Verification/TestFailure.swift
@@ -1,10 +1,3 @@
-//
-//  TestFailure.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Verification/Verification.swift
+++ b/Sources/MockingbirdFramework/Verification/Verification.swift
@@ -1,10 +1,3 @@
-//
-//  MockingbirdVerification.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 7/29/19.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdFramework/Verification/XCTFailSwizzler.swift
+++ b/Sources/MockingbirdFramework/Verification/XCTFailSwizzler.swift
@@ -1,10 +1,3 @@
-//
-//  XCTFailSwizzler.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 3/11/20.
-//
-
 import Foundation
 import XCTest
 

--- a/Sources/MockingbirdGenerator/Generator/Extensions/Attributes+Sanitize.swift
+++ b/Sources/MockingbirdGenerator/Generator/Extensions/Attributes+Sanitize.swift
@@ -1,10 +1,3 @@
-//
-//  Attributes+Sanitize.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 2/22/20.
-//
-
 import Foundation
 
 private enum Constants {

--- a/Sources/MockingbirdGenerator/Generator/Operations/FileGenerator.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/FileGenerator.swift
@@ -1,11 +1,3 @@
-//
-//  FileGenerator.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/5/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 // swiftlint:disable leading_whitespace
 
 import Foundation

--- a/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/GenerateFileOperation.swift
@@ -1,11 +1,3 @@
-//
-//  GenerateFileOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import PathKit
 import os.log

--- a/Sources/MockingbirdGenerator/Generator/Operations/RenderTemplateOperation.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/RenderTemplateOperation.swift
@@ -1,11 +1,3 @@
-//
-//  RenderTemplateOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/18/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 class RenderTemplateOperation: BasicOperation {

--- a/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  InitializerMethodTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/18/20.
-//
-
 import Foundation
 
 /// Renders initializer method declarations.

--- a/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -1,11 +1,3 @@
-//
-//  MethodTemplate.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/6/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 // swiftlint:disable leading_whitespace
 
 import Foundation

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeInitializerTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  MockableTypeInitializerTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/14/19.
-//
-
 import Foundation
 
 struct MockableTypeInitializerTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -1,11 +1,3 @@
-//
-//  MockGenerator.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/6/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 // swiftlint:disable leading_whitespace
 
 import Foundation

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/BlockTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/BlockTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  BlockTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/23/21.
-//
-
 import Foundation
 
 struct BlockTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ClosureTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ClosureTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  ClosureTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/22/21.
-//
-
 import Foundation
 
 struct ClosureTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ForInStatementTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ForInStatementTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  ForInStatementTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/24/21.
-//
-
 import Foundation
 
 struct ForInStatementTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionCallTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionCallTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  FunctionCallTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 struct FunctionCallTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionDefinitionTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/FunctionDefinitionTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  FunctionDefinitionTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 struct FunctionDefinitionTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/GuardStatement.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/GuardStatement.swift
@@ -1,10 +1,3 @@
-//
-//  GuardStatement.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/24/21.
-//
-
 import Foundation
 
 struct GuardStatementTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/IfStatementTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/IfStatementTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  IfStatementTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/24/21.
-//
-
 import Foundation
 
 struct IfStatementTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/NominalTypeDefinitionTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/NominalTypeDefinitionTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  NominalTypeDefinitionTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/23/21.
-//
-
 import Foundation
 
 struct NominalTypeDefinitionTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ObjectInitializationTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/ObjectInitializationTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  ObjectInitializationTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 struct ObjectInitializationTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/PropertyDefinitionTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/PropertyDefinitionTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  PropertyDefinitionTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 struct PropertyDefinitionTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/SwitchStatementTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/SwitchStatementTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  SwitchStatementTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/24/21.
-//
-
 import Foundation
 
 struct SwitchStatementTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/Primitives/VariableDefinitionTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Primitives/VariableDefinitionTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  VariableDefinitionTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 struct VariableDefinitionTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  SubscriptMethodTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/18/20.
-//
-
 // swiftlint:disable leading_whitespace
 
 import Foundation

--- a/Sources/MockingbirdGenerator/Generator/Templates/Template.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/Template.swift
@@ -1,10 +1,3 @@
-//
-//  Template.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/14/19.
-//
-
 import Foundation
 
 /// Able to be rendered into a `String` using a potentially non-O(1) operation.

--- a/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
@@ -1,10 +1,3 @@
-//
-//  ThunkTemplate.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/24/21.
-//
-
 import Foundation
 
 class ThunkTemplate: Template {

--- a/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -1,11 +1,3 @@
-//
-//  VariableTemplate.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/6/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 // swiftlint:disable leading_whitespace
 
 import Foundation

--- a/Sources/MockingbirdGenerator/Parser/Models/DeclaredType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/DeclaredType.swift
@@ -1,10 +1,3 @@
-//
-//  DeclaredType.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/1/19.
-//
-
 import Foundation
 
 /// Recursively parses type declarations.

--- a/Sources/MockingbirdGenerator/Parser/Models/Function.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Function.swift
@@ -1,10 +1,3 @@
-//
-//  Function.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 5/24/20.
-//
-
 import Foundation
 
 struct Function: CustomStringConvertible, CustomDebugStringConvertible, SerializableType {

--- a/Sources/MockingbirdGenerator/Parser/Models/GenericType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/GenericType.swift
@@ -1,11 +1,3 @@
-//
-//  GenericType.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Models/InferType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/InferType.swift
@@ -1,11 +1,3 @@
-//
-//  InferType.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 /// This type inference system is passable but still a bit lacking. We need to modify the type

--- a/Sources/MockingbirdGenerator/Parser/Models/Method.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Method.swift
@@ -1,11 +1,3 @@
-//
-//  Method.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Models/MethodParameter.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/MethodParameter.swift
@@ -1,10 +1,3 @@
-//
-//  MethodParameter.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Models/MockableType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/MockableType.swift
@@ -1,11 +1,3 @@
-//
-//  MockableType.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Models/ParsedFile.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/ParsedFile.swift
@@ -1,10 +1,3 @@
-//
-//  ParsedFile.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/22/20.
-//
-
 import Foundation
 import PathKit
 import SourceKittenFramework

--- a/Sources/MockingbirdGenerator/Parser/Models/Primitives.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Primitives.swift
@@ -1,10 +1,3 @@
-//
-//  Primitives.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/7/19.
-//
-
 import Foundation
 
 /// Static cache for primative `DeclaredType` objects.

--- a/Sources/MockingbirdGenerator/Parser/Models/RawType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/RawType.swift
@@ -1,10 +1,3 @@
-//
-//  RawType.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/29/19.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/SerializationRequest.swift
@@ -1,10 +1,3 @@
-//
-//  SerializationRequest.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/7/19.
-//
-
 import Foundation
 
 /// Fully qualifies tokenized `DeclaredType` objects given a declaration context.

--- a/Sources/MockingbirdGenerator/Parser/Models/Single.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Single.swift
@@ -1,10 +1,3 @@
-//
-//  Single.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 3/24/20.
-//
-
 import Foundation
 
 indirect enum Single: CustomStringConvertible, CustomDebugStringConvertible, SerializableType {

--- a/Sources/MockingbirdGenerator/Parser/Models/Specializable.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Specializable.swift
@@ -1,10 +1,3 @@
-//
-//  Specializable.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 3/26/20.
-//
-
 import Foundation
 
 /// Stores type specializations, e.g. `Dictionary<String, Int>`, mapping each generic type parameter

--- a/Sources/MockingbirdGenerator/Parser/Models/Tuple.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Tuple.swift
@@ -1,10 +1,3 @@
-//
-//  Tuple.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 3/24/20.
-//
-
 import Foundation
 
 struct Tuple: CustomStringConvertible, CustomDebugStringConvertible, SerializableType {

--- a/Sources/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
@@ -1,11 +1,3 @@
-//
-//  TypeAttributes.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/4/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Models/Typealias.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Typealias.swift
@@ -1,10 +1,3 @@
-//
-//  Typealias.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/29/19.
-//
-
 import Foundation
 import MockingbirdCommon
 import SourceKittenFramework

--- a/Sources/MockingbirdGenerator/Parser/Models/Variable.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Variable.swift
@@ -1,11 +1,3 @@
-//
-//  Variable.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/10/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Operations/BasicOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/BasicOperation.swift
@@ -1,11 +1,3 @@
-//
-//  BasicOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/8/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 public class BasicOperation: Operation {

--- a/Sources/MockingbirdGenerator/Parser/Operations/CheckCacheOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/CheckCacheOperation.swift
@@ -1,10 +1,3 @@
-//
-//  CheckCacheOperation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/30/19.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Operations/ExtractSourcesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ExtractSourcesOperation.swift
@@ -1,11 +1,3 @@
-//
-//  ExtractSourcesOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import PathKit
 import XcodeProj

--- a/Sources/MockingbirdGenerator/Parser/Operations/FindMockedTypesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/FindMockedTypesOperation.swift
@@ -1,10 +1,3 @@
-//
-//  FindMockedTypesOperation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/7/20.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/FlattenInheritanceOperation.swift
@@ -1,10 +1,3 @@
-//
-//  FlattenInheritanceOperation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import MockingbirdCommon
 import SourceKittenFramework

--- a/Sources/MockingbirdGenerator/Parser/Operations/ParseFilesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ParseFilesOperation.swift
@@ -1,11 +1,3 @@
-//
-//  ParseFilesOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import PathKit
 import SourceKittenFramework

--- a/Sources/MockingbirdGenerator/Parser/Operations/ParseSingleFileOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ParseSingleFileOperation.swift
@@ -1,10 +1,3 @@
-//
-//  ParseSingleFileOperation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/22/20.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ProcessStructuresOperation.swift
@@ -1,10 +1,3 @@
-//
-//  ProcessStructuresOperation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import SourceKittenFramework
 

--- a/Sources/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ProcessTypesOperation.swift
@@ -1,11 +1,3 @@
-//
-//  ProcessTypesOperation.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import SourceKittenFramework
 import os.log

--- a/Sources/MockingbirdGenerator/Parser/Operations/SourceFileAuxiliaryParser.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/SourceFileAuxiliaryParser.swift
@@ -1,10 +1,3 @@
-//
-//  SourceFileAuxiliaryParser.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/22/20.
-//
-
 import Foundation
 import SwiftSyntax
 

--- a/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/TestFileParser.swift
@@ -1,10 +1,3 @@
-//
-//  TestFileParser.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/7/20.
-//
-
 import Foundation
 import SwiftSyntax
 

--- a/Sources/MockingbirdGenerator/Parser/Project/BuildSetting.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/BuildSetting.swift
@@ -1,10 +1,3 @@
-//
-//  BuildSetting.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 5/25/20.
-//
-
 import Foundation
 
 /// Super tiny recursive parser for Xcode build settings.

--- a/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/CodableTarget.swift
@@ -1,10 +1,3 @@
-//
-//  CodableTarget.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/29/19.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Project/PBXTarget+Target.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/PBXTarget+Target.swift
@@ -1,10 +1,3 @@
-//
-//  PBXTarget+Target.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/15/20.
-//
-
 import Foundation
 import PathKit
 import XcodeProj

--- a/Sources/MockingbirdGenerator/Parser/Project/Project.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/Project.swift
@@ -1,10 +1,3 @@
-//
-//  Project.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 9/23/20.
-//
-
 import Foundation
 import XcodeProj
 

--- a/Sources/MockingbirdGenerator/Parser/Project/ProjectDescription.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/ProjectDescription.swift
@@ -1,10 +1,3 @@
-//
-//  ProjectDescription.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 9/23/20.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdGenerator/Parser/Project/SourceTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/SourceTarget.swift
@@ -1,10 +1,3 @@
-//
-//  SourceTarget.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/9/20.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Parser/Project/SubstitutionStyle.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/SubstitutionStyle.swift
@@ -1,10 +1,3 @@
-//
-//  SubstitutionStyle.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/15/20.
-//
-
 import Foundation
 
 /// Variable substitution using parentheses or curly braces. Technically Make accepts Bash-style

--- a/Sources/MockingbirdGenerator/Parser/Project/Target.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/Target.swift
@@ -1,10 +1,3 @@
-//
-//  Target.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/15/20.
-//
-
 import Foundation
 import PathKit
 import XcodeProj

--- a/Sources/MockingbirdGenerator/Parser/Project/TargetType.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/TargetType.swift
@@ -1,10 +1,3 @@
-//
-//  TargetType.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/9/20.
-//
-
 import Foundation
 import XcodeProj
 

--- a/Sources/MockingbirdGenerator/Parser/Project/TestTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/TestTarget.swift
@@ -1,10 +1,3 @@
-//
-//  TestTarget.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/10/20.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdGenerator/Utilities/Array+Extensions.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Array+Extensions.swift
@@ -1,11 +1,3 @@
-//
-//  Array+Extensions.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/19/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 extension Array {

--- a/Sources/MockingbirdGenerator/Utilities/CharacterSet+Extensions.swift
+++ b/Sources/MockingbirdGenerator/Utilities/CharacterSet+Extensions.swift
@@ -1,10 +1,3 @@
-//
-//  CharacterSet+Extensions.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/30/19.
-//
-
 import Foundation
 
 extension CharacterSet {

--- a/Sources/MockingbirdGenerator/Utilities/Deallocation.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Deallocation.swift
@@ -1,10 +1,3 @@
-//
-//  Deallocation.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/23/20.
-//
-
 import Foundation
 
 private var objectReferences = [AnyObject]()

--- a/Sources/MockingbirdGenerator/Utilities/KeyedDecodingContainer+Array.swift
+++ b/Sources/MockingbirdGenerator/Utilities/KeyedDecodingContainer+Array.swift
@@ -1,10 +1,3 @@
-//
-//  KeyedDecodingContainer+Array.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/22/21.
-//
-
 import Foundation
 
 extension KeyedDecodingContainer {

--- a/Sources/MockingbirdGenerator/Utilities/Log.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Log.swift
@@ -1,10 +1,3 @@
-//
-//  Log.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/16/19.
-//
-
 import Foundation
 import MockingbirdCommon
 import PathKit

--- a/Sources/MockingbirdGenerator/Utilities/OSLog+Extensions.swift
+++ b/Sources/MockingbirdGenerator/Utilities/OSLog+Extensions.swift
@@ -1,10 +1,3 @@
-//
-//  OSLog+Extensions.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/12/19.
-//
-
 import Foundation
 import os.signpost
 

--- a/Sources/MockingbirdGenerator/Utilities/OperationQueue+Extensions.swift
+++ b/Sources/MockingbirdGenerator/Utilities/OperationQueue+Extensions.swift
@@ -1,11 +1,3 @@
-//
-//  OperationQueue+Extensions.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/19/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 public extension OperationQueue {

--- a/Sources/MockingbirdGenerator/Utilities/OutputStream+Extensions.swift
+++ b/Sources/MockingbirdGenerator/Utilities/OutputStream+Extensions.swift
@@ -1,10 +1,3 @@
-//
-//  OutputStream+Extensions.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 4/24/20.
-//
-
 import Foundation
 
 public extension OutputStream {

--- a/Sources/MockingbirdGenerator/Utilities/Path+Codable.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Path+Codable.swift
@@ -1,10 +1,3 @@
-//
-//  Path+Codable.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 6/10/20.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Path+Fnmatch.swift
@@ -1,10 +1,3 @@
-//
-//  Path+Fnmatch.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import PathKit
 import Darwin
 

--- a/Sources/MockingbirdGenerator/Utilities/Path+WriteUtf8Strings.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Path+WriteUtf8Strings.swift
@@ -1,10 +1,3 @@
-//
-//  Path+WriteUtf8Strings.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 9/3/19.
-//
-
 import Foundation
 import PathKit
 

--- a/Sources/MockingbirdGenerator/Utilities/String+Components.swift
+++ b/Sources/MockingbirdGenerator/Utilities/String+Components.swift
@@ -1,10 +1,3 @@
-//
-//  String+Components.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 5/25/20.
-//
-
 import Foundation
 
 public extension Dictionary where Key == Character, Value == Character {

--- a/Sources/MockingbirdGenerator/Utilities/String+GeneratorUtils.swift
+++ b/Sources/MockingbirdGenerator/Utilities/String+GeneratorUtils.swift
@@ -1,10 +1,3 @@
-//
-//  String+GeneratorUtils.swift
-//  MockingbirdGenerator
-//
-//  Created by typealias on 7/21/21.
-//
-
 import Foundation
 
 extension String {

--- a/Sources/MockingbirdGenerator/Utilities/String+ParserUtils.swift
+++ b/Sources/MockingbirdGenerator/Utilities/String+ParserUtils.swift
@@ -1,11 +1,3 @@
-//
-//  String+ParserUtils.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 public extension String {

--- a/Sources/MockingbirdGenerator/Utilities/Substring+Components.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Substring+Components.swift
@@ -1,10 +1,3 @@
-//
-//  Substring+Components.swift
-//  MockingbirdGenerator
-//
-//  Created by Andrew Chang on 5/25/20.
-//
-
 import Foundation
 
 public extension Substring {

--- a/Sources/MockingbirdGenerator/Utilities/Timing.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Timing.swift
@@ -1,11 +1,3 @@
-//
-//  Utilities.swift
-//  MockingbirdCli
-//
-//  Created by Andrew Chang on 8/14/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import os.log
 

--- a/Sources/MockingbirdTestsHost/ArgumentMatching.swift
+++ b/Sources/MockingbirdTestsHost/ArgumentMatching.swift
@@ -1,11 +1,3 @@
-//
-//  ArgumentMatching.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol BaseProtocol: Equatable {}

--- a/Sources/MockingbirdTestsHost/Child.swift
+++ b/Sources/MockingbirdTestsHost/Child.swift
@@ -1,11 +1,3 @@
-//
-//  Child.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 class Child: Parent {

--- a/Sources/MockingbirdTestsHost/ChildProtocol.swift
+++ b/Sources/MockingbirdTestsHost/ChildProtocol.swift
@@ -1,11 +1,3 @@
-//
-//  ChildProtocol.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol ChildProtocol: ParentProtocol {

--- a/Sources/MockingbirdTestsHost/ClassInitializers.swift
+++ b/Sources/MockingbirdTestsHost/ClassInitializers.swift
@@ -1,10 +1,3 @@
-//
-//  ClassInitializers.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/25/19.
-//
-
 import Foundation
 
 class NoInitializerClass {}

--- a/Sources/MockingbirdTestsHost/ClassOnlyProtocols.swift
+++ b/Sources/MockingbirdTestsHost/ClassOnlyProtocols.swift
@@ -1,10 +1,3 @@
-//
-//  ClassOnlyProtocols.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 10/1/19.
-//
-
 import Foundation
 
 // MARK: - Deprecated class conformance

--- a/Sources/MockingbirdTestsHost/ClassScopedTypes.swift
+++ b/Sources/MockingbirdTestsHost/ClassScopedTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ClassScopedTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/27/19.
-//
-
 import Foundation
 
 class TopLevelType {

--- a/Sources/MockingbirdTestsHost/ClosureParameters.swift
+++ b/Sources/MockingbirdTestsHost/ClosureParameters.swift
@@ -1,10 +1,3 @@
-//
-//  ClosureParameters.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 
 struct ClosureWrapper {

--- a/Sources/MockingbirdTestsHost/Collections.swift
+++ b/Sources/MockingbirdTestsHost/Collections.swift
@@ -1,10 +1,3 @@
-//
-//  Collections.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/6/19.
-//
-
 import Foundation
 
 protocol ArrayCollection {

--- a/Sources/MockingbirdTestsHost/CompilationDirectives.swift
+++ b/Sources/MockingbirdTestsHost/CompilationDirectives.swift
@@ -1,10 +1,3 @@
-//
-//  CompilationDirectives.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/18/19.
-//
-
 import Foundation
 
 #if DEBUG

--- a/Sources/MockingbirdTestsHost/CompoundTypes.swift
+++ b/Sources/MockingbirdTestsHost/CompoundTypes.swift
@@ -1,10 +1,3 @@
-//
-//  CompoundTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import Foundation
 
 protocol ArrayTypes {

--- a/Sources/MockingbirdTestsHost/ConflictingProtocolProperties.swift
+++ b/Sources/MockingbirdTestsHost/ConflictingProtocolProperties.swift
@@ -1,10 +1,3 @@
-//
-//  ConflictingProtocolProperties.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 5/4/20.
-//
-
 import Foundation
 
 protocol InheritedConflictingProtocolProperties {

--- a/Sources/MockingbirdTestsHost/DeclarationAttributes.swift
+++ b/Sources/MockingbirdTestsHost/DeclarationAttributes.swift
@@ -1,10 +1,3 @@
-//
-//  DeclarationAttributes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/6/19.
-//
-
 import Foundation
 
 protocol DeclarationAttributesProtocol {

--- a/Sources/MockingbirdTestsHost/DefaultArgumentValues.swift
+++ b/Sources/MockingbirdTestsHost/DefaultArgumentValues.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultArgumentValues.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import Foundation
 
 protocol DefaultArgumentValuesProtocol {

--- a/Sources/MockingbirdTestsHost/DuplicateProtocolMembers.swift
+++ b/Sources/MockingbirdTestsHost/DuplicateProtocolMembers.swift
@@ -1,10 +1,3 @@
-//
-//  DuplicateProtocolMembers.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 5/8/20.
-//
-
 import Foundation
 
 // General de-deduplication of inherited methods and properties.

--- a/Sources/MockingbirdTestsHost/EmptyTypes.swift
+++ b/Sources/MockingbirdTestsHost/EmptyTypes.swift
@@ -1,10 +1,3 @@
-//
-//  EmptyTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 
 protocol EmptyProtocol {}

--- a/Sources/MockingbirdTestsHost/Extensions.swift
+++ b/Sources/MockingbirdTestsHost/Extensions.swift
@@ -1,11 +1,3 @@
-//
-//  Extensions.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import AppKit
 

--- a/Sources/MockingbirdTestsHost/ExternalModuleClassScopedTypes.swift
+++ b/Sources/MockingbirdTestsHost/ExternalModuleClassScopedTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleClassScopedTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import MockingbirdModuleTestsHost
 

--- a/Sources/MockingbirdTestsHost/ExternalModuleImplicitlyImportedTypes.swift
+++ b/Sources/MockingbirdTestsHost/ExternalModuleImplicitlyImportedTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleImplicitlyImportedTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 2/29/20.
-//
-
 import Foundation
 
 // Implicitly importing `ExternalObjectiveCProtocol` from `MockingbirdModuleTestsHost` via header.

--- a/Sources/MockingbirdTestsHost/ExternalModuleTypealiasing.swift
+++ b/Sources/MockingbirdTestsHost/ExternalModuleTypealiasing.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleTypealiasing.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import MockingbirdModuleTestsHost
 

--- a/Sources/MockingbirdTestsHost/ExternalModuleTypes.swift
+++ b/Sources/MockingbirdTestsHost/ExternalModuleTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import MockingbirdModuleTestsHost
 import MockingbirdShadowedTestsHost

--- a/Sources/MockingbirdTestsHost/FakeableTypes.swift
+++ b/Sources/MockingbirdTestsHost/FakeableTypes.swift
@@ -1,10 +1,3 @@
-//
-//  FakeableTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/11/20.
-//
-
 import Foundation
 
 // MARK: - Types

--- a/Sources/MockingbirdTestsHost/Generics.swift
+++ b/Sources/MockingbirdTestsHost/Generics.swift
@@ -1,11 +1,3 @@
-//
-//  Generics.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/20/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import AppKit
 

--- a/Sources/MockingbirdTestsHost/Grandparent.swift
+++ b/Sources/MockingbirdTestsHost/Grandparent.swift
@@ -1,11 +1,3 @@
-//
-//  Grandparent.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 class Grandparent {

--- a/Sources/MockingbirdTestsHost/GrandparentProtocol.swift
+++ b/Sources/MockingbirdTestsHost/GrandparentProtocol.swift
@@ -1,11 +1,3 @@
-//
-//  GrandparentProtocol.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol GrandparentProtocol {

--- a/Sources/MockingbirdTestsHost/ImplicitVariableTypes.swift
+++ b/Sources/MockingbirdTestsHost/ImplicitVariableTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ImplicitVariableTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 5/4/20.
-//
-
 import Foundation
 
 func NotAType() -> Bool { return true }

--- a/Sources/MockingbirdTestsHost/InheritedTypeQualification.swift
+++ b/Sources/MockingbirdTestsHost/InheritedTypeQualification.swift
@@ -1,10 +1,3 @@
-//
-//  InheritedTypeQualification.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/31/19.
-//
-
 import Foundation
 
 struct UnscopedType {}

--- a/Sources/MockingbirdTestsHost/Initializers.swift
+++ b/Sources/MockingbirdTestsHost/Initializers.swift
@@ -1,10 +1,3 @@
-//
-//  Initializers.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/5/19.
-//
-
 import Foundation
 
 protocol InitializerProtocol {

--- a/Sources/MockingbirdTestsHost/InoutParameters.swift
+++ b/Sources/MockingbirdTestsHost/InoutParameters.swift
@@ -1,11 +1,3 @@
-//
-//  InoutParameters.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol InoutProtocol {

--- a/Sources/MockingbirdTestsHost/KeywordArgumentNames.swift
+++ b/Sources/MockingbirdTestsHost/KeywordArgumentNames.swift
@@ -1,11 +1,3 @@
-//
-//  KeywordArgumentNames.swift
-//  MockingbirdTestsHost
-//
-//  Created by Ryan Meisters on 2/9/20.
-//  Copyright © 2020 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol KeywordArgNamesProtocol {

--- a/Sources/MockingbirdTestsHost/MinimalTestTypes.swift
+++ b/Sources/MockingbirdTestsHost/MinimalTestTypes.swift
@@ -1,10 +1,3 @@
-//
-//  MinimalTestTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Foundation
 
 protocol MinimalProtocol {

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/!EscapedNegationPrefixIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/!EscapedNegationPrefixIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  !EscapedNegationPrefixIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 protocol EscapedNegationPrefixIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/#EscapedCommentPrefixIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/#EscapedCommentPrefixIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  #EscapedCommentPrefixIngoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 protocol EscapedCommentPrefixIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/CascadingExcludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/CascadingExcludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  CascadingExcludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Rules later in the ignore file have higher precedence.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/CascadingIncludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/CascadingIncludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  CascadingIncludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Rules later in the ignore file have higher precedence.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/RelativeTopLevelFileIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/RelativeTopLevelFileIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  RelativeTopLevelFileIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 protocol RelativeTopLevelFileIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group1/DirectoryIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group1/DirectoryIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  DirectoryIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 
 protocol DirectoryIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/EnclosingDirectoryOverriddenIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/EnclosingDirectoryOverriddenIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  EnclosingDirectoryOverriddenIgnoredSource.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Excluded in a more specific directory scope than the inclusion rule.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/OverriddenIncludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/OverriddenIncludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  OverriddenIncludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Included in the same directory scope as the exclusion rule.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/WildcardFileIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group2/WildcardFileIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  WildcardFileIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 
 protocol WildcardFileIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group3/Group/EnclosingDirectoryOverriddenIncludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group3/Group/EnclosingDirectoryOverriddenIncludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  EnclosingDirectoryOverridenIncludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Included in a more specific directory scope than the exclusion rule.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group3/Group/WildcardDirectoryIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group3/Group/WildcardDirectoryIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  WildcardDirectoryIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 
 protocol WildcardDirectoryIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group4/DirectoryNonRelativeIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group4/DirectoryNonRelativeIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  DirectoryNonRelativeIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Ignored using a non-relative pattern from a more general directory scope.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group5/WildcardFileNonRelativeIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/Group5/WildcardFileNonRelativeIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  WildcardFileNonRelativeIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 /// Ignored using a non-relative wildcard pattern from a more general directory scope.

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/NonRelativeSecondLevelFileIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/NonRelativeSecondLevelFileIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  NonRelativeSecondLevelFileIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/2/20.
-//
-
 import Foundation
 
 protocol NonRelativeSecondLevelFileIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/RelativeSecondLevelFileIncludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/RelativeSecondLevelFileIncludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  RelativeSecondLevelFileIncludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 protocol RelativeSecondLevelFileIncludedSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/SecondLevelFileIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/SecondLevel/SecondLevelFileIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  SecondLevelFileIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 
 protocol SecondLevelFileIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/TopLevelFileIgnoredSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/TopLevelFileIgnoredSource.swift
@@ -1,10 +1,3 @@
-//
-//  TopLevelFileIgnoredSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 
 protocol TopLevelFileIgnoredSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdIgnore/TrivialIncludedSource.swift
+++ b/Sources/MockingbirdTestsHost/MockingbirdIgnore/TrivialIncludedSource.swift
@@ -1,10 +1,3 @@
-//
-//  TrivialIncludedSource.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 
 protocol TrivialIncludedSource {}

--- a/Sources/MockingbirdTestsHost/MockingbirdTestsHost.h
+++ b/Sources/MockingbirdTestsHost/MockingbirdTestsHost.h
@@ -1,9 +1,2 @@
-//
-//  MockingbirdTestsHost.h
-//  Mockingbird
-//
-//  Created by Andrew Chang on 2/29/20.
-//
-
 // Enable implicit Swift module imports for `MockingbirdModuleTestsHost`.
 #import <MockingbirdModuleTestsHost/MockingbirdModuleTestsHost-Swift.h>

--- a/Sources/MockingbirdTestsHost/Module/ClassScopedTypes.swift
+++ b/Sources/MockingbirdTestsHost/Module/ClassScopedTypes.swift
@@ -1,10 +1,3 @@
-//
-//  ClassScopedTypes.swift
-//  MockingbirdModuleTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 
 open class TopLevelType {

--- a/Sources/MockingbirdTestsHost/Module/Generics.swift
+++ b/Sources/MockingbirdTestsHost/Module/Generics.swift
@@ -1,10 +1,3 @@
-//
-//  Generics.swift
-//  MockingbirdModuleTestsHost
-//
-//  Created by Andrew Chang on 9/21/19.
-//
-
 import Foundation
 import AppKit
 

--- a/Sources/MockingbirdTestsHost/Module/MockableTypes.swift
+++ b/Sources/MockingbirdTestsHost/Module/MockableTypes.swift
@@ -1,10 +1,3 @@
-//
-//  MockableTypes.swift
-//  Mockingbird
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 
 protocol InternalExternalProtocol {

--- a/Sources/MockingbirdTestsHost/Module/ObjectiveC.swift
+++ b/Sources/MockingbirdTestsHost/Module/ObjectiveC.swift
@@ -1,10 +1,3 @@
-//
-//  ObjectiveC.swift
-//  MockingbirdModuleTestsHost
-//
-//  Created by Andrew Chang on 2/29/20.
-//
-
 import Foundation
 
 @objc(MKBExternalObjectiveCProtocol)

--- a/Sources/MockingbirdTestsHost/Module/Typealiasing.swift
+++ b/Sources/MockingbirdTestsHost/Module/Typealiasing.swift
@@ -1,10 +1,3 @@
-//
-//  Typealiasing.swift
-//  MockingbirdModuleTestsHost
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 
 public typealias NSObject = TopLevelType

--- a/Sources/MockingbirdTestsHost/ModuleImportCases.swift
+++ b/Sources/MockingbirdTestsHost/ModuleImportCases.swift
@@ -1,11 +1,3 @@
-//
-//  ModuleImportCases.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/18/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import ObjectiveC
 import Foundation // Ignore duplicates (and this comment)

--- a/Sources/MockingbirdTestsHost/ObjCParameters.swift
+++ b/Sources/MockingbirdTestsHost/ObjCParameters.swift
@@ -1,10 +1,3 @@
-//
-//  ObjCParameters.swift
-//  MockingbirdTestsHost
-//
-//  Created by typealias on 12/22/21.
-//
-
 import AppKit
 import Foundation
 

--- a/Sources/MockingbirdTestsHost/OpaquelyInheritedTypes.swift
+++ b/Sources/MockingbirdTestsHost/OpaquelyInheritedTypes.swift
@@ -1,10 +1,3 @@
-//
-//  OpaquelyInheritedTypes.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/17/19.
-//
-
 import Foundation
 import AppKit
 

--- a/Sources/MockingbirdTestsHost/Optionals.swift
+++ b/Sources/MockingbirdTestsHost/Optionals.swift
@@ -1,10 +1,3 @@
-//
-//  Optionals.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/7/19.
-//
-
 import Foundation
 
 protocol OptionalsProtocol {

--- a/Sources/MockingbirdTestsHost/OverloadedMethods.swift
+++ b/Sources/MockingbirdTestsHost/OverloadedMethods.swift
@@ -1,10 +1,3 @@
-//
-//  OverloadedMethods.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/25/19.
-//
-
 import Foundation
 
 protocol OverloadedMethodsProtocol {

--- a/Sources/MockingbirdTestsHost/Parent.swift
+++ b/Sources/MockingbirdTestsHost/Parent.swift
@@ -1,11 +1,3 @@
-//
-//  Parent.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 class Parent: Grandparent {

--- a/Sources/MockingbirdTestsHost/ParentProtocol.swift
+++ b/Sources/MockingbirdTestsHost/ParentProtocol.swift
@@ -1,11 +1,3 @@
-//
-//  ParentProtocol.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol ParentProtocol: GrandparentProtocol {

--- a/Sources/MockingbirdTestsHost/ProtocolInitializers.swift
+++ b/Sources/MockingbirdTestsHost/ProtocolInitializers.swift
@@ -1,10 +1,3 @@
-//
-//  ProtocolInitializers.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/25/19.
-//
-
 import Foundation
 
 protocol NoInitializerProtocol {}

--- a/Sources/MockingbirdTestsHost/Shadowed/ModuleNameShadowing.swift
+++ b/Sources/MockingbirdTestsHost/Shadowed/ModuleNameShadowing.swift
@@ -1,10 +1,3 @@
-//
-//  ModuleNameShadowing.swift
-//  MockingbirdShadowedTestsHost
-//
-//  Created by typealias on 9/24/20.
-//
-
 import Foundation
 
 // In cases where the module name is shadowed by a type declaration, we need to avoid qualifying

--- a/Sources/MockingbirdTestsHost/Subscripts.swift
+++ b/Sources/MockingbirdTestsHost/Subscripts.swift
@@ -1,10 +1,3 @@
-//
-//  Subscripts.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 4/18/20.
-//
-
 import Foundation
 
 protocol SubscriptedProtocol {

--- a/Sources/MockingbirdTestsHost/ThrowingMethods.swift
+++ b/Sources/MockingbirdTestsHost/ThrowingMethods.swift
@@ -1,10 +1,3 @@
-//
-//  Exceptions.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 9/14/19.
-//
-
 import Foundation
 
 protocol ThrowingProtocol {

--- a/Sources/MockingbirdTestsHost/Typealiasing.swift
+++ b/Sources/MockingbirdTestsHost/Typealiasing.swift
@@ -1,10 +1,3 @@
-//
-//  Typealiasing.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/29/19.
-//
-
 import Foundation
 
 // MARK: - Type-scoped typealiases

--- a/Sources/MockingbirdTestsHost/UndefinedArgumentLabels.swift
+++ b/Sources/MockingbirdTestsHost/UndefinedArgumentLabels.swift
@@ -1,10 +1,3 @@
-//
-//  UndefinedArgumentLabels.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 
 protocol UndefinedArgumentLabels {

--- a/Sources/MockingbirdTestsHost/Variables.swift
+++ b/Sources/MockingbirdTestsHost/Variables.swift
@@ -1,10 +1,3 @@
-//
-//  Variables.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/27/19.
-//
-
 import Foundation
 
 protocol VariablesContainerProtocol {

--- a/Sources/MockingbirdTestsHost/VariadicParameters.swift
+++ b/Sources/MockingbirdTestsHost/VariadicParameters.swift
@@ -1,11 +1,3 @@
-//
-//  VariadicParameters.swift
-//  MockingbirdTestsHost
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 protocol VariadicProtocol {

--- a/Tests/MockingbirdAutomationTests/E2ETests.swift
+++ b/Tests/MockingbirdAutomationTests/E2ETests.swift
@@ -1,10 +1,3 @@
-//
-//  E2ETests.swift
-//  MockingbirdAutomationTests
-//
-//  Created by typealias on 12/29/21.
-//
-
 import MockingbirdAutomation
 import MockingbirdCommon
 import PathKit

--- a/Tests/MockingbirdTests/E2E/ChildMockMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ChildMockMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ChildMockMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 

--- a/Tests/MockingbirdTests/E2E/ChildMockStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ChildMockStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ChildMockStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/16/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ChildProtocolMockMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ChildProtocolMockMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ChildProtocolMockMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/18/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ChildProtocolMockStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ChildProtocolMockStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ChildProtocolMockStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/18/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ClassScopedTypesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ClassScopedTypesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ClassScopedTypesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/27/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ClassScopedTypesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ClassScopedTypesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ClassScopedTypesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/27/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ClosureParametersMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ClosureParametersMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ClosureParametersMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ClosureParametersStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ClosureParametersStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ClosureParametersStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/DefaultArgumentValuesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/DefaultArgumentValuesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultArgumentValuesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/DefaultArgumentValuesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/DefaultArgumentValuesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultArgumentValuesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/EmptyTypesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/EmptyTypesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  EmptyTypesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ExceptionsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExceptionsMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExceptionsMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/14/19.
-//
-
 import Foundation
 @testable import MockingbirdTestsHost
 

--- a/Tests/MockingbirdTests/E2E/ExceptionsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExceptionsStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExceptionsStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/14/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ExtensionsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExtensionsMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ExtensionsMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ExtensionsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExtensionsStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  ExtensionsStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ExternalModuleClassScopedTypesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExternalModuleClassScopedTypesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleClassScopedTypesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import Mockingbird
 import MockingbirdModuleTestsHost

--- a/Tests/MockingbirdTests/E2E/ExternalModuleClassScopedTypesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExternalModuleClassScopedTypesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleClassScopedTypesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import Mockingbird
 import MockingbirdModuleTestsHost

--- a/Tests/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExternalModuleTypesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleTypesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import MockingbirdModuleTestsHost
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ExternalModuleTypesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ExternalModuleTypesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import Mockingbird
 import MockingbirdModuleTestsHost

--- a/Tests/MockingbirdTests/E2E/GenericsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/GenericsMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  GenericsMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/20/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/GenericsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/GenericsStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  GenericsStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/IgnoredSourceExclusionTests.swift
+++ b/Tests/MockingbirdTests/E2E/IgnoredSourceExclusionTests.swift
@@ -1,10 +1,3 @@
-//
-//  IgnoredSourceExclusionTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/11/19.
-//
-
 import Foundation
 @testable import MockingbirdTestsHost
 

--- a/Tests/MockingbirdTests/E2E/IgnoredSourceInclusionTests.swift
+++ b/Tests/MockingbirdTests/E2E/IgnoredSourceInclusionTests.swift
@@ -1,10 +1,3 @@
-//
-//  IgnoredSourceInclusionTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/3/20.
-//
-
 import Foundation
 @testable import MockingbirdTestsHost
 

--- a/Tests/MockingbirdTests/E2E/ImplicitVariableTypesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ImplicitVariableTypesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ImplicitVariableTypesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 5/4/20.
-//
-
 import Foundation
 @testable import MockingbirdTestsHost
 

--- a/Tests/MockingbirdTests/E2E/ImplicitVariableTypesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/ImplicitVariableTypesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  ImplicitVariableTypesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 5/4/20.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/InitializersMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/InitializersMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  InitializersMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/15/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/InoutParametersMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/InoutParametersMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  InoutParametersMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/InoutParametersStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/InoutParametersStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  InoutParametersStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/KeywordArgumentNamesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/KeywordArgumentNamesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  KeywordArgumentNamesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Ryan Meisters on 2/9/20.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/KeywordArgumentNamesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/KeywordArgumentNamesStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  KeywordArgumentNamesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Ryan Meisters on 2/9/20.
-//  Copyright © 2020 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/SubscriptMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/SubscriptMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  SubscriptMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/25/20.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/SubscriptStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/SubscriptStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  SubscriptStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/25/20.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/TypealiasingMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/TypealiasingMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  TypealiasingMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/31/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/TypealiasingStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/TypealiasingStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  TypealiasingStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/31/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/UndefinedArgumentLabelsMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/UndefinedArgumentLabelsMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  UndefinedArgumentLabelsMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/UndefinedArgumentLabelsStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/UndefinedArgumentLabelsStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  UndefinedArgumentLabelsStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/28/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/VariablesMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/VariablesMockableTests.swift
@@ -1,10 +1,3 @@
-//
-//  VariablesMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/9/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/VariablesStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/VariablesStubbableTests.swift
@@ -1,10 +1,3 @@
-//
-//  VariablesStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/10/19.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/VariadicParametersMockableTests.swift
+++ b/Tests/MockingbirdTests/E2E/VariadicParametersMockableTests.swift
@@ -1,11 +1,3 @@
-//
-//  VariadicParametersMockableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/E2E/VariadicParametersStubbableTests.swift
+++ b/Tests/MockingbirdTests/E2E/VariadicParametersStubbableTests.swift
@@ -1,11 +1,3 @@
-//
-//  VariadicParametersStubbableTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/ArgumentCaptorTests.swift
+++ b/Tests/MockingbirdTests/Framework/ArgumentCaptorTests.swift
@@ -1,10 +1,3 @@
-//
-//  ArgumentCaptorTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/25/19.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/ArgumentMatchingTests.swift
+++ b/Tests/MockingbirdTests/Framework/ArgumentMatchingTests.swift
@@ -1,11 +1,3 @@
-//
-//  ArgumentMatchingTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Foundation
 
 import XCTest

--- a/Tests/MockingbirdTests/Framework/AsyncVerificationTests.swift
+++ b/Tests/MockingbirdTests/Framework/AsyncVerificationTests.swift
@@ -1,11 +1,3 @@
-//
-//  AsyncVerificationTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/13/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/ChainedStubbingTests.swift
+++ b/Tests/MockingbirdTests/Framework/ChainedStubbingTests.swift
@@ -1,10 +1,3 @@
-//
-//  ChainedStubbingTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 5/30/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/ClosureParameterTests.swift
+++ b/Tests/MockingbirdTests/Framework/ClosureParameterTests.swift
@@ -1,10 +1,3 @@
-//
-//  ClosureParameterTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 11/29/19.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/CollectionArgumentMatchingTests.swift
+++ b/Tests/MockingbirdTests/Framework/CollectionArgumentMatchingTests.swift
@@ -1,10 +1,3 @@
-//
-//  CollectionArgumentMatchingTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/6/19.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/CountMatcherTests.swift
+++ b/Tests/MockingbirdTests/Framework/CountMatcherTests.swift
@@ -1,10 +1,3 @@
-//
-//  CountMatcherTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/2/20.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/DefaultValueProviderTests.swift
+++ b/Tests/MockingbirdTests/Framework/DefaultValueProviderTests.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultValueProviderTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/11/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/DynamicSwiftTests.swift
+++ b/Tests/MockingbirdTests/Framework/DynamicSwiftTests.swift
@@ -1,10 +1,3 @@
-//
-//  ObjectiveCTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/17/21.
-//
-
 import Mockingbird
 @testable import MockingbirdTestsHost
 import XCTest

--- a/Tests/MockingbirdTests/Framework/FloatingPointMatcherTests.swift
+++ b/Tests/MockingbirdTests/Framework/FloatingPointMatcherTests.swift
@@ -1,10 +1,3 @@
-//
-//  FloatingPointMatcherTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/3/20.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/GenericsTests.swift
+++ b/Tests/MockingbirdTests/Framework/GenericsTests.swift
@@ -1,10 +1,3 @@
-//
-//  GenericsTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 7/26/20.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/InitializerTests.swift
+++ b/Tests/MockingbirdTests/Framework/InitializerTests.swift
@@ -1,10 +1,3 @@
-//
-//  InitializerTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/5/19.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/InlinePropertyTests.swift
+++ b/Tests/MockingbirdTests/Framework/InlinePropertyTests.swift
@@ -1,10 +1,3 @@
-//
-//  InlinePropertyTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/LastSetValueStubTests.swift
+++ b/Tests/MockingbirdTests/Framework/LastSetValueStubTests.swift
@@ -1,11 +1,3 @@
-//
-//  LastSetValueStubTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/17/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/ObjectiveCParameterTests.swift
+++ b/Tests/MockingbirdTests/Framework/ObjectiveCParameterTests.swift
@@ -1,10 +1,3 @@
-//
-//  ObjectiveCParameterTests.swift
-//  MockingbirdTestsHost
-//
-//  Created by typealias on 12/22/21.
-//
-
 import Mockingbird
 @testable import MockingbirdTestsHost
 import XCTest

--- a/Tests/MockingbirdTests/Framework/ObjectiveCTests.swift
+++ b/Tests/MockingbirdTests/Framework/ObjectiveCTests.swift
@@ -1,10 +1,3 @@
-//
-//  ObjectiveCTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/28/21.
-//
-
 import CoreBluetooth
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/OptionalsTests.swift
+++ b/Tests/MockingbirdTests/Framework/OptionalsTests.swift
@@ -1,10 +1,3 @@
-//
-//  OptionalsTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 12/22/21.
-//
-
 import Mockingbird
 @testable import MockingbirdTestsHost
 import XCTest

--- a/Tests/MockingbirdTests/Framework/OrderedVerificationTests.swift
+++ b/Tests/MockingbirdTests/Framework/OrderedVerificationTests.swift
@@ -1,10 +1,3 @@
-//
-//  OrderedVerificationTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/9/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/OverloadedMethodTests.swift
+++ b/Tests/MockingbirdTests/Framework/OverloadedMethodTests.swift
@@ -1,10 +1,3 @@
-//
-//  OverloadedMethodTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/25/19.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/PartialMockTests.swift
+++ b/Tests/MockingbirdTests/Framework/PartialMockTests.swift
@@ -1,10 +1,3 @@
-//
-//  PartialMockTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/SequentialValueStubbingTests.swift
+++ b/Tests/MockingbirdTests/Framework/SequentialValueStubbingTests.swift
@@ -1,10 +1,3 @@
-//
-//  SequentialValueStubbingTests.swift
-//  MockingbirdFramework
-//
-//  Created by Andrew Chang on 4/15/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/StubbingInoutTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingInoutTests.swift
@@ -1,10 +1,3 @@
-//
-//  StubbingInoutTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Mockingbird
 @testable import MockingbirdTestsHost
 import XCTest

--- a/Tests/MockingbirdTests/Framework/StubbingTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingTests.swift
@@ -1,11 +1,3 @@
-//
-//  StubbingTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/18/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import Mockingbird
 import XCTest
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/StubbingThrowingErrorsTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingThrowingErrorsTests.swift
@@ -1,10 +1,3 @@
-//
-//  StubbingThrowingErrorsTests.swift
-//  MockingbirdTests
-//
-//  Created by typealias on 7/25/21.
-//
-
 import Foundation
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/SubscriptTests.swift
+++ b/Tests/MockingbirdTests/Framework/SubscriptTests.swift
@@ -1,10 +1,3 @@
-//
-//  SubscriptTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/18/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/Utilities/BaseTestCase.swift
+++ b/Tests/MockingbirdTests/Framework/Utilities/BaseTestCase.swift
@@ -1,10 +1,3 @@
-//
-//  BaseTestCase.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/11/20.
-//
-
 import Foundation
 import XCTest
 import Mockingbird

--- a/Tests/MockingbirdTests/Framework/Utilities/XFailTestFailer.swift
+++ b/Tests/MockingbirdTests/Framework/Utilities/XFailTestFailer.swift
@@ -1,10 +1,3 @@
-//
-//  XFailTestFailer.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/11/20.
-//
-
 import Foundation
 import Mockingbird
 import XCTest

--- a/Tests/MockingbirdTests/Framework/VariadicParametersTests.swift
+++ b/Tests/MockingbirdTests/Framework/VariadicParametersTests.swift
@@ -1,11 +1,3 @@
-//
-//  VariadicParametersTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 8/21/19.
-//  Copyright © 2019 Bird Rides, Inc. All rights reserved.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Framework/XFailOrderedVerificationTests.swift
+++ b/Tests/MockingbirdTests/Framework/XFailOrderedVerificationTests.swift
@@ -1,10 +1,3 @@
-//
-//  XFailOrderedVerificationTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 3/12/20.
-//
-
 import XCTest
 import Mockingbird
 @testable import MockingbirdTestsHost

--- a/Tests/MockingbirdTests/Generator/DeclaredTypeTests.swift
+++ b/Tests/MockingbirdTests/Generator/DeclaredTypeTests.swift
@@ -1,10 +1,3 @@
-//
-//  DeclaredTypeTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import XCTest
 @testable import MockingbirdGenerator
 

--- a/Tests/MockingbirdTests/Generator/InferTypeTests.swift
+++ b/Tests/MockingbirdTests/Generator/InferTypeTests.swift
@@ -1,10 +1,3 @@
-//
-//  InferTypeTests.swift
-//  MockingbirdTests
-//
-//  Created by Ryan Meisters on 4/23/20.
-//
-
 import XCTest
 
 @testable import MockingbirdGenerator

--- a/Tests/MockingbirdTests/Generator/PBXTargetTests.swift
+++ b/Tests/MockingbirdTests/Generator/PBXTargetTests.swift
@@ -1,10 +1,3 @@
-//
-//  PBXTargetTests.swift
-//  MockingbirdTests
-//
-//  Created by Sterling Hackley on 10/26/19.
-//
-
 import XCTest
 import XcodeProj
 @testable import MockingbirdGenerator

--- a/Tests/MockingbirdTests/Generator/PathFnmatchTests.swift
+++ b/Tests/MockingbirdTests/Generator/PathFnmatchTests.swift
@@ -1,10 +1,3 @@
-//
-//  PathFnmatchTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 10/29/19.
-//
-
 import XCTest
 import PathKit
 @testable import MockingbirdGenerator

--- a/Tests/MockingbirdTests/Generator/StringExtensionsTests.swift
+++ b/Tests/MockingbirdTests/Generator/StringExtensionsTests.swift
@@ -1,10 +1,3 @@
-//
-//  StringExtensionsTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 9/2/19.
-//
-
 import XCTest
 @testable import MockingbirdGenerator
 

--- a/Tests/MockingbirdTests/Generator/SubstitutionStyleTests.swift
+++ b/Tests/MockingbirdTests/Generator/SubstitutionStyleTests.swift
@@ -1,10 +1,3 @@
-//
-//  SubstitutionStyleTests.swift
-//  MockingbirdTests
-//
-//  Created by Andrew Chang on 4/15/20.
-//
-
 import XCTest
 @testable import MockingbirdGenerator
 

--- a/Tests/MockingbirdTests/Generator/TargetDescriptionTests.swift
+++ b/Tests/MockingbirdTests/Generator/TargetDescriptionTests.swift
@@ -1,10 +1,3 @@
-//
-//  TargetDescriptionTests.swift
-//  MockingbirdTests
-//
-//  Created by Kiel Gillard on 22/7/21.
-//
-
 import XCTest
 @testable import MockingbirdGenerator
 


### PR DESCRIPTION
**Stack:**
📚 #259 [4/x] Bump versions to 0.19.0
📚 #258 ***← [3/x] Codemod Xcode-generated file header comments***
📚 #257 [2/x] Migrate to DocC for API reference docs
📚 #256 [1/x] Clean up automation pipeline

## Overview

Standardizes the Swift header comments across the codebase.

## Test Plan

```console
$ grep -r '\/\/  Created by' ./Sources
$ grep -r '\/\/  Created by' ./Tests
```