### PR TITLE
[2/x] Remove Obj-C based nil check

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2813969C279759FA00025F2D /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2813969B279759FA00025F2D /* Optional+Extensions.swift */; };
 		281B6246251DC7220084EBED /* MockingbirdShadowedTestsHost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 281B6226251DC5AD0084EBED /* MockingbirdShadowedTestsHost.framework */; };
 		281B6286251DC7FC0084EBED /* ModuleNameShadowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281B61F1251DBBDE0084EBED /* ModuleNameShadowing.swift */; };
 		281B62FF251DCCFC0084EBED /* MockingbirdShadowedTestsHostMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281B62FE251DCCFC0084EBED /* MockingbirdShadowedTestsHostMocks.generated.swift */; };
@@ -521,6 +522,7 @@
 
 /* Begin PBXFileReference section */
 		2803D96827781A4D00651C60 /* String+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
+		2813969B279759FA00025F2D /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		281B61F1251DBBDE0084EBED /* ModuleNameShadowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleNameShadowing.swift; sourceTree = "<group>"; };
 		281B6226251DC5AD0084EBED /* MockingbirdShadowedTestsHost.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MockingbirdShadowedTestsHost.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		281B62CF251DCAB90084EBED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1862,6 +1864,7 @@
 				28DDDFC026B8571D002556C7 /* DynamicCast.swift */,
 				289FD00126D5D8D6009786A3 /* MockingbirdBridge.swift */,
 				28B4F6E126B3C9C7005C0049 /* ObjCTypeEncodings.swift */,
+				2813969B279759FA00025F2D /* Optional+Extensions.swift */,
 				D3E6F67B24844C5B000D1971 /* SourceLocation.swift */,
 				D3B3D4C5248CC15E00FEEDA0 /* StackTrace.swift */,
 				OBJ_51 /* String+Extensions.swift */,
@@ -2688,6 +2691,7 @@
 				D3E6F67C24844C5B000D1971 /* SourceLocation.swift in Sources */,
 				28843B2826AE710400AFB8DF /* MKBTestUtils.m in Sources */,
 				287C4F5026A36DC000A7E0D9 /* MKBTypeFacade.m in Sources */,
+				2813969C279759FA00025F2D /* Optional+Extensions.swift in Sources */,
 				28571ACD26A668530063AB83 /* MKBInvocationHandlerChain.m in Sources */,
 				28571A9126A65FD80063AB83 /* MKBCharInvocationHandler.m in Sources */,
 				287C4F6626A3E00800A7E0D9 /* NonEscapingType.swift in Sources */,

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTestUtils.h
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/include/MKBTestUtils.h
@@ -8,26 +8,4 @@ void MKBThrowException(NSException *reason);
 
 NSException *_Nullable MKBTryBlock(void(^_Nonnull NS_NOESCAPE block)(void));
 
-/// Returns `true` if the value is equal to `NSNull`.
-///
-/// @param value The value to check.
-///
-/// Fully type erased optionals in Swift causes typical `nil` checks to fail. For example:
-///
-/// ```swift
-/// func erase<T>(_ value: T) {
-///   print(value == nil)                       // false
-///   print(value as Optional<Any> == nil)      // false
-///   print(value as? Optional<String> == nil)  // false
-///   print(value as! Optional<String> == nil)  // true
-/// }
-/// erase(Optional<String>(nil))
-/// ```
-///
-/// Since Objective-C implicitly bridges to `NSNull`, an easy (albeit hacky) way to check if the
-/// value is both an `Optional` and `nil` at runtime is to pass it Objective-C. Swift does support
-/// referencing the `NSNull` instance, so callers need to check if the value is actually `NSNull` on
-/// the Swift side.
-bool MKBCheckIfTypeErasedNil(id _Nullable value);
-
 NS_ASSUME_NONNULL_END

--- a/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTestUtils.m
+++ b/Sources/MockingbirdFramework/Objective-C/Bridge/sources/MKBTestUtils.m
@@ -22,8 +22,3 @@ NSException *_Nullable MKBTryBlock(void(^_Nonnull NS_NOESCAPE block)(void))
   }
   return nil;
 }
-
-bool MKBCheckIfTypeErasedNil(id _Nullable value)
-{
-  return value == [NSNull null];
-}

--- a/Sources/MockingbirdFramework/Stubbing/StubbingContext+ObjC.swift
+++ b/Sources/MockingbirdFramework/Stubbing/StubbingContext+ObjC.swift
@@ -43,7 +43,7 @@ extension StubbingContext {
         ?? Self.noImplementation
       // It's possible to stub `NSNull` as a return value, so we need to check that this is an
       // actual nil Swift value before creating a `NilValue` representation for Obj-C.
-      if !(value is NSNull) && MKBCheckIfTypeErasedNil(value) {
+      if !(value is NSNull) && (value as? Nullable)?.isNil ?? false {
         return NilValue()
       } else {
         return value

--- a/Sources/MockingbirdFramework/Utilities/Optional+Extensions.swift
+++ b/Sources/MockingbirdFramework/Utilities/Optional+Extensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+protocol Nullable {
+  var isNil: Bool { get }
+}
+
+/// Used to determine if a type-erased value is `nil`.
+extension Optional: Nullable {
+  /// Whether the wrapped value is equal to `nil`.
+  var isNil: Bool { self == nil }
+}


### PR DESCRIPTION
## Stack

📚 #275 [5/x] Clean up Synchronized wrapper
📚 #274 [4/x] Fix nested optional property and Obj-C types
📚 #273 [3/x] Improve compile-time checks for Swift mocks
📚 #272 ***← [2/x] Remove Obj-C based nil check***
📚 #271 [1/x] Add Algolia DocSearch to the documentation

## Overview

Removes the `MKBCheckIfTypeErasedNil` workaround in favor of a simple protocol extension on `Optional`.

## Test Plan

```swift
func test<T>(_ value: T) -> Bool {
  return (value as? Nullable)?.isNil ?? false
}
test(Optional<Int>(nil))  // true
test(Optional<Int>(42))   // false
test(42)   // false
```
