### PR TITLE
Fix the problem `no LC_RPATH load command with path` when building cli with Xcode14.1

### DIFF
--- a/Sources/MockingbirdAutomationCli/Commands/BuildCli.swift
+++ b/Sources/MockingbirdAutomationCli/Commands/BuildCli.swift
@@ -32,7 +32,7 @@ extension Build {
       let developerDirectory = try XcodeSelect.printPath()
       let swiftToolchainPath = developerDirectory
         + "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"
-      try InstallNameTool.deleteRpath(swiftToolchainPath.absolute().string, binary: binary)
+      try? InstallNameTool.deleteRpath(swiftToolchainPath.absolute().string, binary: binary)
       // Swift 5.5 is only present in Xcode 13.2+
       let swift5_5ToolchainPath = developerDirectory
         + "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"


### PR DESCRIPTION
## Overview

Use `try?` to try to delete rpath of swift toolchain path.

This PR fixes the building problem by using Xcode 14.1 :
```
/path/to/mockingbird $ xcrun install_name_tool -delete_rpath /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx /path/to/mockingbird/.build/arm64-apple-macosx/release/mockingbird
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: no LC_RPATH load command with path: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx found in: /path/to/mockingbird/.build/arm64-apple-macosx/release/mockingbird (for architecture arm64), required for specified option "-delete_rpath /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"
```

## Test Plan
CI