### PR TITLE
[4/y] Enable mocking sources in test bundles

### DIFF
--- a/Sources/MockingbirdCli/main.swift
+++ b/Sources/MockingbirdCli/main.swift
@@ -1,10 +1,16 @@
 import Foundation
 import MockingbirdGenerator
 
-do {
+func main() -> Int32 {
   defer { flushLogs() }
-  var command = try Mockingbird.parseAsRoot()
-  try command.run()
-} catch {
-  Mockingbird.exit(withError: error)
+  do {
+    var command = try Mockingbird.parseAsRoot()
+    try command.run()
+    return 0
+  } catch {
+    logError(error)
+    return 1
+  }
 }
+
+exit(main())

--- a/Sources/MockingbirdGenerator/Parser/Operations/ExtractSourcesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/ExtractSourcesOperation.swift
@@ -84,6 +84,7 @@ public class ExtractSourcesOperation<T: Target>: BasicOperation, ExtractSourcesA
     
     let moduleName = resolveProductModuleName(for: target)
     let paths = target.findSourceFilePaths(sourceRoot: sourceRoot)
+      .filter({ !$0.string.hasSuffix(".generated.swift") })
       .map({ SourcePath(path: $0, moduleName: moduleName) })
     
     let includedPaths = includedSourcePaths(for: Set(paths))

--- a/Sources/MockingbirdGenerator/Parser/Operations/FindMockedTypesOperation.swift
+++ b/Sources/MockingbirdGenerator/Parser/Operations/FindMockedTypesOperation.swift
@@ -36,7 +36,6 @@ public class FindMockedTypesOperation: BasicOperation {
       }
       
       let operations = extractSourcesResult.targetPaths
-        .filter({ "\($0.path)".hasSuffix(".generated.swift") == false })
         .map({ sourcePath -> ParseTestFileOperation in
           let operation = ParseTestFileOperation(
             sourcePath: sourcePath,

--- a/Sources/MockingbirdGenerator/Utilities/Log.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Log.swift
@@ -100,13 +100,13 @@ public func log(_ message: @escaping @autoclosure () -> String,
   }
 }
 
-/// Convenience for logging a `.info` message type.
+/// Log an informational message.
 public func logInfo(_ message: @escaping @autoclosure () -> String,
                     output: UnsafeMutablePointer<FILE>? = nil) {
   log(message(), type: .info, output: output)
 }
 
-/// Convenience for logging a `.warn` message type.
+/// Log a warning message.
 public func logWarning(_ message: @escaping @autoclosure () -> String,
                        diagnostic: DiagnosticType? = nil,
                        output: UnsafeMutablePointer<FILE>? = nil,
@@ -120,16 +120,33 @@ public func logWarning(_ message: @escaping @autoclosure () -> String,
       line: line())
 }
 
-/// Convenience for logging an `.error` message type.
-public func log(_ error: Error,
-                diagnostic: DiagnosticType? = nil,
-                output: UnsafeMutablePointer<FILE>? = nil,
-                filePath: Path? = nil,
-                line: @escaping @autoclosure () -> Int? = nil) {
-  log("\(error)",
+/// Log an error message.
+public func logError(_ message: String,
+                     diagnostic: DiagnosticType? = nil,
+                     output: UnsafeMutablePointer<FILE>? = nil,
+                     filePath: Path? = nil,
+                     line: @escaping @autoclosure () -> Int? = nil) {
+  log(message,
       type: .error,
       diagnostic: diagnostic,
       output: output,
       filePath: filePath,
       line: line())
+}
+
+/// Convenience for logging an error.
+public func logError(_ error: Error,
+                     diagnostic: DiagnosticType? = nil,
+                     output: UnsafeMutablePointer<FILE>? = nil,
+                     filePath: Path? = nil,
+                     line: @escaping @autoclosure () -> Int? = nil) {
+  let localizedDescription: String = {
+    guard let localizedError = error as? LocalizedError else { return "\(error)" }
+    return localizedError.localizedDescription
+  }()
+  logError(localizedDescription,
+           diagnostic: diagnostic,
+           output: output,
+           filePath: filePath,
+           line: line())
 }

--- a/Sources/MockingbirdGenerator/Utilities/Path+WriteUtf8Strings.swift
+++ b/Sources/MockingbirdGenerator/Utilities/Path+WriteUtf8Strings.swift
@@ -1,12 +1,12 @@
 import Foundation
 import PathKit
 
-enum WriteUtf8StringFailure: Error, CustomStringConvertible {
+enum WriteUtf8StringFailure: Error, LocalizedError {
   case streamCreationFailure(path: Path)
   case dataEncodingFailure
   case streamWritingFailure(error: Error?)
   
-  var description: String {
+  var errorDescription: String? {
     switch self {
     case .streamCreationFailure(let path): return "Unable to create output stream to \(path)"
     case .dataEncodingFailure: return "Unable to encode data to UTF8"


### PR DESCRIPTION
## Stack

📚 #287 [5/y] Improve static mocking APIs
📚 #286 ***← [4/y] Enable mocking sources in test bundles***
📚 #285 [3/y] Fix read-only subscripts
📚 #284 [2/y] Fix warnings in throwing initializers
📚 #283 [1/y] Add backwards compatibility with Swift 5.5

## Overview

It’s uncommon, but possible, to need to mock types defined in a test bundle. For example, one use case is supplying a common set of default implementations for partial mocking. A non-typical case is mocking types in test bundle A and using them in test bundle B, which is straightforward to set up in SwiftPM / JSON project descriptions but not so much with an Xcode project.

To simplify the automatic setup process and reduce potential user errors, the configurator will continue to validate that the configuration target is a test bundle and each source target is not a test bundle. Advanced users can modify the build phase manually to bypass this as needed.

## Test Plan

Ran the generator against the `MockingbirdTests` target with various thunk pruning levels.