### PR TITLE
[2/y] Fix warnings in throwing initializers

### DIFF
--- a/Mockingbird.xcodeproj/xcconfigs/MockingbirdTests.xcconfig
+++ b/Mockingbird.xcodeproj/xcconfigs/MockingbirdTests.xcconfig
@@ -4,3 +4,6 @@
 PRODUCT_MODULE_NAME = MockingbirdTests
 PRODUCT_NAME = MockingbirdTests
 TARGET_NAME = MockingbirdTests
+
+// Build flags
+SWIFT_TREAT_WARNINGS_AS_ERRORS = YES

--- a/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/InitializerMethodTemplate.swift
@@ -37,8 +37,7 @@ class InitializerMethodTemplate: MethodTemplate {
     let trivia = "// MARK: Mocked \(fullNameForMocking)"
     let declaration = "public \(overridableModifiers)\(uniqueDeclaration)"
     lazy var didInvoke = FunctionCallTemplate(name: "self.mockingbirdContext.mocking.didInvoke",
-                                              unlabeledArguments: [mockableInvocation],
-                                              isThrowing: method.attributes.contains(.throws)).render()
+                                              unlabeledArguments: [mockableInvocation]).render()
     
     if isClassBound {
       // Class-defined initializer, called from an `InitializerProxy`.
@@ -89,6 +88,6 @@ class InitializerMethodTemplate: MethodTemplate {
   }()
   
   override var overridableUniqueDeclaration: String {
-    return "\(fullNameForMocking)\(returnTypeAttributesForMocking)\(genericConstraints) "
+    return fullNameForMocking + returnTypeAttributesForMocking + genericConstraints
   }
 }

--- a/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -88,7 +88,9 @@ class MethodTemplate: Template {
       "// MARK: Mocked \(fullNameForMocking)",
       FunctionDefinitionTemplate(attributes: method.attributes.safeDeclarations,
                                  declaration: declaration,
-                                 genericConstraints: method.whereClauses.map({ context.specializeTypeName("\($0)") }),
+                                 genericConstraints: method.whereClauses.map({
+                                   context.specializeTypeName("\($0)")
+                                 }),
                                  body: body).render(),
     ])
   }
@@ -108,7 +110,7 @@ class MethodTemplate: Template {
   
   /// Methods synthesized specifically for the stubbing and verification APIs.
   var synthesizedDeclarations: String {
-    let invocationType = "(\(separated: matchableParameterTypes)) \(returnTypeAttributesForMatching)-> \(matchableReturnType)"
+    let invocationType = "(\(separated: matchableParameterTypes))\(returnTypeAttributesForMatching) -> \(matchableReturnType)"
     
     var methods = [String]()
     let genericTypes = [declarationTypeForMocking, invocationType, matchableReturnType]
@@ -361,10 +363,10 @@ class MethodTemplate: Template {
   }()
   
   lazy var returnTypeAttributesForMatching: String = {
-    var returnType = ""
-    if method.isAsync { returnType += "async " }
-    if method.isThrowing { returnType += "throws " }
-    return returnType
+    var attributes = ""
+    if method.isAsync { attributes += " async" }
+    if method.isThrowing { attributes += " throws" }
+    return attributes
   }()
   
   lazy var declarationTypeForMocking: String = {

--- a/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
@@ -94,7 +94,9 @@ class ThunkTemplate: Template {
         return \(FunctionCallTemplate(
                   name: "Mockingbird.dynamicCast",
                   unlabeledArguments: [
-                    FunctionCallTemplate(name: "mkbImpl", isAsync: isAsync, isThrowing: isThrowing).render()
+                    FunctionCallTemplate(name: "mkbImpl",
+                                         isAsync: isAsync,
+                                         isThrowing: isThrowing).render()
                   ])) as \(returnType)
         """).render()
     }()


### PR DESCRIPTION
## Stack

📚 #287 [5/y] Improve static mocking APIs
📚 #286 [4/y] Enable mocking sources in test bundles
📚 #285 [3/y] Fix read-only subscripts
📚 #284 ***← [2/y] Fix warnings in throwing initializers***
📚 #283 [1/y] Add backwards compatibility with Swift 5.5

## Overview

Fixes compile-time warnings in mocked initializer declarations like the one below:

`No calls to throwing functions occur within 'try' expression`

## Test Plan

Enabled “treat warnings as errors” on the tests target so that the CI can catch regressions in generator warnings.