### PR TITLE
Makes lastSetValue work with short property syntax

### DIFF
--- a/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
+++ b/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
@@ -13,7 +13,7 @@ import Foundation
 /// ```
 ///
 /// - Parameter initial: The initial value to return.
-public func lastSetValue<DeclarationType: PropertyGetterDeclaration, InvocationType, ReturnType>(
+public func lastSetValue<DeclarationType: AnyDeclaration, InvocationType, ReturnType>(
   initial: ReturnType
 ) -> ImplementationProvider<DeclarationType, InvocationType, ReturnType> {
   var currentValue = initial

--- a/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
+++ b/Sources/MockingbirdFramework/Stubbing/PropertyProviders.swift
@@ -13,7 +13,7 @@ import Foundation
 /// ```
 ///
 /// - Parameter initial: The initial value to return.
-public func lastSetValue<DeclarationType: AnyDeclaration, InvocationType, ReturnType>(
+public func lastSetValue<DeclarationType: Declaration, InvocationType, ReturnType>(
   initial: ReturnType
 ) -> ImplementationProvider<DeclarationType, InvocationType, ReturnType> {
   var currentValue = initial


### PR DESCRIPTION
## Overview
As discussed internally, this PR relaxes `lastSetValue` compile-time-safety to enable it to work with short property syntax, as it is shown in documentation: https://mockingbirdswift.com/stubbing

Previously, it was failing in these scenarios:
- short property syntax in Swift
```
let stub = mock(FooStateProvider.self)
given(stub.getIsInFlight()).willReturn(lastSetValue(initial: false))
given(stub.isInFlight).willReturn(lastSetValue(initial: false))
                                  ^
Global function 'lastSetValue(initial:)' requires that 'AnyDeclaration' inherit from 'PropertyGetterDeclaration'
```

- a mock of an ObjC object, where synthesized getter syntax is not available
```
let session = mock(FOOSession.self)
given(session.context).willReturn(lastSetValue(initial: .none))
                                  ^
Global function 'lastSetValue(initial:)' requires that 'AnyDeclaration' inherit from 'PropertyGetterDeclaration'
```

## Test Plan
CI