### PR TITLE
[6/x] Update example projects to use 0.19.1

### DIFF
--- a/Examples/CarthageExample/Cartfile
+++ b/Examples/CarthageExample/Cartfile
@@ -1,1 +1,1 @@
-github "birdrides/mockingbird" ~> 0.18
+github "birdrides/mockingbird" ~> 0.19

--- a/Examples/CarthageExample/Cartfile.resolved
+++ b/Examples/CarthageExample/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "birdrides/mockingbird" "0.18.1"
+github "birdrides/mockingbird" "0.19.1"

--- a/Examples/CarthageExample/CarthageExample.xcodeproj/project.pbxproj
+++ b/Examples/CarthageExample/CarthageExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1391E46C3692F8B7F8A796C7 /* CarthageExampleTests-CarthageExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CF22C052D30C11807879EB /* CarthageExampleTests-CarthageExampleMocks.generated.swift */; };
 		2803D8E62776C35400651C60 /* CarthageExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D8E52776C35400651C60 /* CarthageExampleApp.swift */; };
 		2803D8E82776C35400651C60 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D8E72776C35400651C60 /* ContentView.swift */; };
 		2803D8EA2776C35700651C60 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2803D8E92776C35700651C60 /* Assets.xcassets */; };
@@ -17,7 +18,6 @@
 		2803D9212776C74800651C60 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D91E2776C74800651C60 /* Person.swift */; };
 		2803D9222776C74800651C60 /* Bird.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D91F2776C74800651C60 /* Bird.swift */; };
 		2803D9242776C76900651C60 /* PersonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D9232776C76900651C60 /* PersonTests.swift */; };
-		657F927858EBA8B0BB83320A /* CarthageExampleTests-CarthageExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BD719B97F0B98B149EDD58 /* CarthageExampleTests-CarthageExampleMocks.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +44,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		18CF22C052D30C11807879EB /* CarthageExampleTests-CarthageExampleMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; lastKnownFileType = sourcecode.swift; name = "CarthageExampleTests-CarthageExampleMocks.generated.swift"; path = "MockingbirdMocks/CarthageExampleTests-CarthageExampleMocks.generated.swift"; sourceTree = "<group>"; };
 		2803D8E22776C35400651C60 /* CarthageExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarthageExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2803D8E52776C35400651C60 /* CarthageExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarthageExampleApp.swift; sourceTree = "<group>"; };
 		2803D8E72776C35400651C60 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -150,7 +151,7 @@
 		776CF9BCCB0A649A5163DBC5 /* Generated Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				37BD719B97F0B98B149EDD58 /* CarthageExampleTests-CarthageExampleMocks.generated.swift */,
+				18CF22C052D30C11807879EB /* CarthageExampleTests-CarthageExampleMocks.generated.swift */,
 			);
 			name = "Generated Mocks";
 			sourceTree = "<group>";
@@ -179,7 +180,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2803D9092776C35700651C60 /* Build configuration list for PBXNativeTarget "CarthageExampleTests" */;
 			buildPhases = (
-				CAB6A2CC6B0BC72ADDB24338 /* Clean Mockingbird Mocks */,
 				418264D864CAE3A2D47E82C0 /* Generate Mockingbird Mocks */,
 				2803D8EE2776C35700651C60 /* Sources */,
 				2803D8EF2776C35700651C60 /* Frameworks */,
@@ -257,11 +257,11 @@
 /* Begin PBXShellScriptBuildPhase section */
 		418264D864CAE3A2D47E82C0 /* Generate Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"/tmp/Mockingbird-B9CD2C93-2161-4BF0-8F70-F58307489F60",
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
@@ -269,22 +269,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-B9CD2C93-2161-4BF0-8F70-F58307489F60'\n\nCarthage/Checkouts/mockingbird/mockingbird generate \\\n  --targets 'CarthageExample' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/CarthageExampleTests-CarthageExampleMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"";
-		};
-		CAB6A2CC6B0BC72ADDB24338 /* Clean Mockingbird Mocks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Clean Mockingbird Mocks";
-			outputPaths = (
-				"/tmp/Mockingbird-B9CD2C93-2161-4BF0-8F70-F58307489F60",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo $RANDOM > '/tmp/Mockingbird-B9CD2C93-2161-4BF0-8F70-F58307489F60'\n";
+			shellScript = "set -eu\n\n# Prevent Xcode 13 from running this script while indexing.\n[[ \"${ACTION}\" == \"indexbuild\" ]] && exit 0\n\n\"${SRCROOT}/Carthage/Checkouts/mockingbird/mockingbird\" generate --targets \"CarthageExample\" --outputs \"${SRCROOT}/MockingbirdMocks/CarthageExampleTests-CarthageExampleMocks.generated.swift\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -306,7 +291,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2803D9242776C76900651C60 /* PersonTests.swift in Sources */,
-				657F927858EBA8B0BB83320A /* CarthageExampleTests-CarthageExampleMocks.generated.swift in Sources */,
+				1391E46C3692F8B7F8A796C7 /* CarthageExampleTests-CarthageExampleMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/CarthageExample/MockingbirdSupport/LICENSE.md
+++ b/Examples/CarthageExample/MockingbirdSupport/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Bird Rides, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Examples/CocoaPodsExample/CocoaPodsExample.xcodeproj/project.pbxproj
+++ b/Examples/CocoaPodsExample/CocoaPodsExample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		18F86AACCDF3985595C8864E /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2685EC5AA11B76B8B45741D /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */; };
 		24A195D12D36DF221C5354EF /* Pods_CocoaPodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE50D55BDECD335E01A9D9B7 /* Pods_CocoaPodsExample.framework */; };
 		2803D8CD2776A08B00651C60 /* Bird.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D8CC2776A08B00651C60 /* Bird.swift */; };
 		2803D8D32776A19100651C60 /* PersonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D8D22776A19100651C60 /* PersonTests.swift */; };
@@ -18,6 +17,7 @@
 		2852645127769CEC000298B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2852645027769CEC000298B3 /* Assets.xcassets */; };
 		2852645427769CEC000298B3 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2852645327769CEC000298B3 /* Preview Assets.xcassets */; };
 		2F948F49E2B63DFC45AE2BFE /* Pods_CocoaPodsExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34132D90ECAACCBBD8217029 /* Pods_CocoaPodsExampleTests.framework */; };
+		C01D23DD1577F866B666F5DB /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B931A7B4B18AAC3A9A4027 /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,11 +45,11 @@
 		2852645327769CEC000298B3 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2852645927769CEC000298B3 /* CocoaPodsExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaPodsExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		34132D90ECAACCBBD8217029 /* Pods_CocoaPodsExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		61B931A7B4B18AAC3A9A4027 /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift"; path = "MockingbirdMocks/CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift"; sourceTree = "<group>"; };
 		82A90B13498132DF88301F72 /* Pods-CocoaPodsExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsExampleTests/Pods-CocoaPodsExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9BD33FD3D336D5492627F106 /* Pods-CocoaPodsExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsExampleTests.release.xcconfig"; path = "Target Support Files/Pods-CocoaPodsExampleTests/Pods-CocoaPodsExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		A3C3C30350B77C3C403E8A47 /* Pods-CocoaPodsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsExample.debug.xcconfig"; path = "Target Support Files/Pods-CocoaPodsExample/Pods-CocoaPodsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		AE50D55BDECD335E01A9D9B7 /* Pods_CocoaPodsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2685EC5AA11B76B8B45741D /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift"; path = "MockingbirdMocks/CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,7 +147,7 @@
 		86BE5DA1B7EBC6D6EE5E3D2F /* Generated Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				D2685EC5AA11B76B8B45741D /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */,
+				61B931A7B4B18AAC3A9A4027 /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift */,
 			);
 			name = "Generated Mocks";
 			sourceTree = "<group>";
@@ -187,7 +187,6 @@
 			buildConfigurationList = 2852647027769CEC000298B3 /* Build configuration list for PBXNativeTarget "CocoaPodsExampleTests" */;
 			buildPhases = (
 				1CE1A05DF61B14E2FB4460D8 /* [CP] Check Pods Manifest.lock */,
-				6ADD0EA29254C22C4E14682B /* Clean Mockingbird Mocks */,
 				F009A44DFA6C09BC0FF61D3B /* Generate Mockingbird Mocks */,
 				2852645527769CEC000298B3 /* Sources */,
 				2852645627769CEC000298B3 /* Frameworks */,
@@ -306,21 +305,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6ADD0EA29254C22C4E14682B /* Clean Mockingbird Mocks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Clean Mockingbird Mocks";
-			outputPaths = (
-				"/tmp/Mockingbird-5DE10430-A98E-4307-8F77-968CD8B5F01D",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo $RANDOM > '/tmp/Mockingbird-5DE10430-A98E-4307-8F77-968CD8B5F01D'\n";
-		};
 		E46A3A1DB52F18771FFD5E10 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -329,9 +313,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CocoaPodsExampleTests/Pods-CocoaPodsExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-CocoaPodsExampleTests/Pods-CocoaPodsExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -340,11 +328,11 @@
 		};
 		F009A44DFA6C09BC0FF61D3B /* Generate Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"/tmp/Mockingbird-5DE10430-A98E-4307-8F77-968CD8B5F01D",
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
@@ -352,7 +340,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-5DE10430-A98E-4307-8F77-968CD8B5F01D'\n\nPods/MockingbirdFramework/mockingbird generate \\\n  --targets 'CocoaPodsExample' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift\"\n";
+			shellScript = "set -eu\n\n# Prevent Xcode 13 from running this script while indexing.\n[[ \"${ACTION}\" == \"indexbuild\" ]] && exit 0\n\n\"${SRCROOT}/Pods/MockingbirdFramework/mockingbird\" generate --targets \"CocoaPodsExample\" --outputs \"${SRCROOT}/MockingbirdMocks/CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -374,7 +362,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2803D8D32776A19100651C60 /* PersonTests.swift in Sources */,
-				18F86AACCDF3985595C8864E /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift in Sources */,
+				C01D23DD1577F866B666F5DB /* CocoaPodsExampleTests-CocoaPodsExampleMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/CocoaPodsExample/MockingbirdSupport/LICENSE.md
+++ b/Examples/CocoaPodsExample/MockingbirdSupport/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Bird Rides, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Examples/CocoaPodsExample/Podfile
+++ b/Examples/CocoaPodsExample/Podfile
@@ -4,6 +4,6 @@ target 'CocoaPodsExample' do
   use_frameworks!
   target 'CocoaPodsExampleTests' do
     inherit! :search_paths
-    pod 'MockingbirdFramework', '~> 0.18'
+    pod 'MockingbirdFramework', '~> 0.19'
   end
 end

--- a/Examples/CocoaPodsExample/Podfile.lock
+++ b/Examples/CocoaPodsExample/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - MockingbirdFramework (0.18.1)
+  - MockingbirdFramework (0.19.1)
 
 DEPENDENCIES:
-  - MockingbirdFramework (~> 0.18)
+  - MockingbirdFramework (~> 0.19)
 
 SPEC REPOS:
   trunk:
     - MockingbirdFramework
 
 SPEC CHECKSUMS:
-  MockingbirdFramework: f68dfb16f5b8bff2ebb6e8fefe565f8a1d573cc7
+  MockingbirdFramework: c85c2e2ec44890c5ec609a11398795cb2fe474a1
 
-PODFILE CHECKSUM: 80451792bd34783abf5eec5eb11f80a5b5850bc5
+PODFILE CHECKSUM: b671ca82bfe4d83304df291b7f0c23c6e1fb93d2
 
 COCOAPODS: 1.11.2

--- a/Examples/SPMPackageExample/MockingbirdSupport/LICENSE.md
+++ b/Examples/SPMPackageExample/MockingbirdSupport/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Bird Rides, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Examples/SPMPackageExample/Package.resolved
+++ b/Examples/SPMPackageExample/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/birdrides/mockingbird.git",
         "state": {
           "branch": null,
-          "revision": "4069bb0cb0163b1f05b2bbb95f9396964d5a19ca",
-          "version": "0.18.1"
+          "revision": "e761bd971a4a425720888fa7241367b8e661f743",
+          "version": "0.19.1"
         }
       }
     ]

--- a/Examples/SPMPackageExample/Package.swift
+++ b/Examples/SPMPackageExample/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .package(
       name: "Mockingbird",
       url: "https://github.com/birdrides/mockingbird.git",
-      .upToNextMinor(from: "0.18.0")),
+      .upToNextMinor(from: "0.19.0")),
   ],
   targets: [
     .target(

--- a/Examples/SPMProjectExample/MockingbirdSupport/LICENSE.md
+++ b/Examples/SPMProjectExample/MockingbirdSupport/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Bird Rides, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Examples/SPMProjectExample/SPMProjectExample.xcodeproj/project.pbxproj
+++ b/Examples/SPMProjectExample/SPMProjectExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BD8FDBE67453E1CF48F7318 /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F02931C308F7FB7AD6FED6F /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */; };
 		2803D9322777F9AE00651C60 /* SPMProjectExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D9312777F9AE00651C60 /* SPMProjectExampleApp.swift */; };
 		2803D9342777F9AE00651C60 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D9332777F9AE00651C60 /* ContentView.swift */; };
 		2803D9362777F9B100651C60 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2803D9352777F9B100651C60 /* Assets.xcassets */; };
@@ -16,7 +17,6 @@
 		2803D9632777FAD400651C60 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D9602777FAD400651C60 /* Fruit.swift */; };
 		2803D9642777FAD400651C60 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2803D9612777FAD400651C60 /* Person.swift */; };
 		2803D9672777FBDE00651C60 /* Mockingbird in Frameworks */ = {isa = PBXBuildFile; productRef = 2803D9662777FBDE00651C60 /* Mockingbird */; };
-		DDD24D98DB4EA69DEE0015DC /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DBF62A89CDF87671D25BBC /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,7 +41,7 @@
 		2803D95F2777FAD400651C60 /* Bird.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bird.swift; sourceTree = "<group>"; };
 		2803D9602777FAD400651C60 /* Fruit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		2803D9612777FAD400651C60 /* Person.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
-		C4DBF62A89CDF87671D25BBC /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift"; path = "MockingbirdMocks/SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift"; sourceTree = "<group>"; };
+		5F02931C308F7FB7AD6FED6F /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift"; path = "MockingbirdMocks/SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,7 +66,7 @@
 		26416AED1E2ACC4BD972D443 /* Generated Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				C4DBF62A89CDF87671D25BBC /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */,
+				5F02931C308F7FB7AD6FED6F /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift */,
 			);
 			name = "Generated Mocks";
 			sourceTree = "<group>";
@@ -247,7 +247,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Prevent Xcode 13 from running this script while indexing.\n[[ \"${ACTION}\" == \"indexbuild\" ]] && exit 0\n\n# Infer the derived data location from the build environment.\n[[ -z \"${DERIVED_DATA+x}\" ]] && DERIVED_DATA=\"$(echo \"${BUILD_ROOT}\" | sed -n 's|\\(.*\\)/Build/.*|\\1|p')\"\n\n\"${DERIVED_DATA}/SourcePackages/checkouts/mockingbird/mockingbird\" generate \\\n  --targets 'SPMProjectExample' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n";
+			shellScript = "set -eu\n\n# Prevent Xcode 13 from running this script while indexing.\n[[ \"${ACTION}\" == \"indexbuild\" ]] && exit 0\n\n# Infer the derived data location from the build environment.\n[[ -z \"${DERIVED_DATA+x}\" ]] && DERIVED_DATA=\"$(echo \"${BUILD_ROOT}\" | sed -n 's|\\(.*\\)/Build/.*|\\1|p')\"\n\n\"${DERIVED_DATA}/SourcePackages/checkouts/mockingbird/mockingbird\" generate --targets \"SPMProjectExample\" --outputs \"${SRCROOT}/MockingbirdMocks/SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -269,7 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2803D95E2777FAB600651C60 /* PersonTests.swift in Sources */,
-				DDD24D98DB4EA69DEE0015DC /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift in Sources */,
+				0BD8FDBE67453E1CF48F7318 /* SPMProjectExampleTests-SPMProjectExampleMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,7 +551,7 @@
 			repositoryURL = "https://github.com/birdrides/mockingbird";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.18.0;
+				minimumVersion = 0.19.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Examples/SPMProjectExample/SPMProjectExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SPMProjectExample/SPMProjectExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/birdrides/mockingbird",
         "state": {
           "branch": null,
-          "revision": "4069bb0cb0163b1f05b2bbb95f9396964d5a19ca",
-          "version": "0.18.1"
+          "revision": "e761bd971a4a425720888fa7241367b8e661f743",
+          "version": "0.19.1"
         }
       }
     ]

--- a/Sources/MockingbirdAutomation/Interop/SwiftPackage.swift
+++ b/Sources/MockingbirdAutomation/Interop/SwiftPackage.swift
@@ -29,7 +29,7 @@ public enum SwiftPackage {
   public enum PackageConfiguration {
     case libraries
     case executables
-    func getEnvironment(
+    public func getEnvironment(
       _ baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> [String: String] {
       var processEnvironment = baseEnvironment

--- a/Sources/MockingbirdAutomation/Interop/XcodeBuild.swift
+++ b/Sources/MockingbirdAutomation/Interop/XcodeBuild.swift
@@ -67,10 +67,13 @@ public enum XcodeBuild {
     public static let tmpBuildPath = Path("/tmp/Mockingbird.dst")
   }
   
-  public static func test(target: Target,
-                          project: Project,
-                          destination: Destination,
-                          buildPath: Path = Constants.tmpBuildPath) throws {
+  public static func test(
+    target: Target,
+    project: Project,
+    destination: Destination,
+    buildPath: Path = Constants.tmpBuildPath,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) throws {
     try Subprocess("xcrun", [
       "xcodebuild",
       "test",
@@ -78,7 +81,7 @@ public enum XcodeBuild {
       "-\(target.optionName)", target.name,
       "-\(project.optionName)", project.path.absolute().string,
       "-destination", destination.optionValue,
-    ]).run()
+    ], environment: environment).run()
   }
   
   public static func clean(target: Target,
@@ -93,11 +96,14 @@ public enum XcodeBuild {
     ]).run()
   }
   
-  public static func resolvePackageDependencies(project: Project) throws {
+  public static func resolvePackageDependencies(
+    project: Project,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) throws {
     try Subprocess("xcrun", [
       "xcodebuild",
       "-resolvePackageDependencies",
       "-\(project.optionName)", project.path.absolute().string,
-    ]).run()
+    ], environment: environment).run()
   }
 }

--- a/Sources/MockingbirdAutomationCli/Commands/TestExampleProject.swift
+++ b/Sources/MockingbirdAutomationCli/Commands/TestExampleProject.swift
@@ -128,10 +128,13 @@ extension Test {
             return
           }
           let projectPath = Path("Examples/SPMProjectExample/SPMProjectExample.xcodeproj")
-          try XcodeBuild.resolvePackageDependencies(project: .project(path: projectPath))
+          let environment = SwiftPackage.PackageConfiguration.libraries.getEnvironment()
+          try XcodeBuild.resolvePackageDependencies(project: .project(path: projectPath),
+                                                    environment: environment)
           try XcodeBuild.test(target: .scheme(name: "SPMProjectExample"),
                               project: .project(path: projectPath),
-                              destination: .iOSSimulator(deviceUUID: uuid))
+                              destination: .iOSSimulator(deviceUUID: uuid),
+                              environment: environment)
         }
       }
     }


### PR DESCRIPTION
## Stack

📚 #266 ***← [6/x] Update example projects to use 0.19.1***
📚 #265 [5/x] Fix support for Swift library evolution
📚 #264 [4/x] Fix configurator relative path handling
📚 #263 [3/x] Fix package manager integrations
📚 #261 [2/x] Archive supporting sources in release workflow
📚 #260 [1/x] Fix CLI archiving and distribution

## Overview

Bumps the example projects to use the 0.19 release train. Mostly important due to the switch from `install` to `configure`.

## Test Plan

Example project tests pass locally and on CI.