### PR TITLE
[5/x] Clean up Synchronized wrapper

### DIFF
--- a/Sources/MockingbirdCommon/Synchronized.swift
+++ b/Sources/MockingbirdCommon/Synchronized.swift
@@ -2,35 +2,40 @@ import Foundation
 
 /// A simple wrapper for thread-safe data access.
 public class Synchronized<T> {
+  private let queue = DispatchQueue(label: "co.bird.mockingbird.synchronized",
+                                    attributes: .concurrent)
   private(set) public var unsafeValue: T
   public var value: T {
     get {
       var value: T!
-      queue.sync { value = unsafeValue }
+      queue.sync {
+        value = unsafeValue
+      }
       return value
     }
     set {
-      queue.sync { unsafeValue = newValue }
+      queue.sync(flags: .barrier) {
+        unsafeValue = newValue
+      }
     }
   }
-  private let queue = DispatchQueue(label: "co.bird.mockingbird.synchronized")
   
   public init(_ value: T) {
     self.unsafeValue = value
   }
   
-  public func update(_ block: (inout T) throws -> Void) rethrows {
-    try queue.sync { try block(&unsafeValue) }
-  }
-  
   @discardableResult
   public func update<R>(_ block: (inout T) throws -> R) rethrows -> R {
-    return try queue.sync { try block(&unsafeValue) }
+    return try queue.sync(flags: .barrier) {
+      try block(&unsafeValue)
+    }
   }
   
   public func read<R>(_ block: (T) throws -> R) rethrows -> R {
     var value: R!
-    try queue.sync { value = try block(unsafeValue) }
+    try queue.sync {
+      value = try block(unsafeValue)
+    }
     return value
   }
 }


### PR DESCRIPTION
## Stack

📚 #275 ***← [5/x] Clean up Synchronized wrapper***
📚 #274 [4/x] Fix nested optional property and Obj-C types
📚 #273 [3/x] Improve compile-time checks for Swift mocks
📚 #272 [2/x] Remove Obj-C based nil check
📚 #271 [1/x] Add Algolia DocSearch to the documentation

## Overview

Minor cleanup of the `Synchronized` wrapper to make the behavior better conform to a standard RW lock. Once the migration to Swift Concurrency is complete we should remove this in favor of actors.

## Test Plan

- CI tests pass