### PR TITLE
[2/x] Archive supporting sources in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,15 @@ jobs:
       run: |
         Sources/MockingbirdAutomationCli/buildAndRun.sh build framework \
           --archive .build/mockingbird/artifacts/Mockingbird.xcframework.zip
+    - name: Build Supporting Sources
+      run: |
+        Sources/MockingbirdAutomationCli/buildAndRun.sh build supporting \
+          --archive .build/mockingbird/artifacts/MockingbirdSupport.zip
     - name: Document SHAs
       run: |
         shasum -a 512 .build/mockingbird/artifacts/Mockingbird.zip
         shasum -a 512 .build/mockingbird/artifacts/Mockingbird.xcframework.zip
+        shasum -a 512 .build/mockingbird/artifacts/MockingbirdSupport.zip
     - name: Upload CLI
       uses: actions/upload-artifact@v2
       with:
@@ -47,6 +52,11 @@ jobs:
       with:
         name: Mockingbird.xcframework.zip
         path: .build/mockingbird/artifacts/Mockingbird.xcframework.zip
+    - name: Upload Supporting Sources
+      uses: actions/upload-artifact@v2
+      with:
+        name: MockingbirdSupport.zip
+        path: .build/mockingbird/artifacts/MockingbirdSupport.zip
 
   build-docs:
     name: Build Docs

--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		28719AF326B22D1300C38C2C /* Stubbing+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28719AF226B22D1300C38C2C /* Stubbing+ObjC.swift */; };
 		28719AF526B23AB200C38C2C /* ObjectiveCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28719AF426B23AB200C38C2C /* ObjectiveCTests.swift */; };
 		2873D49A27896DE7004523BC /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2873D49927896DE7004523BC /* Zip.swift */; };
+		2873D49E27899CE2004523BC /* BuildSupportingSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2873D49D27899CE2004523BC /* BuildSupportingSources.swift */; };
 		287BB9CB26AE1578004014CA /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287BB9CA26AE1577004014CA /* Mock.swift */; };
 		287BB9CD26AE15F0004014CA /* InvocationForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287BB9CC26AE15F0004014CA /* InvocationForwarding.swift */; };
 		287C4F3B26A3547000A7E0D9 /* MKBClassMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 287C4F3926A3547000A7E0D9 /* MKBClassMock.h */; };
@@ -624,6 +625,7 @@
 		28719AF226B22D1300C38C2C /* Stubbing+ObjC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stubbing+ObjC.swift"; sourceTree = "<group>"; };
 		28719AF426B23AB200C38C2C /* ObjectiveCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCTests.swift; sourceTree = "<group>"; };
 		2873D49927896DE7004523BC /* Zip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zip.swift; sourceTree = "<group>"; };
+		2873D49D27899CE2004523BC /* BuildSupportingSources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSupportingSources.swift; sourceTree = "<group>"; };
 		287BB9CA26AE1577004014CA /* Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		287BB9CC26AE15F0004014CA /* InvocationForwarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationForwarding.swift; sourceTree = "<group>"; };
 		287C4F3926A3547000A7E0D9 /* MKBClassMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MKBClassMock.h; sourceTree = "<group>"; };
@@ -1378,6 +1380,7 @@
 				285CEA8B278523C70005C91F /* BuildCli.swift */,
 				28DBC3DE277ED20800A6C96F /* BuildDocumentation.swift */,
 				285CEA8C278523C70005C91F /* BuildFramework.swift */,
+				2873D49D27899CE2004523BC /* BuildSupportingSources.swift */,
 				285C8E93277D315F00DE525A /* Configure.swift */,
 				285C8E96277D554000DE525A /* Test.swift */,
 				285C8D832779452800DE525A /* TestExampleProject.swift */,
@@ -2461,6 +2464,7 @@
 				28DBC3DF277ED20800A6C96F /* BuildDocumentation.swift in Sources */,
 				285CEA8E278523C70005C91F /* BuildFramework.swift in Sources */,
 				28E2A59A277E8F5D002975B3 /* TestExampleProject.swift in Sources */,
+				2873D49E27899CE2004523BC /* BuildSupportingSources.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MockingbirdAutomationCli/Commands/Build.swift
+++ b/Sources/MockingbirdAutomationCli/Commands/Build.swift
@@ -10,6 +10,7 @@ struct Build: ParsableCommand {
       BuildCli.self,
       BuildFramework.self,
       BuildDocumentation.self,
+      BuildSupportingSources.self,
     ])
   
   struct Options: ParsableArguments {

--- a/Sources/MockingbirdAutomationCli/Commands/BuildSupportingSources.swift
+++ b/Sources/MockingbirdAutomationCli/Commands/BuildSupportingSources.swift
@@ -1,0 +1,24 @@
+import ArgumentParser
+import Foundation
+import MockingbirdAutomation
+import PathKit
+
+extension Build {
+  struct BuildSupportingSources: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      commandName: "supporting",
+      abstract: "Build a supporting source files bundle.")
+    
+    @OptionGroup()
+    var globalOptions: Options
+    
+    func run() throws {
+      guard let location = globalOptions.archiveLocation else {
+        logError("You must specify an archive location when building supporting sources")
+        return
+      }
+      let modules = try Path("Sources/MockingbirdSupport").children()
+      try archive(artifacts: modules.map({ ("", $0) }), destination: Path(location))
+    }
+  }
+}


### PR DESCRIPTION
## Stack

📚 #266 [6/x] Update example projects to use 0.19.1
📚 #265 [5/x] Fix support for Swift library evolution
📚 #264 [4/x] Fix configurator relative path handling
📚 #263 [3/x] Fix package manager integrations
📚 #261 ***← [2/x] Archive supporting sources in release workflow***
📚 #260 [1/x] Fix CLI archiving and distribution

## Overview

Adds a step to the build release artifacts job to archive the supporting sources at `Sources/MockingbirdSupport` along with the license file.

## Test Plan

Building a supporting source archive with `--archive` creates a ZIP that includes the `LICENSE.md` and can be inflated.

```console
% Sources/MockingbirdAutomationCli/buildAndRun.sh build supporting
[8/8] Build complete!
error: You must specify an archive location when building supporting sources
% Sources/MockingbirdAutomationCli/buildAndRun.sh build supporting --archive .build/mockingbird/archives/MockingbirdSupport.zip
[2/2] Build complete!
Creating archive at .build/mockingbird/archives/MockingbirdSupport.zip
% unzip .build/mockingbird/archives/MockingbirdSupport.zip
Archive:  .build/mockingbird/archives/MockingbirdSupport.zip
  inflating: MockingbirdSupport/LICENSE.md  
  inflating: MockingbirdSupport/.DS_Store  
   creating: MockingbirdSupport/UIKit/
  inflating: MockingbirdSupport/UIKit/UIView.swift  
  inflating: MockingbirdSupport/UIKit/UIViewController.swift  
  inflating: MockingbirdSupport/UIKit/UILabel.swift  
  inflating: MockingbirdSupport/UIKit/UIControl.swift  
   creating: MockingbirdSupport/Foundation/
   creating: MockingbirdSupport/Foundation/ObjectiveC/
  inflating: MockingbirdSupport/Foundation/ObjectiveC/NSObject.swift  
   creating: MockingbirdSupport/Swift/
  inflating: MockingbirdSupport/Swift/Hashable.swift  
  inflating: MockingbirdSupport/Swift/Comparable.swift  
  inflating: MockingbirdSupport/Swift/Misc.swift  
  inflating: MockingbirdSupport/Swift/Codable.swift  
  inflating: MockingbirdSupport/Swift/Equatable.swift  
   creating: MockingbirdSupport/AppKit/
  inflating: MockingbirdSupport/AppKit/NSResponder.swift  
  inflating: MockingbirdSupport/AppKit/NSView.swift  
  inflating: MockingbirdSupport/AppKit/NSViewController.swift  
```