### PR TITLE
[1/y] Add backwards compatibility with Swift 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,23 @@
 name: CI
 
 on: [push, pull_request]
-env:
-  DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
 
 jobs:
   test-e2e:
-    name: Test E2E
+    name: Test E2E (Xcode ${{ matrix.xcode }})
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        xcode:
+        - '13.1' # Swift 5.5
+        - '13.2' # Swift 5.5.2
     steps:
     - uses: actions/checkout@v2
     - name: Set Up Project
       run: Sources/MockingbirdAutomationCli/buildAndRun.sh configure load --overwrite
     - name: Test
+      env:
+        DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
       run: Sources/MockingbirdAutomationCli/buildAndRun.sh test e2e
 
   test-example-project:
@@ -30,6 +35,7 @@ jobs:
     - name: Test
       env:
         GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       run: Sources/MockingbirdAutomationCli/buildAndRun.sh test example ${{ matrix.type }}
 
   test-cli-launcher:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     - 'release-*'
     tags:
     - '*'
+
 env:
   DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
 

--- a/Sources/MockingbirdFramework/Mocking/MockingContext.swift
+++ b/Sources/MockingbirdFramework/Mocking/MockingContext.swift
@@ -20,6 +20,14 @@ import Foundation
     return try thunk(invocation)
   }
   
+  /// Invoke a non-throwing thunk.
+  func didInvoke<T, I: Invocation>(_ invocation: I, evaluating thunk: (I) -> T) -> T {
+    // Ensures that the thunk is evaluated prior to recording the invocation.
+    defer { didInvoke(invocation) }
+    return thunk(invocation)
+  }
+  
+#if swift(>=5.5.2)
   /// Invoke an async thunk that can throw.
   @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func didInvoke<T, I: Invocation>(_ invocation: I,
@@ -29,13 +37,6 @@ import Foundation
     return try await thunk(invocation)
   }
   
-  /// Invoke a non-throwing thunk.
-  func didInvoke<T, I: Invocation>(_ invocation: I, evaluating thunk: (I) -> T) -> T {
-    // Ensures that the thunk is evaluated prior to recording the invocation.
-    defer { didInvoke(invocation) }
-    return thunk(invocation)
-  }
-  
   /// Invoke an async non-throwing thunk.
   @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func didInvoke<T, I: Invocation>(_ invocation: I, evaluating thunk: (I) async -> T) async -> T {
@@ -43,6 +44,7 @@ import Foundation
     defer { didInvoke(invocation) }
     return await thunk(invocation)
   }
+#endif
   
   /// Invoke a thunk from Objective-C.
   @objc public func objcDidInvoke(_ invocation: ObjCInvocation,

--- a/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
+++ b/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
@@ -296,15 +296,16 @@ public class StubbingManager<DeclarationType: Declaration, InvocationType, Retur
   /// - Returns: The current stubbing manager which can be used to chain additional stubs.
   @discardableResult
   public func willReturn(_ value: ReturnType) -> Self {
+#if swift(>=5.5.2)
     if isAsync {
       if isThrowing {
         return addImplementation({ () async throws in value })
       } else {
         return addImplementation({ () async in value })
       }
-    } else {
-      return addImplementation({ value })
     }
+#endif
+    return addImplementation({ value })
   }
   
   /// Stub a mocked method or property with an implementation provider.
@@ -497,15 +498,17 @@ public func ~> <DeclarationType: Declaration, InvocationType, ReturnType>(
   manager: StaticStubbingManager<DeclarationType, InvocationType, ReturnType>,
   implementation: @escaping @autoclosure () -> ReturnType
 ) {
+#if swift(>=5.5.2)
   if manager.isAsync {
     if manager.isThrowing {
       manager.addImplementation({ () async throws in implementation() })
     } else {
       manager.addImplementation({ () async in implementation() })
     }
-  } else {
-    manager.addImplementation({ implementation() })
+    return
   }
+#endif
+  manager.addImplementation({ implementation() })
 }
 
 /// Stub a mocked method or property with a closure implementation.

--- a/Sources/MockingbirdTestsHost/AsyncMethods.swift
+++ b/Sources/MockingbirdTestsHost/AsyncMethods.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if swift(>=5.5.2)
 protocol AsyncProtocol {  
   @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func asyncMethodVoid() async
@@ -19,3 +20,4 @@ protocol AsyncProtocol {
   @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func asyncClosureThrowingMethod(block: () async throws -> Bool) async throws -> Bool
 }
+#endif

--- a/Tests/MockingbirdTests/Framework/StubbingAsyncTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingAsyncTests.swift
@@ -3,6 +3,7 @@ import Mockingbird
 @testable import MockingbirdTestsHost
 import XCTest
 
+#if swift(>=5.5.2)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension XCTest {
   func XCTAssertThrowsAsyncError<T: Sendable>(
@@ -109,3 +110,4 @@ class StubbingAsyncTests: BaseTestCase {
   }
   
 }
+#endif


### PR DESCRIPTION
## Stack

📚 #287 [5/y] Improve static mocking APIs
📚 #286 [4/y] Enable mocking sources in test bundles
📚 #285 [3/y] Fix read-only subscripts
📚 #284 [2/y] Fix warnings in throwing initializers
📚 #283 ***← [1/y] Add backwards compatibility with Swift 5.5***

## Overview

Adding support for concurrency implicitly increased our minimum Swift target to 5.5.2. Trying to consume the framework on an older toolchain like Xcode 13.1 (Swift 5.5) would fail to compile. I wrapped all async/await testing interfaces in `#if swift(>=5.5.2)` compilation conditions. Technically we could target Swift 5.5 for concurrency which has different platform targets (no support for older OSes), but this increases the complexity of both the framework interface and the testing matrix we need to use without much benefit.

## Test Plan

Added CI tests that run on Xcode 13.1 (Swift 5.5) and Xcode 13.2 (Swift 5.5.2).