### PR TITLE
[4/x] Bump versions to 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="#quick-start"><img src="https://img.shields.io/badge/package-CocoaPods%20%7C%20Carthage%20%7C%20SwiftPM-4BC51D.svg" alt="Package managers"></a>
-  <a href="/birdrides/mockingbird/blob/add-readme-logo/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT licensed"></a>
+  <a href="https://github.com/birdrides/mockingbird/blob/master/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT licensed"></a>
   <a href="https://join.slack.com/t/birdopensource/shared_invite/zt-wogxij50-3ZM7F8ZxFXvPkE0j8xTtmw" rel="nofollow"><img src="https://img.shields.io/badge/slack-%23mockingbird-A417A6.svg" alt="#mockingbird Slack channel"></a>
 </p>
 

--- a/Sources/MockingbirdCli/Info.plist
+++ b/Sources/MockingbirdCli/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18.0</string>
+	<string>0.19.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdCommon/Version.swift
+++ b/Sources/MockingbirdCommon/Version.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public let mockingbirdVersion = Version(shortString: "0.18.0")
+public let mockingbirdVersion = Version(shortString: "0.19.0")
 
 public struct Version: Comparable, CustomStringConvertible {
   public let semver: [Int]

--- a/Sources/MockingbirdFramework/Info.plist
+++ b/Sources/MockingbirdFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18.0</string>
+	<string>0.19.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdGenerator/Info.plist
+++ b/Sources/MockingbirdGenerator/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18.0</string>
+	<string>0.19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Stack:**
📚 #259 ***← [4/x] Bump versions to 0.19.0***
📚 #258 [3/x] Codemod Xcode-generated file header comments
📚 #257 [2/x] Migrate to DocC for API reference docs
📚 #256 [1/x] Clean up automation pipeline

## Overview

Cut release for 0.19.0.

## Test Plan

```console
$ Sources/MockingbirdCli/buildAndRun.sh --version
[94/94] Build complete!
0.19.0
```