### PR TITLE
[1/x] Fix cross-project cache invalidation

### DIFF
--- a/Sources/MockingbirdCli/Commands/Generate.swift
+++ b/Sources/MockingbirdCli/Commands/Generate.swift
@@ -117,11 +117,10 @@ extension Mockingbird {
         return path
       }()
       let environmentSourceRoot: Path? = {
-        guard validProject.path.extension == "xcodeproj" else { return validProject.path.parent() }
-        guard let sourceRoot = environment["SRCROOT"] ?? environment["SOURCE_ROOT"] else {
-          return nil
+        if let sourceRoot = environment["SRCROOT"] ?? environment["SOURCE_ROOT"] {
+          return Path(sourceRoot)
         }
-        return Path(sourceRoot)
+        return environmentProjectFilePath?.parent()
       }()
       let environmentTargetName: String? = validTestBundle?.name
         ?? environment["TARGET_NAME"]

--- a/Sources/MockingbirdCli/Handlers/Generator+Pipeline.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator+Pipeline.swift
@@ -59,6 +59,9 @@ extension Generator {
                                          target: target,
                                          outputFilePath: outputPath)
         checkCache?.addDependency(extractSources)
+        if let findMockedTypesOperation = findMockedTypesOperation {
+          checkCache?.addDependency(findMockedTypesOperation)
+        }
         
       case .testTarget:
         fatalError("Invalid pipeline input target")
@@ -169,7 +172,8 @@ extension Generator {
       }
       
       let data = try JSONEncoder().encode(target)
-      let filePath = cacheDirectory.targetLockFilePath(for: target.name, testBundle: self.environmentTargetName)
+      let filePath = cacheDirectory.targetLockFilePath(for: target.name,
+                                                       testBundle: self.environmentTargetName)
       try filePath.write(data)
       log("Cached pipeline input target \(inputTarget.name.singleQuoted) to \(filePath.absolute())")
     }
@@ -181,7 +185,8 @@ extension Generator {
                               configHash: String,
                               cacheDirectory: Path,
                               sourceRoot: Path) -> SourceTarget? {
-    let filePath = cacheDirectory.targetLockFilePath(for: targetName, testBundle: self.config.environmentTargetName)
+    let filePath = cacheDirectory.targetLockFilePath(for: targetName,
+                                                     testBundle: self.config.environmentTargetName)
     
     guard filePath.exists else {
       log("No cached source target metadata exists for \(targetName.singleQuoted) at \(filePath.absolute())")

--- a/Sources/MockingbirdCli/Handlers/Generator+PruningPipeline.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator+PruningPipeline.swift
@@ -99,7 +99,6 @@ extension Generator {
     
     func cache(projectHash: String,
                cliVersion: String,
-               configHash: String,
                sourceRoot: Path,
                cacheDirectory: Path,
                environment: () -> [String: Any]) throws {
@@ -113,7 +112,6 @@ extension Generator {
                                 mockedTypeNames: mockedTypeNames,
                                 projectHash: projectHash,
                                 cliVersion: cliVersion,
-                                configHash: configHash,
                                 environment: environment)
         
       case .describedTarget(let pipelineTarget):
@@ -122,7 +120,6 @@ extension Generator {
                                 mockedTypeNames: mockedTypeNames,
                                 projectHash: projectHash,
                                 cliVersion: cliVersion,
-                                configHash: configHash,
                                 environment: environment)
         
       case .sourceTarget:
@@ -134,12 +131,12 @@ extension Generator {
                                 mockedTypeNames: mockedTypeNames,
                                 projectHash: projectHash,
                                 cliVersion: cliVersion,
-                                configHash: configHash,
                                 environment: environment)
       }
       
       let data = try JSONEncoder().encode(target)
-      let filePath = cacheDirectory.targetLockFilePath(for: target.name, testBundle:  environmentTargetName)
+      let filePath = cacheDirectory.targetLockFilePath(for: target.name,
+                                                       testBundle: environmentTargetName)
       try filePath.write(data)
       log("Cached pipeline test target \(target.name.singleQuoted) to \(filePath.absolute())")
     }
@@ -148,10 +145,10 @@ extension Generator {
   func findCachedTestTarget(for targetName: String,
                             projectHash: String,
                             cliVersion: String,
-                            configHash: String,
                             cacheDirectory: Path,
                             sourceRoot: Path) -> TestTarget? {
-    let filePath = cacheDirectory.targetLockFilePath(for: targetName, testBundle: self.config.environmentTargetName)
+    let filePath = cacheDirectory.targetLockFilePath(for: targetName,
+                                                     testBundle: self.config.environmentTargetName)
     
     guard filePath.exists else {
       log("No cached test target metadata exists for \(targetName.singleQuoted) at \(filePath.absolute())")
@@ -175,11 +172,6 @@ extension Generator {
     
     guard cliVersion == target.cliVersion else {
       log("Invalidated cached test target metadata for \(target.name.singleQuoted) because the CLI version changed from \(target.cliVersion.singleQuoted) to \(cliVersion.singleQuoted)")
-      return nil
-    }
-    
-    guard configHash == target.configHash else {
-      log("Invalidated cached test target metadata for \(target.name.singleQuoted) because the config hash changed from \(target.configHash.singleQuoted) to \(configHash.singleQuoted)")
       return nil
     }
     

--- a/Sources/MockingbirdCli/Handlers/Generator.swift
+++ b/Sources/MockingbirdCli/Handlers/Generator.swift
@@ -100,14 +100,14 @@ class Generator {
     }
   }
   
-  var projectHash: String?
+  var projectHashes: [Path: String] = [:]
   func getProjectHash(_ projectPath: Path) -> String? {
-    if let projectHash = projectHash { return projectHash }
+    if let projectHash = projectHashes[projectPath.absolute()] { return projectHash }
     let filePath = projectPath.extension == "xcodeproj"
       ? projectPath.glob("*.pbxproj").sorted().first
       : projectPath
     let projectHash = try? filePath?.read().hash()
-    self.projectHash = projectHash
+    self.projectHashes[projectPath.absolute()] = projectHash
     return projectHash
   }
   
@@ -135,7 +135,6 @@ class Generator {
       let cachedTarget = findCachedTestTarget(for: targetName,
                                               projectHash: projectHash,
                                               cliVersion: cliVersion,
-                                              configHash: configHash,
                                               cacheDirectory: cacheDirectory,
                                               sourceRoot: testSourceRoot)
       else { return nil }
@@ -231,11 +230,12 @@ class Generator {
     // Cache test target for thunk pruning.
     if config.pruningMethod != .disable {
       if let testTargetCacheDirectory = testTargetCacheDirectory,
-        let environmentSourceRoot = config.environmentSourceRoot {
+         let environmentSourceRoot = config.environmentSourceRoot,
+         let testProjectPath = config.environmentProjectFilePath,
+         let projectHash = getProjectHash(testProjectPath) {
         try testTargetCacheDirectory.mkpath()
         try pruningPipeline?.cache(projectHash: projectHash,
                                    cliVersion: cliVersion,
-                                   configHash: configHash,
                                    sourceRoot: environmentSourceRoot,
                                    cacheDirectory: testTargetCacheDirectory,
                                    environment: getBuildEnvironment)

--- a/Sources/MockingbirdGenerator/Parser/Project/TestTarget.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/TestTarget.swift
@@ -5,13 +5,11 @@ public class TestTarget: CodableTarget {
   public let mockedTypeNames: [Path: Set<String>]
   public let projectHash: String
   public let cliVersion: String
-  public let configHash: String
   
   enum CodingKeys: String, CodingKey {
     case mockedTypeNames
     case projectHash
     case cliVersion
-    case configHash
   }
   
   public init<T: Target>(from target: T,
@@ -19,12 +17,10 @@ public class TestTarget: CodableTarget {
                          mockedTypeNames: [Path: Set<String>],
                          projectHash: String,
                          cliVersion: String,
-                         configHash: String,
                          environment: () -> [String: Any]) throws {
     self.mockedTypeNames = mockedTypeNames
     self.projectHash = projectHash
     self.cliVersion = cliVersion
-    self.configHash = configHash
     
     var ignoredDependencies = Set<String>()
     try super.init(from: target,
@@ -40,7 +36,6 @@ public class TestTarget: CodableTarget {
     self.mockedTypeNames = try container.decode([Path: Set<String>].self, forKey: .mockedTypeNames)
     self.projectHash = try container.decode(String.self, forKey: .projectHash)
     self.cliVersion = try container.decode(String.self, forKey: .cliVersion)
-    self.configHash = try container.decode(String.self, forKey: .configHash)
     
     try super.init(from: decoder)
   }
@@ -51,7 +46,6 @@ public class TestTarget: CodableTarget {
     try container.encode(mockedTypeNames, forKey: .mockedTypeNames)
     try container.encode(projectHash, forKey: .projectHash)
     try container.encode(cliVersion, forKey: .cliVersion)
-    try container.encode(configHash, forKey: .configHash)
     
     try super.encode(to: encoder)
   }

--- a/mockingbird
+++ b/mockingbird
@@ -11,7 +11,7 @@
 set -eu
 
 readonly srcroot="$(dirname "$0")"
-pushd .
+pushd . > /dev/null
 cd "${srcroot}"
 
 function getVersion {
@@ -49,7 +49,7 @@ if [[ ! -x "${executable}" ]]; then
     if xcrun codesign -vv -R Sources/MockingbirdAutomationCli/Resources/CodesigningRequirements/mockingbird.txt "${executable}"; then
       echo '✅ Verified the code signature'
     else
-      echo -e '\033[1;31merror:\033[0m The downloaded binary does not have a valid code signature. Set `MKB_NO_VERIFY=1` to bypass this error at your own risk.'
+      echo "error: Mockingbird does not have a valid code signature; set 'MKB_NO_VERIFY=1' to bypass this error at your own risk"
       rm "${executable}"
       exit 1
     fi
@@ -57,5 +57,5 @@ if [[ ! -x "${executable}" ]]; then
   chmod u+x "${executable}"
 fi
 
-popd
+popd > /dev/null
 MKB_LAUNCHER="$0" "${srcroot}/${executable}" "$@"


### PR DESCRIPTION
## Stack

📚 #279 [2/x] Fix optional members in Obj-C protocols
📚 #278 ***← [1/x] Fix cross-project cache invalidation***

## Overview

Test and source target caching is improperly invalidated when generating mocks for targets outside of the current test target context. The caching issues are compounded when generating mocks for multiple projects in the same test target. This PR fixes the caching behavior for cross-project mocking setups.

## Test Plan

Validated that the test and source target caches are invalidated iff the inputs are changed.