### PR TITLE
[3/y] Fix read-only subscripts

### DIFF
--- a/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -76,12 +76,16 @@ class SubscriptMethodTemplate: MethodTemplate {
                       },
                       invocationArguments: setterInvocationArguments).render())
     
+    let accessors = method.attributes.contains(.readonly) ? [getterDefinition.render()] : [
+      getterDefinition.render(),
+      setterDefinition.render(),
+    ]
+    
     return String(lines: [
       "// MARK: Mocked \(fullNameForMocking)",
       VariableDefinitionTemplate(attributes: method.attributes.safeDeclarations,
                                  declaration: "public \(overridableModifiers)\(uniqueDeclaration)",
-                                 body: String(lines: [getterDefinition.render(),
-                                                      setterDefinition.render()])).render(),
+                                 body: String(lines: accessors)).render(),
     ])
   }
   

--- a/Sources/MockingbirdTestsHost/Subscripts.swift
+++ b/Sources/MockingbirdTestsHost/Subscripts.swift
@@ -4,7 +4,7 @@ protocol SubscriptedProtocol {
   subscript(index: Int) -> String { get set }
   subscript(index: Int) -> Bool { get set } // Overloaded parameter type
   subscript(index: String) -> String { get set } // Overloaded return type
-  subscript(index: Int) -> Int { get } // Only getter
+  subscript(object: AnyObject) -> Int { get } // Only getter
   subscript(row: Int, column: Int) -> String { get set } // Multiple parameters
   subscript(indexes: String...) -> String { get set } // Variadic parameter
   subscript<IndexType: Equatable, ReturnType: Hashable>(index: IndexType) -> ReturnType { get set }
@@ -29,8 +29,14 @@ class SubscriptedClass {
   }
   
   // Only getter
-  subscript(index: Int) -> Int {
+  subscript(object: AnyObject) -> Int {
     get { fatalError() }
+  }
+  
+  // Private setter
+  private(set) subscript(object: NSObject) -> Int {
+    get { fatalError() }
+    set { fatalError() }
   }
   
   // Multiple parameters

--- a/Tests/MockingbirdTests/Framework/SubscriptTests.swift
+++ b/Tests/MockingbirdTests/Framework/SubscriptTests.swift
@@ -15,25 +15,28 @@ class SubscriptTests: BaseTestCase {
     classMock = mock(SubscriptedClass.self)
   }
   
+  private class MyObject {}
+  
   // MARK: - Protocol mock
   
   // MARK: Getter
   
   func testSubscriptProtocol_handlesBasicSingleParameterGetter() {
+    let object = MyObject()
     given(protocolMock.getSubscript(42)) ~> "bar"
     given(protocolMock.getSubscript(42)) ~> true
     given(protocolMock.getSubscript("foo")) ~> "bar"
-    given(protocolMock.getSubscript(42)) ~> 99
+    given(protocolMock.getSubscript(object)) ~> 99
     
     XCTAssertEqual(protocolInstance[42], "bar")
     XCTAssertEqual(protocolInstance[42], true)
     XCTAssertEqual(protocolInstance["foo"], "bar")
-    XCTAssertEqual(protocolInstance[42], 99)
+    XCTAssertEqual(protocolInstance[object], 99)
     
     verify(protocolMock.getSubscript(42)).returning(String.self).wasCalled()
     verify(protocolMock.getSubscript(42)).returning(Bool.self).wasCalled()
     verify(protocolMock.getSubscript("foo")).returning(String.self).wasCalled()
-    verify(protocolMock.getSubscript(42)).returning(Int.self).wasCalled()
+    verify(protocolMock.getSubscript(object)).returning(Int.self).wasCalled()
   }
   
   func testSubscriptProtocol_handlesMultipleParameterGetter() {
@@ -109,20 +112,21 @@ class SubscriptTests: BaseTestCase {
   // MARK: - Class mock
   
   func testSubscriptClass_handlesBasicSingleParameterCalls() {
+    let object = MyObject()
     given(classMock.getSubscript(42)) ~> "bar"
     given(classMock.getSubscript(42)) ~> true
     given(classMock.getSubscript("foo")) ~> "bar"
-    given(classMock.getSubscript(42)) ~> 99
+    given(classMock.getSubscript(object)) ~> 99
     
     XCTAssertEqual(classInstance[42], "bar")
     XCTAssertEqual(classInstance[42], true)
     XCTAssertEqual(classInstance["foo"], "bar")
-    XCTAssertEqual(classInstance[42], 99)
+    XCTAssertEqual(classInstance[object], 99)
     
     verify(classMock.getSubscript(42)).returning(String.self).wasCalled()
     verify(classMock.getSubscript(42)).returning(Bool.self).wasCalled()
     verify(classMock.getSubscript("foo")).returning(String.self).wasCalled()
-    verify(classMock.getSubscript(42)).returning(Int.self).wasCalled()
+    verify(classMock.getSubscript(object)).returning(Int.self).wasCalled()
   }
   
   func testSubscriptClass_handlesMultipleParameterCalls() {


### PR DESCRIPTION
## Stack

📚 #287 [5/y] Improve static mocking APIs
📚 #286 [4/y] Enable mocking sources in test bundles
📚 #285 ***← [3/y] Fix read-only subscripts***
📚 #284 [2/y] Fix warnings in throwing initializers
📚 #283 [1/y] Add backwards compatibility with Swift 5.5

## Overview

Read-only subscripts were incorrectly generating setter thunks which weren’t caught by the test suite due to the generic `Equatable` overload. This adds the `readonly` attribute as needed when parsing subscript methods using similar logic as properties.

Closes #281

## Test Plan

Fixed read-only subscript tests and added an additional case for setters marked as (file)private.