### PR TITLE
[EZ] Fix GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,3 @@
----
-name: Pull Request
-about: Submit a new pull request
-title: ''
-labels: ''
-assignees: ''
-
----
-
 ## Overview
 
 The motivation for making this change, what it does, and any additional considerations.


### PR DESCRIPTION
## Overview

Moves the pull request template to `.github/PULL_REQUEST_TEMPLATE.md` so that query parameters aren’t needed to display it ([GitHub docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)).

## Test Plan

Pull request template is displayed on stage:

![image](https://user-images.githubusercontent.com/47129469/148747574-1ae8ddbb-c415-47e4-b695-f3843860dadb.png)
