### PR TITLE
[3/x] Improve compile-time checks for Swift mocks

### DIFF
--- a/Sources/MockingbirdFramework/Mocking/Declaration.swift
+++ b/Sources/MockingbirdFramework/Mocking/Declaration.swift
@@ -25,8 +25,11 @@ public class SubscriptGetterDeclaration: SubscriptDeclaration {}
 /// Mockable subscript setter declarations.
 public class SubscriptSetterDeclaration: SubscriptDeclaration {}
 
+/// All mockable declarations conform to this protocol.
+public protocol AnyMockable {}
+
 /// Represents a mocked declaration that can be stubbed or verified.
-public struct Mockable<DeclarationType: Declaration, InvocationType, ReturnType> {
+public struct Mockable<DeclarationType: Declaration, InvocationType, ReturnType>: AnyMockable {
   let mock: Mock
   let invocation: Invocation
 }

--- a/Sources/MockingbirdFramework/Mocking/Mocking.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mocking.swift
@@ -1,33 +1,16 @@
 import Foundation
 
-/// Returns a mock of a given Swift type.
+/// Fallback for types without a generated mock.
 ///
-/// Initialized mocks can be passed in place of the original type. Protocol mocks do not require
-/// explicit initialization while class mocks should be created using `initialize(…)`.
-///
-/// ```swift
-/// protocol Bird {
-///   init(name: String)
-/// }
-/// class Tree {
-///   init(with bird: Bird) {}
-/// }
-///
-/// let bird = mock(Bird.self)  // Protocol mock
-/// let tree = mock(Tree.self).initialize(with: bird)  // Class mock
-/// ```
-///
-/// Generated mock types are suffixed with `Mock` and should not be coerced into their supertype.
-///
-/// ```swift
-/// let bird: BirdMock = mock(Bird.self)  // The concrete type is `BirdMock`
-/// let inferredBird = mock(Bird.self)    // Type inference also works
-/// let coerced: Bird = mock(Bird.self)   // Avoid upcasting mocks
-/// ```
-///
-/// - Parameter type: The type to mock.
-@available(*, unavailable, message: "No generated mock for this type which might be resolved by building the test target (⇧⌘U)")
-public func mock<T>(_ type: T.Type) -> T { fatalError() }
+/// Each generated mock defines a specialized version of `mock`, and the absence of a mocked type is
+/// detected at compile time with this overload. In most cases, generating mocks for the current
+/// test target will fix the issue. Otherwise, please consult the troubleshooting guide for
+/// additional solutions: https://mockingbirdswift.com/common-problems
+@available(*, unavailable,
+           message: "No generated mock for this type; try building the test target (⇧⌘U) to generate mocks")
+public func mock<T>(_ type: T.Type) -> T {
+  fatalError()
+}
 
 /// Returns a dynamic mock of a given Objective-C object type.
 ///

--- a/Sources/MockingbirdFramework/Utilities/Optional+Extensions.swift
+++ b/Sources/MockingbirdFramework/Utilities/Optional+Extensions.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Type-erased `Optional`.
+public protocol AnyOptional {
+  associatedtype Wrapped
+}
+
+extension Optional: AnyOptional {}
+
 protocol Nullable {
   var isNil: Bool { get }
 }

--- a/Sources/MockingbirdFramework/Verification/Verification.swift
+++ b/Sources/MockingbirdFramework/Verification/Verification.swift
@@ -11,7 +11,7 @@ import XCTest
 /// verify(bird.setProperty(any())).wasCalled()
 /// ```
 ///
-/// Match exact or wildcard argument values when verifying methods with parameters.
+/// You can match exact or wildcard argument values when verifying.
 ///
 /// ```swift
 /// verify(bird.canChirp(volume: any())).wasCalled()     // Called with any volume
@@ -38,7 +38,7 @@ public func verify<DeclarationType: Declaration, InvocationType, ReturnType>(
 /// verify(bird.setProperty(any())).wasCalled()
 /// ```
 ///
-/// Match exact or wildcard argument values when verifying methods with parameters.
+/// You can match exact or wildcard argument values when verifying.
 ///
 /// ```swift
 /// verify(bird.canChirp(volume: any())).wasCalled()     // Called with any volume


### PR DESCRIPTION
## Stack

📚 #275 [5/x] Clean up Synchronized wrapper
📚 #274 [4/x] Fix nested optional property and Obj-C types
📚 #273 ***← [3/x] Improve compile-time checks for Swift mocks***
📚 #272 [2/x] Remove Obj-C based nil check
📚 #271 [1/x] Add Algolia DocSearch to the documentation

## Overview

The Objective-C overloads introduced in 0.18 makes it difficult for the Swift compiler to choose the correct branch when type checking `given` expressions. This is exacerbated with the stubbing operator which can provide incorrect constraints on the return type, preventing implicit bridging of optionals and Foundation types.

```swift
protocol Foo {
  var nonOptional: String { get }
  var optional: String? { get }
  var bridged: NSString { get }
}
var stored: String! = "foo"
given(myMock.nonOptional) ~> stored  // Compiler fails to coerce `String?` to `String`
given(myMock.optional) ~> "foo"  // Compiler fails to coerce `String` to `String?`
given(myMock.bridged) ~> "foo"  // Compiler fails to coerce `String` to `NSString`
```

Additionally, closure-based stubs on Swift methods aren’t protected against changes to the function signature and silently fall back to use Objective-C wildcard stubbing.

Although the issues likely won’t surface frequently, they are very big foot guns. A few non-mutually exclusive options considered:

1. De-unify the static and dynamic stubbing APIs with `given` and `givenDynamic`. This is a source-incompatible change and makes the API less ergonomic. In addition, the dynamic stubbing path is not just used for Objective-C mocks, but also for the Swift property syntax `given(myMock.property)`.
2. Catch malformed Swift stubs with a more specific overload of `given`. Due to how the compiler picks overloads, the new function can only be annotated with a `deprecated` or `obsoleted` warning, but not `unavailable` error.
3. Declare a new stubbing API `givenSwift` to surface compiler errors or disambiguate the type checking when using the stubbing operator.

The best options are to pair (2) and (3), with the intention that `givenSwift` is only used for debugging warnings emitted by (2) or in cases where it’s more ergonomic to not provide explicit type annotations (e.g. for complex closure stubs).

## Test Plan

- No stubbing warnings in `MockingbirdTests`
- CI tests pass