### PR TITLE
[2/x] Fix optional members in Obj-C protocols

### DIFF
--- a/Mockingbird.xcodeproj/project.pbxproj
+++ b/Mockingbird.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		28843B2726AE710400AFB8DF /* MKBTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 28843B2526AE710400AFB8DF /* MKBTestUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		28843B2826AE710400AFB8DF /* MKBTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 28843B2626AE710400AFB8DF /* MKBTestUtils.m */; };
 		28843B2A26AE77E800AFB8DF /* InlinePropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28843B2926AE77E800AFB8DF /* InlinePropertyTests.swift */; };
+		288678E6279B9C25004FFB3D /* ObjCProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288678E5279B9C25004FFB3D /* ObjCProtocol.swift */; };
+		288678E8279B9C5E004FFB3D /* ObjectiveCProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288678E7279B9C5E004FFB3D /* ObjectiveCProtocolTests.swift */; };
 		28874F8B26BF12DD00097529 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 28874F8A26BF12DD00097529 /* ArgumentParser */; };
 		28874F8D26BF7AB000097529 /* Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28874F8C26BF7AB000097529 /* Configure.swift */; };
 		28874F8F26BF7C3C00097529 /* XcodeProjPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28874F8E26BF7C3C00097529 /* XcodeProjPath.swift */; };
@@ -645,6 +647,8 @@
 		28843B2526AE710400AFB8DF /* MKBTestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MKBTestUtils.h; sourceTree = "<group>"; };
 		28843B2626AE710400AFB8DF /* MKBTestUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MKBTestUtils.m; sourceTree = "<group>"; };
 		28843B2926AE77E800AFB8DF /* InlinePropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlinePropertyTests.swift; sourceTree = "<group>"; };
+		288678E5279B9C25004FFB3D /* ObjCProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCProtocol.swift; sourceTree = "<group>"; };
+		288678E7279B9C5E004FFB3D /* ObjectiveCProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCProtocolTests.swift; sourceTree = "<group>"; };
 		28874F8C26BF7AB000097529 /* Configure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configure.swift; sourceTree = "<group>"; };
 		28874F8E26BF7C3C00097529 /* XcodeProjPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeProjPath.swift; sourceTree = "<group>"; };
 		28874F9026BF7FA400097529 /* ValidatableArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatableArgument.swift; sourceTree = "<group>"; };
@@ -1562,6 +1566,7 @@
 				28A1F3C326ADD57C002F282D /* MinimalTestTypes.swift */,
 				OBJ_196 /* ModuleImportCases.swift */,
 				28D08CCF277477F700AE7C39 /* ObjCParameters.swift */,
+				288678E5279B9C25004FFB3D /* ObjCProtocol.swift */,
 				OBJ_198 /* OpaquelyInheritedTypes.swift */,
 				OBJ_199 /* Optionals.swift */,
 				OBJ_200 /* OverloadedMethods.swift */,
@@ -1745,6 +1750,7 @@
 				OBJ_261 /* LastSetValueStubTests.swift */,
 				28719AF426B23AB200C38C2C /* ObjectiveCTests.swift */,
 				28D08CD1277479B600AE7C39 /* ObjectiveCParameterTests.swift */,
+				288678E7279B9C5E004FFB3D /* ObjectiveCProtocolTests.swift */,
 				28D08CCD2774247C00AE7C39 /* OptionalsTests.swift */,
 				OBJ_262 /* OrderedVerificationTests.swift */,
 				OBJ_263 /* OverloadedMethodTests.swift */,
@@ -2555,6 +2561,7 @@
 				OBJ_1066 /* InitializerTests.swift in Sources */,
 				OBJ_1067 /* LastSetValueStubTests.swift in Sources */,
 				OBJ_1068 /* OrderedVerificationTests.swift in Sources */,
+				288678E8279B9C5E004FFB3D /* ObjectiveCProtocolTests.swift in Sources */,
 				OBJ_1069 /* OverloadedMethodTests.swift in Sources */,
 				OBJ_1070 /* SequentialValueStubbingTests.swift in Sources */,
 				OBJ_1071 /* StubbingTests.swift in Sources */,
@@ -2597,6 +2604,7 @@
 				OBJ_1136 /* Extensions.swift in Sources */,
 				OBJ_1137 /* ExternalModuleClassScopedTypes.swift in Sources */,
 				OBJ_1138 /* ExternalModuleImplicitlyImportedTypes.swift in Sources */,
+				288678E6279B9C25004FFB3D /* ObjCProtocol.swift in Sources */,
 				OBJ_1139 /* ExternalModuleTypealiasing.swift in Sources */,
 				5E45ADF7279DB9A9004AB972 /* AsyncMethods.swift in Sources */,
 				OBJ_1140 /* ExternalModuleTypes.swift in Sources */,

--- a/Mockingbird.xcodeproj/xcconfigs/MockingbirdFramework.xcconfig
+++ b/Mockingbird.xcodeproj/xcconfigs/MockingbirdFramework.xcconfig
@@ -9,6 +9,8 @@ TARGET_NAME = Mockingbird
 
 // Build Flags
 BUILD_LIBRARY_FOR_DISTRIBUTION = YES
+GCC_ENABLE_OBJC_EXCEPTIONS = YES
+GCC_WARN_SHADOW = YES
 
 // Linking
 OTHER_LDFLAGS = $(inherited) -framework XCTest

--- a/Mockingbird.xcodeproj/xcconfigs/MockingbirdGenerator.xcconfig
+++ b/Mockingbird.xcodeproj/xcconfigs/MockingbirdGenerator.xcconfig
@@ -1,7 +1,11 @@
 #include "FrameworkBase.xcconfig"
 
+// Identifiers
 INFOPLIST_FILE = $(SRCROOT)/Sources/MockingbirdGenerator/Info.plist
 SUPPORTED_PLATFORMS = macosx
 PRODUCT_MODULE_NAME = MockingbirdGenerator
 PRODUCT_NAME = MockingbirdGenerator
 TARGET_NAME = MockingbirdGenerator
+
+// Compatibility
+MACOSX_DEPLOYMENT_TARGET = 10.15

--- a/Sources/MockingbirdFramework/Mocking/Mocking.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mocking.swift
@@ -46,6 +46,7 @@ public func mock<T>(_ type: T.Type) -> T {
 /// ```
 ///
 /// - Parameter type: The type to mock.
+@_disfavoredOverload
 public func mock<T: NSObjectProtocol>(_ type: T.Type) -> T {
   return MKBTypeFacade.create(from: MKBMock(type))
 }
@@ -121,6 +122,7 @@ public func reset(_ staticMocks: Mock.Type...) {
 /// ```
 ///
 /// - Parameter mocks: A set of Objective-C mocks to reset.
+@_disfavoredOverload
 public func reset(_ mocks: NSObjectProtocol...) {
   mocks.forEach({ mock in
     clearInvocations(on: mock)
@@ -183,6 +185,7 @@ public func clearInvocations(on mocks: Mock.Type...) {
 /// ```
 ///
 /// - Parameter mocks: A set of Objective-C mocks to reset.
+@_disfavoredOverload
 public func clearInvocations(on mocks: NSObjectProtocol...) {
   mocks.forEach({ mock in
     guard let context = mock.mockingbirdContext else { return }
@@ -239,6 +242,7 @@ public func clearStubs(on mocks: Mock.Type...) {
 /// ```
 ///
 /// - Parameter mocks: A set of mocks to reset.
+@_disfavoredOverload
 public func clearStubs(on mocks: NSObjectProtocol...) {
   mocks.forEach({ mock in
     guard let context = mock.mockingbirdContext else { return }

--- a/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
+++ b/Sources/MockingbirdFramework/Objective-C/MKBConcreteMock.m
@@ -72,8 +72,8 @@
     case MKBInvocationRecorderModeNone: {
       id _Nullable returnValue =
         [self.mockingbirdContext.mocking
-         objcDidInvoke:objcInvocation evaluating:^id _Nullable(MKBObjCInvocation *invocation) {
-          return [self.mockingbirdContext.stubbing evaluateReturnValueFor:invocation];
+         objcDidInvoke:objcInvocation evaluating:^id _Nullable(MKBObjCInvocation *invo) {
+          return [self.mockingbirdContext.stubbing evaluateReturnValueFor:invo];
         }];
 
       if (returnValue == [MKBStubbingContext noImplementation]) {

--- a/Sources/MockingbirdFramework/Stubbing/InvocationForwarding.swift
+++ b/Sources/MockingbirdFramework/Stubbing/InvocationForwarding.swift
@@ -337,6 +337,7 @@ public extension NSObjectProtocol {
   /// ```
   ///
   /// - Returns: A partial mock using the superclass to handle invocations.
+  @_disfavoredOverload
   @discardableResult
   func forwardCallsToSuper() -> Self {
     mockingbirdContext?.proxy.addTarget(.super)
@@ -388,6 +389,7 @@ public extension NSObjectProtocol {
   ///
   /// - Parameter object: An object that should handle forwarded invocations.
   /// - Returns: A partial mock using `object` to handle invocations.
+  @_disfavoredOverload
   @discardableResult
   func forwardCalls<T>(to target: T) -> Self {
     mockingbirdContext?.proxy.addTarget(.object(target))

--- a/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -60,8 +60,11 @@ class MethodTemplate: Template {
                     isAsync: method.isAsync,
                     isThrowing: method.isThrowing,
                     isStatic: method.kind.typeScope.isStatic,
+                    isOptional: method.attributes.contains(.optional),
                     callMember: { scope in
-                      let scopedName = "\(scope).\(backticked: self.method.shortName)"
+                      let optionalPostfix = self.method.attributes.contains(.optional) ? "?" : ""
+                      let scopedName =
+                        "\(scope).\(backticked: self.method.shortName)\(optionalPostfix)"
                       guard self.method.isVariadic else {
                         return FunctionCallTemplate(
                           name: scopedName,

--- a/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -46,6 +46,7 @@ class SubscriptMethodTemplate: MethodTemplate {
                       isAsync: method.isAsync,
                       isThrowing: method.isThrowing,
                       isStatic: method.kind.typeScope.isStatic,
+                      isOptional: method.attributes.contains(.optional),
                       callMember: { scope in
                         return "\(scope)[\(separated: callArguments)]"
                       },
@@ -71,7 +72,13 @@ class SubscriptMethodTemplate: MethodTemplate {
                       isAsync: method.isAsync,
                       isThrowing: method.isThrowing,
                       isStatic: method.kind.typeScope.isStatic,
+                      isOptional: method.attributes.contains(.optional),
                       callMember: { scope in
+                        guard !self.method.attributes.contains(.optional) else {
+                          // Optional readwrite subscripts cannot be assigned to:
+                          // Cannot assign through subscript: 'object' is immutable
+                          return ""
+                        }
                         return "\(scope)[\(separated: callArguments)] = newValue"
                       },
                       invocationArguments: setterInvocationArguments).render())

--- a/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -74,6 +74,7 @@ class VariableTemplate: Template {
                       isAsync: false,
                       isThrowing: false,
                       isStatic: variable.kind.typeScope.isStatic,
+                      isOptional: variable.attributes.contains(.optional),
                       callMember: { scope in
                         return "\(scope).\(backticked: self.variable.name)"
                       },
@@ -90,7 +91,13 @@ class VariableTemplate: Template {
                       isAsync: false,
                       isThrowing: false,
                       isStatic: variable.kind.typeScope.isStatic,
+                      isOptional: variable.attributes.contains(.optional),
                       callMember: { scope in
+                        guard !self.variable.attributes.contains(.optional) else {
+                          // Optional readwrite properties cannot be assigned to:
+                          // `Cannot assign to property: 'object' is immutable`
+                          return ""
+                        }
                         return "\(scope).\(backticked: self.variable.name) = newValue"
                       },
                       invocationArguments: [(nil, "newValue")]).render())

--- a/Sources/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/TypeAttributes.swift
@@ -89,22 +89,23 @@ struct Attributes: OptionSet, Hashable {
   static let convenience = Attributes(rawValue: 1 << 5)
   static let override = Attributes(rawValue: 1 << 6)
   static let objcName = Attributes(rawValue: 1 << 7)
+  static let `optional` = Attributes(rawValue: 1 << 8)
   
   // MARK: Inferred attributes
-  static let constant = Attributes(rawValue: 1 << 8)
-  static let readonly = Attributes(rawValue: 1 << 9)
-  static let async = Attributes(rawValue: 1 << 10)
-  static let `throws` = Attributes(rawValue: 1 << 11)
-  static let `inout` = Attributes(rawValue: 1 << 12)
-  static let variadic = Attributes(rawValue: 1 << 13)
-  static let failable = Attributes(rawValue: 1 << 14)
-  static let unwrappedFailable = Attributes(rawValue: 1 << 15)
-  static let closure = Attributes(rawValue: 1 << 16)
-  static let escaping = Attributes(rawValue: 1 << 17)
-  static let autoclosure = Attributes(rawValue: 1 << 18)
+  static let constant = Attributes(rawValue: 1 << 9)
+  static let readonly = Attributes(rawValue: 1 << 10)
+  static let async = Attributes(rawValue: 1 << 11)
+  static let `throws` = Attributes(rawValue: 1 << 12)
+  static let `inout` = Attributes(rawValue: 1 << 13)
+  static let variadic = Attributes(rawValue: 1 << 14)
+  static let failable = Attributes(rawValue: 1 << 15)
+  static let unwrappedFailable = Attributes(rawValue: 1 << 16)
+  static let closure = Attributes(rawValue: 1 << 17)
+  static let escaping = Attributes(rawValue: 1 << 18)
+  static let autoclosure = Attributes(rawValue: 1 << 19)
   
   // MARK: Custom attributes
-  static let implicit = Attributes(rawValue: 1 << 19)
+  static let implicit = Attributes(rawValue: 1 << 20)
   
   static let attributesKey = "key.attributes"
   static let attributeKey = "key.attribute"
@@ -121,6 +122,7 @@ extension Attributes {
     case .convenience: self = .convenience
     case .override: self = .override
     case .objcName: self = .objcName
+    case .`optional`: self = .`optional`
     default: return nil
     }
   }

--- a/Sources/MockingbirdTestsHost/ObjCProtocol.swift
+++ b/Sources/MockingbirdTestsHost/ObjCProtocol.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@objc protocol ObjCProtocol: Foundation.NSObjectProtocol {
+  @objc func trivial()
+  @objc func parameterizedReturning(param: String) -> Bool
+  
+  @objc var property: Bool { get }
+  @objc var readwriteProperty: Bool { get set }
+  
+  // It’s possible to define Obj-C protocols with overloaded subscript requirements, but it can
+  // never be implemented in Swift as the compiler will complain about the conflicting selectors.
+  // @objc subscript(param: Int) -> Int { get set }
+  
+  // MARK: Optional
+  
+  @objc optional func optionalTrivial()
+  @objc optional func optionalParameterizedReturning(param: String) -> Bool
+  
+  @objc optional var optionalProperty: Bool { get }
+  @objc optional var optionalReadwriteProperty: Bool { get set }
+  
+  @objc optional subscript(param: Int) -> Bool { get set }
+}

--- a/Tests/MockingbirdTests/Framework/ObjectiveCProtocolTests.swift
+++ b/Tests/MockingbirdTests/Framework/ObjectiveCProtocolTests.swift
@@ -1,0 +1,202 @@
+import Mockingbird
+@testable import MockingbirdTestsHost
+import XCTest
+
+class ObjectiveCProtocolTests: BaseTestCase {
+  
+  var protocolMock: ObjCProtocolMock!
+  var protocolInstance: ObjCProtocol { protocolMock }
+  
+  var protocolFake = ObjCProtocolFake()
+  
+  class ObjCProtocolFake: Foundation.NSObject, ObjCProtocol {
+    func trivial() {}
+    func parameterizedReturning(param: String) -> Bool { true }
+    
+    var property: Bool { true }
+    var readwriteProperty: Bool = true
+    
+    func optionalTrivial() {}
+    func optionalParameterizedReturning(param: String) -> Bool { true }
+    
+    var optionalProperty: Bool { true }
+    var optionalReadwriteProperty: Bool = true
+    
+    subscript(param: Int) -> Bool {
+      get { true }
+      set {}
+    }
+  }
+  
+  override func setUpWithError() throws {
+    self.protocolMock = mock(ObjCProtocol.self).initialize()
+  }
+  
+  
+  // MARK: - Resetting
+  
+  func testResetMock() {
+    protocolInstance.trivial()
+    reset(protocolMock)
+    verify(protocolMock.trivial()).wasNeverCalled()
+  }
+  
+  func testClearStubs() {
+    given(protocolInstance.parameterizedReturning(param: any())).willReturn(true)
+    clearStubs(on: protocolMock)
+    shouldFail {
+      _ = protocolInstance.parameterizedReturning(param: "foobar")
+    }
+  }
+  
+  func testClearInvocations() {
+    protocolInstance.trivial()
+    clearInvocations(on: protocolMock)
+    verify(protocolMock.trivial()).wasNeverCalled()
+  }
+  
+  
+  // MARK: - Concrete stubs
+  
+  func testTrivial() {
+    given(protocolMock.trivial()).willReturn()
+    protocolInstance.trivial()
+    verify(protocolMock.trivial()).wasCalled()
+  }
+  func testOptionalTrivial() {
+    given(protocolMock.optionalTrivial()).willReturn()
+    protocolInstance.optionalTrivial?()
+    verify(protocolMock.optionalTrivial()).wasCalled()
+  }
+  
+  func testParameterized() {
+    given(protocolMock.parameterizedReturning(param: any())).willReturn(true)
+    XCTAssertTrue(protocolInstance.parameterizedReturning(param: "foobar"))
+    verify(protocolMock.parameterizedReturning(param: any())).wasCalled()
+  }
+  func testOptionalParameterized() {
+    given(protocolMock.optionalParameterizedReturning(param: any())).willReturn(true)
+    XCTAssertTrue(protocolInstance.optionalParameterizedReturning?(param: "foobar") ?? false)
+    verify(protocolMock.optionalParameterizedReturning(param: any())).wasCalled()
+  }
+  
+  func testPropertyGetter() {
+    given(protocolMock.property).willReturn(true)
+    XCTAssertTrue(protocolInstance.property)
+    verify(protocolMock.property).wasCalled()
+  }
+  func testOptionalPropertyGetter() {
+    given(protocolMock.optionalProperty).willReturn(true)
+    XCTAssertTrue(protocolInstance.optionalProperty ?? false)
+    verify(protocolMock.optionalProperty).wasCalled()
+  }
+  
+  func testPropertySetter() {
+    let expectation = expectation(description: "setter was called")
+    given(protocolMock.readwriteProperty = any()).will { (_: Bool) in expectation.fulfill() }
+    protocolInstance.readwriteProperty = true
+    verify(protocolMock.readwriteProperty = any()).wasCalled()
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testOptionalSubscriptGetter() {
+    given(protocolMock[any()]).willReturn(true)
+    XCTAssertTrue(protocolInstance[1] ?? false)
+    verify(protocolMock[any()]).wasCalled()
+  }
+  
+  
+  // MARK: - Object partial mock
+  
+  func testTrivialGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    protocolInstance.trivial()
+    verify(protocolMock.trivial()).wasCalled()
+  }
+  func testTrivialLocalForwarding() {
+    given(protocolMock.trivial()).willForward(to: protocolFake)
+    protocolInstance.trivial()
+    verify(protocolMock.trivial()).wasCalled()
+  }
+  
+  func testParameterizedGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    XCTAssertTrue(protocolInstance.parameterizedReturning(param: "foobar"))
+    verify(protocolMock.parameterizedReturning(param: any())).wasCalled()
+  }
+  func testParameterizedLocalForwarding() {
+    given(protocolMock.parameterizedReturning(param: any())).willForward(to: protocolFake)
+    XCTAssertTrue(protocolInstance.parameterizedReturning(param: "foobar"))
+    verify(protocolMock.parameterizedReturning(param: any())).wasCalled()
+  }
+  
+  func testPropertyGetterGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    XCTAssertTrue(protocolInstance.property)
+    verify(protocolMock.property).wasCalled()
+  }
+  func testPropertyGetterLocalForwarding() {
+    given(protocolMock.property).willForward(to: protocolFake)
+    XCTAssertTrue(protocolInstance.property)
+    verify(protocolMock.property).wasCalled()
+  }
+  
+  func testPropertySetterGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    let instance = protocolMock as ObjCProtocol
+    instance.readwriteProperty = true
+    verify(protocolMock.readwriteProperty = any()).wasCalled()
+  }
+  func testPropertySetterLocalForwarding() {
+    given(protocolMock.readwriteProperty = any()).willForward(to: protocolFake)
+    let instance = protocolMock as ObjCProtocol
+    instance.readwriteProperty = true
+    verify(protocolMock.readwriteProperty = any()).wasCalled()
+  }
+  
+  // MARK: Optionals
+  
+  func testOptionalTrivialGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    protocolInstance.optionalTrivial?()
+    verify(protocolMock.optionalTrivial()).wasCalled()
+  }
+  func testOptionalTrivialLocalForwarding() {
+    given(protocolMock.optionalTrivial()).willForward(to: protocolFake)
+    protocolInstance.optionalTrivial?()
+    verify(protocolMock.optionalTrivial()).wasCalled()
+  }
+  
+  func testOptionalParameterizedGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    XCTAssertTrue(protocolInstance.optionalParameterizedReturning?(param: "foobar") ?? false)
+    verify(protocolMock.optionalParameterizedReturning(param: any())).wasCalled()
+  }
+  func testOptionalParameterizedLocalForwarding() {
+    given(protocolMock.optionalParameterizedReturning(param: any())).willForward(to: protocolFake)
+    XCTAssertTrue(protocolInstance.optionalParameterizedReturning?(param: "foobar") ?? false)
+    verify(protocolMock.optionalParameterizedReturning(param: any())).wasCalled()
+  }
+  
+  func testOptionalPropertyGetterGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    XCTAssertTrue(protocolInstance.optionalProperty ?? false)
+    verify(protocolMock.optionalProperty).wasCalled()
+  }
+  func testOptionalPropertyGetterLocalForwarding() {
+    given(protocolMock.optionalProperty).willForward(to: protocolFake)
+    XCTAssertTrue(protocolInstance.optionalProperty ?? false)
+    verify(protocolMock.optionalProperty).wasCalled()
+  }
+  
+  func testOptionalSubscriptGetterGlobalForwarding() {
+    protocolMock.forwardCalls(to: protocolFake)
+    XCTAssertTrue(protocolInstance[1] ?? false)
+    verify(protocolMock[any()]).wasCalled()
+  }
+  func testOptionalSubscriptGetterLocalForwarding() {
+    given(protocolMock[any()]).willForward(to: protocolFake)
+    XCTAssertTrue(protocolInstance[1] ?? false)
+    verify(protocolMock[any()]).wasCalled()
+  }
+}

--- a/Tests/MockingbirdTests/Framework/Utilities/BaseTestCase.swift
+++ b/Tests/MockingbirdTests/Framework/Utilities/BaseTestCase.swift
@@ -6,7 +6,7 @@ class BaseTestCase: XCTestCase {
   
   func shouldFail(_ times: Int = 1,
                   file: String = #file, line: Int = #line,
-                  _ context: @escaping () -> Void) {
+                  @_implicitSelfCapture _ context: @escaping () -> Void) {
     let testFailer = XFailTestFailer(testCase: self, file: file, line: line)
     swizzleTestFailer(testFailer)
     


### PR DESCRIPTION
## Stack

📚 #279 ***← [2/x] Fix optional members in Obj-C protocols***
📚 #278 [1/x] Fix cross-project cache invalidation

## Overview

Generating Swift mocks for Objective-C annotated protocols with optional members regressed in 0.18 due to invocation forwarding for partial mocks. This PR allows the generator to explicitly handle optional members and improves the overall Objective-C compatibility.

## Test Plan

Added an additional test case for Objective-C protocols.