### PR TITLE
Fix parsing of unrecognized attributes

### DIFF
--- a/Sources/MockingbirdGenerator/Parser/Models/Function.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Function.swift
@@ -97,7 +97,7 @@ struct Function: CustomStringConvertible, CustomDebugStringConvertible, Serializ
               mutableComponent = mutableComponent.dropFirst("@autoclosure".count)
             } else if mutableComponent.hasPrefix("@") { // Unknown parameter attribute.
               logWarning("Ignoring unknown parameter attribute \(String(mutableComponent).singleQuoted) in function type declaration \(String(serialized).singleQuoted)")
-              let index = mutableComponent.firstIndex(where: { !$0.isLetter && !$0.isNumber })
+                let index = mutableComponent.dropFirst().firstIndex { !$0.isLetter && !$0.isNumber }
                 ?? mutableComponent.endIndex
               mutableComponent = mutableComponent[index...]
             } else if mutableComponent == "inout" {

--- a/Sources/MockingbirdGenerator/Parser/Models/Function.swift
+++ b/Sources/MockingbirdGenerator/Parser/Models/Function.swift
@@ -97,7 +97,7 @@ struct Function: CustomStringConvertible, CustomDebugStringConvertible, Serializ
               mutableComponent = mutableComponent.dropFirst("@autoclosure".count)
             } else if mutableComponent.hasPrefix("@") { // Unknown parameter attribute.
               logWarning("Ignoring unknown parameter attribute \(String(mutableComponent).singleQuoted) in function type declaration \(String(serialized).singleQuoted)")
-                let index = mutableComponent.dropFirst().firstIndex { !$0.isLetter && !$0.isNumber }
+              let index = mutableComponent.dropFirst().firstIndex { !$0.isLetter && !$0.isNumber }
                 ?? mutableComponent.endIndex
               mutableComponent = mutableComponent[index...]
             } else if mutableComponent == "inout" {

--- a/Tests/MockingbirdTests/Generator/DeclaredTypeTests.swift
+++ b/Tests/MockingbirdTests/Generator/DeclaredTypeTests.swift
@@ -127,6 +127,12 @@ class DeclaredTypeTests: XCTestCase {
     XCTAssert(actual.isFunction)
   }
   
+  func testDeclaredType_parsesFunctionTypeAttributesIgnoringUnrecognized() {
+    let actual = DeclaredType(from: "(@NotARealAttribute @escaping (Int) -> String) -> Void")
+    XCTAssertEqual(String(reflecting: actual), "DeclaredType(Single(Function((Parameter(@escaping DeclaredType(Single(Function((Parameter(DeclaredType(Single(Int)))) -> DeclaredType(Single(String))))))) -> DeclaredType(Single(Void)))))")
+    XCTAssert(actual.isFunction)
+  }
+  
   func testDeclaredType_parsesFunctionTypeAttributesWithoutWhitespace() {
     let actual = DeclaredType(from: "(@escaping(String)) -> Void")
     XCTAssertEqual(String(reflecting: actual), "DeclaredType(Single(Function((Parameter(@escaping DeclaredType(Single(String)))) -> DeclaredType(Single(Void)))))")


### PR DESCRIPTION
Fixes #310

## Overview

If Mockingbird encounters an unrecognized attribute, it gets stuck in an infinite loop. Although this was first noticed with `@Sendable`, the introduction of global actors means that there may be arbitrary attributes which are unknowable to the generator.

This PR fixes the behavior when encountering an unrecognized attribute, so that the generator no longer gets stuck.

## Test Plan

I added a test case which uses `@NotARealAttribute` to test that the parser skips over unrecognized attributes.
