### PR TITLE
[4/x] Fix configurator relative path handling

### DIFF
--- a/Sources/MockingbirdCli/Arguments/InferableArgument.swift
+++ b/Sources/MockingbirdCli/Arguments/InferableArgument.swift
@@ -6,11 +6,15 @@ struct ArgumentContext: Codable {
   let environment: [String: String]
   let arguments: [String]
   
-  static var shared = ArgumentContext(
-    workingPath: Path(FileManager.default.currentDirectoryPath),
-    environment: ProcessInfo.processInfo.environment,
-    arguments: CommandLine.arguments
-  )
+  static var shared = ArgumentContext()
+  
+  init(workingPath: Path = Path(FileManager.default.currentDirectoryPath),
+       environment: [String: String] = ProcessInfo.processInfo.environment,
+       arguments: [String] = CommandLine.arguments) {
+    self.workingPath = workingPath
+    self.environment = environment
+    self.arguments = arguments
+  }
 }
 
 protocol InferableArgument {

--- a/Sources/MockingbirdCli/Commands/Configure.swift
+++ b/Sources/MockingbirdCli/Commands/Configure.swift
@@ -94,9 +94,15 @@ extension Mockingbird {
     mutating func run() throws {
       let start = Date()
       let parsedConfigureArguments = try infer()
-      let parsedGenerateArguments = try parsedConfigureArguments.generateCommand.infer()
+      let parsedGenerateArguments = try parsedConfigureArguments.generateCommand
+        .infer(context: ArgumentContext(workingPath: parsedConfigureArguments.project.parent()))
       
-      logInfo("🛠  Project: \(parsedConfigureArguments.project.abbreviate())")
+      if parsedConfigureArguments.sourceProject == parsedConfigureArguments.project {
+        logInfo("🛠  Project: \(parsedConfigureArguments.project.abbreviate())")
+      } else {
+        logInfo("🛠  Test Project: \(parsedConfigureArguments.project.abbreviate())")
+        logInfo("🛠  Source Project: \(parsedConfigureArguments.sourceProject.abbreviate())")
+      }
       logInfo("🎯 Test Target: \(parsedConfigureArguments.testTarget)")
       logInfo("🧰 Supporting sources: \(parsedGenerateArguments.support.abbreviate())")
       

--- a/Sources/MockingbirdCli/Commands/Generate.swift
+++ b/Sources/MockingbirdCli/Commands/Generate.swift
@@ -99,11 +99,12 @@ extension Mockingbird {
     }
     
     @discardableResult
-    nonmutating func infer() throws -> Arguments {
-      let validProject = try validateRequiredArgument(inferArgument(project), name: "project")
+    nonmutating func infer(context: ArgumentContext = .shared) throws -> Arguments {
+      let validProject = try validateRequiredArgument(inferArgument(project, in: context),
+                                                      name: "project")
       let validSrcroot = try validateRequiredArgument(
         srcroot ?? DirectoryPath(path: validProject.path.parent()), name: "srcroot")
-      let validTestBundle = try validateOptionalArgument(inferArgument(testbundle),
+      let validTestBundle = try validateOptionalArgument(inferArgument(testbundle, in: context),
                                                          name: "testbundle")
       let validSupportPath = support?.path ?? (validSrcroot.path + "MockingbirdSupport")
       

--- a/Sources/MockingbirdCli/Handlers/Installer.swift
+++ b/Sources/MockingbirdCli/Handlers/Installer.swift
@@ -116,7 +116,8 @@ struct Installer {
   private func rewriteDerivedDataPath(_ path: Path) throws -> String? {
     // It's possible to use a custom derived data path (in addition to a custom build products
     // location), but this is very uncommon so we won't try to handle it.
-    guard path.starts(with: Path("~/Library/Developer/Xcode/DerivedData/")) else {
+    let derivedDataRootPath = Path("~/Library/Developer/Xcode/DerivedData/").absolute().string
+    guard path.absolute().string.starts(with: derivedDataRootPath) else {
       return nil
     }
     log("Attempting to rewrite the derived data path \(path.abbreviate())")


### PR DESCRIPTION
## Stack

📚 #266 [6/x] Update example projects to use 0.19.1
📚 #265 [5/x] Fix support for Swift library evolution
📚 #264 ***← [4/x] Fix configurator relative path handling***
📚 #263 [3/x] Fix package manager integrations
📚 #261 [2/x] Archive supporting sources in release workflow
📚 #260 [1/x] Fix CLI archiving and distribution

## Overview

The configurator produces incorrect paths when run from an Xcode project directory that differs from the test target project that’s being configured. This PR fixes the issue by allowing the configurator to pass a working directory to the generator so that argument values are inferred from the correct base path.

## Test Plan

Running `configure` from the Mockingbird source root while configuring the Carthage example project produces the correct supporting sources path.

```console
mockingbird % ~/mockingbird/Sources/MockingbirdCli/buildAndRun.sh configure CarthageExampleTests --generator Examples/CarthageExample/Carthage/Checkouts/mockingbird/mockingbird --project Examples/CarthageExample/CarthageExample.xcodeproj -- --targets CarthageExample
[3/3] Build complete!
🛠  Project: Examples/CarthageExample/CarthageExample.xcodeproj
🎯 Test Target: CarthageExampleTests
🧰 Supporting sources: Examples/CarthageExample/MockingbirdSupport
✅ Downloaded supporting source files
✅ Added build phase 'Generate Mockingbird Mocks'
🎉 Successfully configured CarthageExampleTests in 1s
🚀 Usage:
   1. Initialize a mock in your test with `mock(SomeType.self)`
   2. Build 'CarthageExampleTests' (⇧⌘U) to generate mocks
   3. Write some Swifty tests!
```