### PR TITLE
[5/y] Improve static mocking APIs

### DIFF
--- a/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Mocking.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Mocking.md
@@ -52,6 +52,28 @@ clearStubs(on: bird)        // Only remove stubs
 clearInvocations(on: bird)  // Only remove recorded invocations
 ```
 
+### Mock Static Members
+
+Just like instances of generated mocks, the mock types themselves can be used as test doubles.
+
+```swift
+protocol Bird {
+  static var species: String { get }
+}
+
+// Use `type(of: mock(…))` so that the mock is generated
+let birdType: BirdMock.Type = type(of: mock(Bird.self))
+print(birdType is Bird.self)  // Prints "true"
+```
+
+The state of static methods and properties persists between tests, so you must reset the mock before stubbing or verifying static members.
+
+```swift
+func setUp() {
+  reset(type(of: mock(Bird.self)))
+}
+```
+
 ## Topics
 
 ### Creating a Mock
@@ -61,9 +83,12 @@ clearInvocations(on: bird)  // Only remove recorded invocations
 ### Resetting State
 
 - ``/documentation/Mockingbird/reset(_:)-2rnp3``
+- ``/documentation/Mockingbird/reset(_:)-7v6hg``
 - ``/documentation/Mockingbird/reset(_:)-1qqcc``
 - ``/documentation/Mockingbird/clearInvocations(on:)-9e90o``
+- ``/documentation/Mockingbird/clearInvocations(on:)-24p8c``
 - ``/documentation/Mockingbird/clearInvocations(on:)-1wkme``
 - ``/documentation/Mockingbird/clearStubs(on:)-3qkw6``
+- ``/documentation/Mockingbird/clearStubs(on:)-4b0ra``
 - ``/documentation/Mockingbird/clearStubs(on:)-23b4v``
 - ``clearDefaultValues(on:)``

--- a/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Stubbing.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Stubbing.md
@@ -77,6 +77,30 @@ bird.name = "Ryan"
 print(bird.name)  // Prints "Ryan"
 ```
 
+### Stub Async Methods
+
+Use the `await` keyword to stub asynchronous methods.
+
+```swift
+protocol Bird {
+  func fetchMessage() async -> String
+}
+given(await bird.fetchMessage()).willReturn("Hello")
+```
+
+### Stub Static Members
+
+Static methods and properties can be stubbed in the same way as instance members. Make sure to reset the mock type before each test run. See <doc:Mocking#Mock-Static-Members> for additional guidance.
+
+```swift
+protocol Bird {
+  static var species: String { get }
+}
+let birdType = type(of: mock(Bird.self))
+given(birdType.species).willReturn("Mimus polyglottos")
+print(birdType.species)  // Prints "Mimus polyglottos"
+```
+
 ### Stub as a Relaxed Mock
 
 Use a `ValueProvider` to create a relaxed mock that returns default values for unstubbed methods. Mockingbird provides preset value providers which are guaranteed to be backwards compatible, such as `.standardProvider`.

--- a/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Verification.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Essentials/Verification.md
@@ -36,6 +36,29 @@ verify(bird.name).wasCalled()
 verify(bird.name = any()).wasCalled()
 ```
 
+### Verify Async Methods
+
+Use the `await` keyword to verify asynchronous methods.
+
+```swift
+protocol Bird {
+  func fetchMessage() async -> String
+}
+verify(await bird.fetchMessage()).wasCalled()
+```
+
+### Verify Static Members
+
+Static methods and properties can be verified in the same way as instance members. Make sure to reset the mock type before each test run. See <doc:Mocking#Mock-Static-Members> for additional guidance.
+
+```swift
+protocol Bird {
+  static var species: String { get }
+}
+let birdType = type(of: mock(Bird.self))
+verify(birdType.species).wasCalled()
+```
+
 ### Verify the Number of Invocations
 
 It’s possible to verify that an invocation was called a specific number of times with a count matcher.
@@ -105,7 +128,7 @@ eventually {
   verify(bird.fly()).wasCalled()
 }
 
-waitForExpectations(timeout: 1.0)
+waitForExpectations(timeout: 1)
 ```
 
 ### Verify Overloaded Methods
@@ -114,12 +137,14 @@ Use the `returning` modifier to disambiguate methods overloaded by return type. 
 
 ```swift
 protocol Bird {
-  func getMessage<T>() -> T    // Overloaded generically
-  func getMessage() -> String  // Overloaded explicitly
-  func getMessage() -> Data
+  func fetchMessage<T>() -> T    // Overloaded generically
+  func fetchMessage() -> String  // Overloaded explicitly
+  func fetchMessage() -> Data
 }
 
-verify(bird.getMessage()).returning(String.self).wasCalled()
+verify(bird.fetchMessage())
+  .returning(String.self)
+  .wasCalled()
 ```
 
 ## Topics
@@ -145,4 +170,3 @@ verify(bird.getMessage()).returning(String.self).wasCalled()
 
 - ``ArgumentCaptor``
 - ``inOrder(with:file:line:_:)``
-- ``eventually(_:_:)``

--- a/Sources/Documentation/Mockingbird.docc/Pages/Meta/Feature-Comparison.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Meta/Feature-Comparison.md
@@ -25,10 +25,11 @@ Compare Swift mocking frameworks by features.
 | Mock Subscripts | ✅ | ❌ | ✅ | ✅ |
 | Mock Static Methods | ✅ | ❌ | ✅ | ✅ |
 | Mock Static Properties | ✅ | ❌ | ✅ | ✅ |
+| Mock Async Methods | ✅ | ✅ | ✅ | ✅ |
 | | | | |
 | Stub Returning Value | ✅ | ✅ | ✅ | ✅ |
 | Stub Throwing Errors | ✅ | ✅ | ✅ | ✅ |
-| Stub Parameterized Method | ✅ | ✅ | ✅ | ✅ |
+| Stub Parameterized Methods | ✅ | ✅ | ✅ | ✅ |
 | Stub Variadic Parameters | ✅ | ❌ | ❌ | ✅ |
 | Stub Inout Parameters | ✅ | ❌ | ✅ | ✴️ |
 | Stub Sequences | ✅ | ✅ | ✅ | ✴️ |

--- a/Sources/Documentation/Mockingbird.docc/Pages/Meta/Internal.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Meta/Internal.md
@@ -63,6 +63,8 @@ Functionality not designed for general use.
 - ``AnyDeclaration``
 - ``FunctionDeclaration``
 - ``ThrowingFunctionDeclaration``
+- ``AsyncFunctionDeclaration``
+- ``ThrowingAsyncFunctionDeclaration``
 - ``VariableDeclaration``
 - ``PropertyGetterDeclaration``
 - ``PropertySetterDeclaration``

--- a/Sources/Documentation/Mockingbird.docc/Pages/Meta/Known-Limitations.md
+++ b/Sources/Documentation/Mockingbird.docc/Pages/Meta/Known-Limitations.md
@@ -36,8 +36,4 @@ _(Empty entries indicate that the feature is not applicable for the given mock t
 | Swift Unavailable Method | ✴️ | ✴️ | ✴️ |   |
 | Swift Unavailable Property | ✴️ | ✴️ | ✴️ |   |
 | | | | |
-| **Swift 5.5** | | | |
-| Swift Async Method | ✴️ | ✴️ |   |   |
-| Swift Actors | ✴️ | ✴️ |   |   |
-| | | | |
 | (This row is intentionally left blank for table formatting.) |   |   |   |   |

--- a/Sources/MockingbirdFramework/Mocking/Declaration.swift
+++ b/Sources/MockingbirdFramework/Mocking/Declaration.swift
@@ -34,6 +34,6 @@ public protocol AnyMockable {}
 
 /// Represents a mocked declaration that can be stubbed or verified.
 public struct Mockable<DeclarationType: Declaration, InvocationType, ReturnType>: AnyMockable {
-  let mock: Mock
+  let context: Context
   let invocation: Invocation
 }

--- a/Sources/MockingbirdFramework/Mocking/GenericStaticMockContext.swift
+++ b/Sources/MockingbirdFramework/Mocking/GenericStaticMockContext.swift
@@ -4,19 +4,18 @@ import Foundation
 ///
 /// Swift does not support static members inside generic types by default. A
 /// `GenericStaticMockContext` provides a type and thread safe way for a generic type to access its
-/// static mock instance.
+/// static mock context.
 class GenericStaticMockContext {
-  private let mocks = Synchronized<[String: StaticMock]>([:])
-  func resolveTypeNames(_ typeNames: [String]) -> StaticMock {
+  private let mocks = Synchronized<[String: Context]>([:])
+  func resolve(_ typeNames: [String]) -> Context {
     let identifier: String = typeNames.joined(separator: ",")
     return mocks.update { mocks in
       if let mock = mocks[identifier] {
         return mock
-      } else {
-        let mock = StaticMock()
-        mocks[identifier] = mock
-        return mock
       }
+      let mock = Context()
+      mocks[identifier] = mock
+      return mock
     }
   }
 }

--- a/Sources/MockingbirdFramework/Mocking/Mock.swift
+++ b/Sources/MockingbirdFramework/Mocking/Mock.swift
@@ -4,12 +4,9 @@ import Foundation
 public protocol Mock: AnyObject {
   /// Runtime metdata about the mock instance.
   var mockingbirdContext: Context { get }
-}
-
-/// Used to store invocations on static or class scoped methods.
-public class StaticMock: Mock {
-  /// Runtime metdata about the mock instance.
-  public let mockingbirdContext = Context()
+  
+  /// The static mocking context.
+  static var mockingbirdContext: Context { get }
 }
 
 /// Stores information about generated mocks.

--- a/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
+++ b/Sources/MockingbirdFramework/Stubbing/Stubbing.swift
@@ -58,7 +58,7 @@ public func given<DeclarationType: Declaration, InvocationType, ReturnType>(
   _ declaration: Mockable<DeclarationType, InvocationType, ReturnType>
 ) -> StaticStubbingManager<DeclarationType, InvocationType, ReturnType> {
   return StaticStubbingManager(invocation: declaration.invocation,
-                               context: declaration.mock.mockingbirdContext)
+                               context: declaration.context)
 }
 
 /// Stub a Swift declaration to return a value or perform an operation.
@@ -424,12 +424,12 @@ extension StubbingManager where DeclarationType == ThrowingFunctionDeclaration {
   ///
   /// ```swift
   /// protocol Bird {
-  ///   func getMessage<T>() throws -> T    // Overloaded generically
-  ///   func getMessage() throws -> String  // Overloaded explicitly
-  ///   func getMessage() throws -> Data
+  ///   func fetchMessage<T>() throws -> T    // Overloaded generically
+  ///   func fetchMessage() throws -> String  // Overloaded explicitly
+  ///   func fetchMessage() throws -> Data
   /// }
   ///
-  /// given(bird.send(any()))
+  /// given(bird.fetchMessage())
   ///   .returning(String.self)
   ///   .willThrow(BirdError())
   /// ```

--- a/Sources/MockingbirdFramework/Verification/AsyncVerification.swift
+++ b/Sources/MockingbirdFramework/Verification/AsyncVerification.swift
@@ -19,7 +19,7 @@ public extension NSObject {
                   timeout: seconds,
                   enforceOrder: enforceOrderOfFulfillment)
   }
-  
+
   /// Create a deferrable test expectation from a block containing verification calls.
   ///
   /// Mocked methods that are invoked asynchronously can be verified using an `eventually` block
@@ -35,7 +35,7 @@ public extension NSObject {
   ///   verify(bird.chirp()).wasCalled()
   /// }
   ///
-  /// waitForExpectations(timeout: 1.0)
+  /// waitForExpectations(timeout: 1)
   /// ```
   ///
   /// - Parameters:
@@ -79,7 +79,7 @@ func createAsyncContext(expectation: XCTestExpectation, block scope: () -> Void)
       capturedExpectation.mockingContext
         .addObserver(observer, for: capturedExpectation.invocation.selectorName)
     })
-    
+
     group.subgroups.forEach({ subgroup in
       let observer = InvocationObserver({ (invocation, mockingContext) -> Bool in
         do {
@@ -93,10 +93,10 @@ func createAsyncContext(expectation: XCTestExpectation, block scope: () -> Void)
       subgroup.expectations.forEach({ $0.mockingContext.addObserver(observer) })
     })
   }
-  
+
   let queue = DispatchQueue(label: "co.bird.mockingbird.verify.eventually")
   queue.setSpecific(key: ExpectationGroup.contextKey, value: group)
   queue.sync { scope() }
-  
+
   try? group.verify()
 }

--- a/Sources/MockingbirdFramework/Verification/Verification.swift
+++ b/Sources/MockingbirdFramework/Verification/Verification.swift
@@ -80,11 +80,11 @@ public class VerificationManager<InvocationType, ReturnType> {
 
   init<DeclarationType>(with declaration: Mockable<DeclarationType, InvocationType, ReturnType>,
                         at sourceLocation: SourceLocation) {
-    self.context = declaration.mock.mockingbirdContext
+    self.context = declaration.context
     self.invocation = declaration.invocation
     self.sourceLocation = sourceLocation
   }
-  
+
   init(from record: InvocationRecord, at sourceLocation: SourceLocation) {
     self.context = record.context
     self.invocation = record.invocation
@@ -97,7 +97,7 @@ public class VerificationManager<InvocationType, ReturnType> {
   public func wasCalled(_ countMatcher: CountMatcher) {
     verify(using: countMatcher, for: sourceLocation)
   }
-  
+
   /// Verify that the mock received the invocation an exact number of times.
   ///
   /// - Parameter times: The exact number of invocations expected.
@@ -109,7 +109,7 @@ public class VerificationManager<InvocationType, ReturnType> {
   public func wasNeverCalled() {
     verify(using: exactly(never), for: sourceLocation)
   }
-  
+
   /// Disambiguate methods overloaded by return type.
   ///
   /// Declarations for methods overloaded by return type cannot type inference and should be
@@ -117,12 +117,12 @@ public class VerificationManager<InvocationType, ReturnType> {
   ///
   /// ```swift
   /// protocol Bird {
-  ///   func getMessage<T>() throws -> T    // Overloaded generically
-  ///   func getMessage() throws -> String  // Overloaded explicitly
-  ///   func getMessage() throws -> Data
+  ///   func fetchMessage<T>() throws -> T    // Overloaded generically
+  ///   func fetchMessage() throws -> String  // Overloaded explicitly
+  ///   func fetchMessage() throws -> Data
   /// }
   ///
-  /// verify(bird.send(any()))
+  /// verify(bird.fetchMessage())
   ///   .returning(String.self)
   ///   .wasCalled()
   /// ```
@@ -131,7 +131,7 @@ public class VerificationManager<InvocationType, ReturnType> {
   public func returning(_ type: ReturnType.Type = ReturnType.self) -> Self {
     return self
   }
-  
+
   /// Runs the block within an attributed `DispatchQueue`.
   func verify(using countMatcher: CountMatcher, for sourceLocation: SourceLocation) {
     let expectation = Expectation(countMatcher: countMatcher,
@@ -152,7 +152,7 @@ struct Expectation {
   let countMatcher: CountMatcher
   let sourceLocation: SourceLocation
   let group: ExpectationGroup?
-  
+
   init(countMatcher: CountMatcher,
        sourceLocation: SourceLocation,
        group: ExpectationGroup?) {
@@ -160,7 +160,7 @@ struct Expectation {
     self.sourceLocation = sourceLocation
     self.group = group
   }
-  
+
   init(from other: Expectation, withGroup: Bool = false) {
     self.init(countMatcher: other.countMatcher,
               sourceLocation: other.sourceLocation,
@@ -201,13 +201,13 @@ func expect(_ mockingContext: MockingContext,
                          expectation: Expectation(from: expectation))
     return []
   }
-  
+
   let allInvocations = findInvocations(in: mockingContext,
                                        with: invocation.selectorName,
                                        before: nextInvocation,
                                        after: baseInvocation)
   let allMatchingInvocations = allInvocations.filter({ $0.isEqual(to: invocation) })
-  
+
   let actualCallCount = allMatchingInvocations.count
   guard !expectation.countMatcher.matches(actualCallCount) else { return allInvocations }
   throw TestFailure.incorrectInvocationCount(invocationCount: actualCallCount,

--- a/Sources/MockingbirdGenerator/Generator/Operations/FileGenerator.swift
+++ b/Sources/MockingbirdGenerator/Generator/Operations/FileGenerator.swift
@@ -151,6 +151,6 @@ class FileGenerator {
   }
   
   private var genericTypesStaticMocks: String {
-    return "private let genericStaticMockContext = Mockingbird.GenericStaticMockContext()"
+    return "private let mkbGenericStaticMockContext = Mockingbird.GenericStaticMockContext()"
   }
 }

--- a/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MethodTemplate.swift
@@ -123,7 +123,8 @@ class MethodTemplate: Template {
     return \(ObjectInitializationTemplate(
               name: "Mockingbird.Mockable",
               genericTypes: genericTypes,
-              arguments: [("mock", mockObject), ("invocation", matchableInvocation())]))
+              arguments: [("context", "self.mockingbirdContext"),
+                          ("invocation", matchableInvocation())]))
     """
     methods.append(
       FunctionDefinitionTemplate(attributes: method.attributes.safeDeclarations,
@@ -138,7 +139,7 @@ class MethodTemplate: Template {
       return \(ObjectInitializationTemplate(
                 name: "Mockingbird.Mockable",
                 genericTypes: genericTypes,
-                arguments: [("mock", mockObject),
+                arguments: [("context", "self.mockingbirdContext"),
                             ("invocation", matchableInvocation(isVariadic: true))]))
       """
       let declaration = "public \(regularModifiers)func \(fullNameForMatchingVariadics) -> \(returnType)"
@@ -401,10 +402,6 @@ class MethodTemplate: Template {
         name: "Mockingbird.ArgumentMatcher",
         arguments: [(nil, "\(backticked: parameter.name)")]).render()
     })
-  }()
-  
-  lazy var mockObject: String = {
-    return method.kind.typeScope.isStatic ? "self.staticMock" : "self"
   }()
   
   /// Original function signature for casting to a matchable signature (variadics support).

--- a/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/MockableTypeTemplate.swift
@@ -190,12 +190,12 @@ class MockableTypeTemplate: Template {
     if !mockableType.genericTypes.isEmpty || mockableType.isInGenericContainingType {
       // Class-level generic types don't support static variables directly.
       let body = !shouldGenerateThunks ? Constants.thunkStub :
-        "return genericStaticMockContext.resolveTypeNames([\(runtimeGenericTypeNames)])"
+        "return mkbGenericStaticMockContext.resolve([\(runtimeGenericTypeNames)])"
       return """
-      static var staticMock: Mockingbird.StaticMock \(BlockTemplate(body: body, multiline: false))
+      public static var mockingbirdContext: Mockingbird.Context \(BlockTemplate(body: body, multiline: false))
       """
     } else {
-      return "static let staticMock = Mockingbird.StaticMock()"
+      return "public static let mockingbirdContext = Mockingbird.Context()"
     }
   }
   
@@ -401,7 +401,7 @@ class MockableTypeTemplate: Template {
       body: String(lines: [
         canCallSuper ? "super.init()" : "",
         "self.mockingbirdContext.sourceLocation = sourceLocation",
-        "\(mockableType.name)Mock.staticMock.mockingbirdContext.sourceLocation = sourceLocation",
+        "\(mockableType.name)Mock.mockingbirdContext.sourceLocation = sourceLocation",
       ])).render()
   }
   

--- a/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/SubscriptMethodTemplate.swift
@@ -164,7 +164,8 @@ class SubscriptMethodTemplate: MethodTemplate {
     return \(ObjectInitializationTemplate(
       name: "Mockingbird.Mockable",
       genericTypes: genericTypes,
-              arguments: [("mock", mockObject), ("invocation", invocation.render())]))
+              arguments: [("context", "self.mockingbirdContext"),
+                          ("invocation", invocation.render())]))
     """
     
     let syntheizedReturnType = "Mockingbird.Mockable<\(separated: genericTypes)>"

--- a/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/ThunkTemplate.swift
@@ -101,9 +101,8 @@ class ThunkTemplate: Template {
         """).render()
     }()
     
-    let context = isStatic ? "self.staticMock.mockingbirdContext" : "self.mockingbirdContext"
     let supertype = isStatic ? "MockingbirdSupertype.Type" : "MockingbirdSupertype"
-    let didInvoke = FunctionCallTemplate(name: "\(context).mocking.didInvoke",
+    let didInvoke = FunctionCallTemplate(name: "self.mockingbirdContext.mocking.didInvoke",
                                          unlabeledArguments: [invocation],
                                          isAsync: isAsync,
                                          isThrowing: isThrowing)
@@ -116,8 +115,9 @@ class ThunkTemplate: Template {
     
     return """
     return \(didInvoke) \(BlockTemplate(body: """
-    \(FunctionCallTemplate(name: "\(context).recordInvocation", arguments: [(nil, "$0")]))
-    let mkbImpl = \(FunctionCallTemplate(name: "\(context).stubbing.implementation",
+    \(FunctionCallTemplate(name: "self.mockingbirdContext.recordInvocation",
+                           arguments: [(nil, "$0")]))
+    let mkbImpl = \(FunctionCallTemplate(name: "self.mockingbirdContext.stubbing.implementation",
                                          arguments: [("for", "$0")]))
     \(String(lines: [
       callDefault,
@@ -126,7 +126,7 @@ class ThunkTemplate: Template {
       callBridgedConvenience,
       !isSubclass && !isProxyable ? "" : ForInStatementTemplate(
         item: "mkbTargetBox",
-        collection: "\(context).proxy.targets(for: $0)",
+        collection: "self.mockingbirdContext.proxy.targets(for: $0)",
         body: SwitchStatementTemplate(
           controlExpression: "mkbTargetBox.target",
           cases: [
@@ -136,7 +136,7 @@ class ThunkTemplate: Template {
                 condition: "var mkbObject = mkbObject as? \(supertype)", body: "break"))
             let mkbValue: \(returnType) = \(callMember(.object))
             \(FunctionCallTemplate(
-                name: "\(context).proxy.updateTarget",
+                name: "self.mockingbirdContext.proxy.updateTarget",
                 arguments: [(nil, "&mkbObject"), ("in", "mkbTargetBox")]))
             return mkbValue
             """)
@@ -145,14 +145,14 @@ class ThunkTemplate: Template {
     \(IfStatementTemplate(
         condition: """
         let mkbValue = \(FunctionCallTemplate(
-                          name: "\(context).stubbing.defaultValueProvider.value.provideValue",
+                          name: "self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue",
                           arguments: [("for", "\(parenthetical: returnType).self")]))
         """,
         body: "return mkbValue"))
-    \(FunctionCallTemplate(name: "\(context).stubbing.failTest",
+    \(FunctionCallTemplate(name: "self.mockingbirdContext.stubbing.failTest",
                            arguments: [
                             ("for", "$0"),
-                            ("at", "\(context).sourceLocation")]).render())
+                            ("at", "self.mockingbirdContext.sourceLocation")]).render())
     """))
     """
   }

--- a/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
+++ b/Sources/MockingbirdGenerator/Generator/Templates/VariableTemplate.swift
@@ -126,7 +126,8 @@ class VariableTemplate: Template {
       return \(ObjectInitializationTemplate(
                 name: "Mockingbird.Mockable",
                 genericTypes: getterGenericTypes,
-                arguments: [("mock", mockObject), ("invocation", getterInvocation)]))
+                arguments: [("context", "self.mockingbirdContext"),
+                            ("invocation", getterInvocation)]))
       """)
     
     let setterReturnType = "Mockingbird.Mockable<\(separated: setterGenericTypes)>"
@@ -137,7 +138,8 @@ class VariableTemplate: Template {
       return \(ObjectInitializationTemplate(
                 name: "Mockingbird.Mockable",
                 genericTypes: setterGenericTypes,
-                arguments: [("mock", mockObject), ("invocation", matchableSetterInvocation)]))
+                arguments: [("context", "self.mockingbirdContext"),
+                            ("invocation", matchableSetterInvocation)]))
       """)
     
     let accessors = !shouldGenerateSetter ? [getterDefinition.render()] : [
@@ -149,10 +151,6 @@ class VariableTemplate: Template {
   
   lazy var modifiers: String = {
     return variable.kind.typeScope.isStatic ? "class " : ""
-  }()
-  
-  lazy var mockObject: String = {
-    return variable.kind.typeScope.isStatic ? "staticMock" : "self"
   }()
   
   // Keep this in sync with `MockingbirdFramework.Invocation.Constants.getterSuffix`

--- a/Tests/MockingbirdTests/Framework/GenericsTests.swift
+++ b/Tests/MockingbirdTests/Framework/GenericsTests.swift
@@ -31,11 +31,11 @@ class GenericsTests: BaseTestCase {
     return classMock
   }
   
-  let staticTestQueue = DispatchQueue(label: "co.bird.mockingbird.tests")
-  
   override func setUp() {
     protocolMock = mock(AssociatedTypeProtocol<EquatableType, HashableType>.self)
     classMock = mock(AssociatedTypeGenericImplementer<EquatableType, [EquatableType]>.self)
+    reset(type(of: protocolMock))
+    reset(type(of: classMock))
   }
   
   // MARK: - Associated type protocol
@@ -61,37 +61,29 @@ class GenericsTests: BaseTestCase {
   }
   
   func testProtocolMock_stubParameterizedReturningStaticMethod_wildcardMatcher() {
-    staticTestQueue.sync {
-      reset(type(of: protocolMock).staticMock)
-      
-      given(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
-        .will { return $0 }
-      XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 1)),
-                     EquatableType(value: 1))
-      verify(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
-        .wasCalled()
-    }
+    given(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+      .will { return $0 }
+    XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 1)),
+                   EquatableType(value: 1))
+    verify(type(of: protocolMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+      .wasCalled()
   }
   
   func testProtocolMock_stubParameterizedReturningStaticMethod_exactMatcher() {
-    staticTestQueue.sync {
-      reset(protocolMock)
-      
-      given(type(of: protocolMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
-        .will { return $0 }
-      given(type(of: protocolMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
-        .willReturn(EquatableType(value: 42))
-      XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 2)),
-                     EquatableType(value: 42))
-      verify(type(of: protocolMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
-        .wasNeverCalled()
-      verify(type(of: protocolMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
-        .wasCalled()
-    }
+    given(type(of: protocolMock)
+      .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .will { return $0 }
+    given(type(of: protocolMock)
+      .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .willReturn(EquatableType(value: 42))
+    XCTAssertEqual(call(type(of: protocolMock), with: EquatableType(value: 2)),
+                   EquatableType(value: 42))
+    verify(type(of: protocolMock)
+      .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .wasNeverCalled()
+    verify(type(of: protocolMock)
+      .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .wasCalled()
   }
   
   // MARK: - Generic class
@@ -121,39 +113,31 @@ class GenericsTests: BaseTestCase {
   }
   
   func testClassMock_stubParameterizedReturningClassMethod_wildcardMatcher() {
-    staticTestQueue.sync {
-      reset(type(of: classMock).staticMock)
-      
-      given(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any()))
-        .will { return $0 }
-      XCTAssertEqual(
-        type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)),
-        EquatableType(value: 1)
-      )
-      verify(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any())).wasCalled()
-    }
+    given(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any()))
+      .will { return $0 }
+    XCTAssertEqual(
+      type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)),
+      EquatableType(value: 1)
+    )
+    verify(type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: any())).wasCalled()
   }
   
   func testClassMock_stubParameterizedReturningClassMethod_exactMatcher() {
-    staticTestQueue.sync {
-      reset(type(of: classMock).staticMock)
-      
-      given(type(of: classMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
-        .will { return $0 }
-      given(type(of: classMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
-        .willReturn(EquatableType(value: 42))
-      XCTAssertEqual(
-        type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)),
-        EquatableType(value: 42)
-      )
-      verify(type(of: classMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
-        .wasNeverCalled()
-      verify(type(of: classMock)
-        .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
-        .wasCalled()
-    }
+    given(type(of: classMock)
+            .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .will { return $0 }
+    given(type(of: classMock)
+            .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .willReturn(EquatableType(value: 42))
+    XCTAssertEqual(
+      type(of: classMock).methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)),
+      EquatableType(value: 42)
+    )
+    verify(type(of: classMock)
+            .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 1)))
+      .wasNeverCalled()
+    verify(type(of: classMock)
+            .methodUsingEquatableTypeWithReturn(equatable: EquatableType(value: 2)))
+      .wasCalled()
   }
 }

--- a/Tests/MockingbirdTests/Framework/StubbingTests.swift
+++ b/Tests/MockingbirdTests/Framework/StubbingTests.swift
@@ -15,6 +15,7 @@ class StubbingTests: BaseTestCase {
   override func setUp() {
     child = mock(Child.self)
     childProtocol = mock(ChildProtocol.self)
+    reset(type(of: mock(ChildProtocol.self)))
   }
   
   func testStubTrivialMethod_onClassMock_implicitlyStubbed() {
@@ -416,5 +417,19 @@ class StubbingTests: BaseTestCase {
     XCTAssertTrue(childProtocolInstance.childInstanceVariable)
     
     verify(childProtocol.getChildInstanceVariable()).wasCalled(exactly(4))
+  }
+  
+  // MARK: Static members
+  
+  func testStubStaticProperty() {
+    given(ChildProtocolMock.childStaticVariable).willReturn(true)
+    XCTAssertTrue(ChildProtocolMock.childStaticVariable)
+    verify(ChildProtocolMock.childStaticVariable).wasCalled()
+  }
+  
+  func testStubStaticMethod() {
+    given(ChildProtocolMock.childParameterizedStaticMethod(param1: any(), any())).willReturn(true)
+    XCTAssertTrue(ChildProtocolMock.childParameterizedStaticMethod(param1: true, 1))
+    verify(ChildProtocolMock.childParameterizedStaticMethod(param1: any(), any())).wasCalled()
   }
 }


### PR DESCRIPTION
## Stack

📚 #287 ***← [5/y] Improve static mocking APIs***
📚 #286 [4/y] Enable mocking sources in test bundles
📚 #285 [3/y] Fix read-only subscripts
📚 #284 [2/y] Fix warnings in throwing initializers
📚 #283 [1/y] Add backwards compatibility with Swift 5.5

## Overview

Mocking static members is currently a bit cumbersome because it requires referencing the `staticMock` property when stubbing or verifying. Now that the mocking and stubbing contexts live under a single context object we can store a static `mockingbirdContext` instance instead of a `Mock`. As a result, the testing API is a lot simpler and works directly on the metatype instance.

```swift
protocol Bird {
  static var species: String { get }
}

let birdType = type(of: mock(Bird.self))
given(birdType.species).willReturn("Mimus polyglottos")
print(birdType.species)  // Prints "Mimus polyglottos"
verify(birdType.species).wasCalled()
```

Like before, the state of static methods and properties persists between tests, so devs must reset the mock before stubbing or verifying static members. This behavior is now clearly documented in the reference articles.

```swift
func setUp() {
  reset(type(of: mock(Bird.self)))
}
```

## Test Plan

Added additional tests for stubbing and verifying static members.